### PR TITLE
[fix] Show loader if there are pending requests to GET /parcels

### DIFF
--- a/webapp/src/components/HomePage/Sidebar/Sidebar.container.js
+++ b/webapp/src/components/HomePage/Sidebar/Sidebar.container.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 import { getWallet } from 'modules/wallet/reducer'
 import { isLoading } from 'modules/ui/loading/reducer'
+import { isLoading as isLoadingParcels } from 'modules/parcels/reducer'
 import { isOpen } from 'modules/ui/sidebar/reducer'
 import { openSidebar, closeSidebar } from 'modules/ui/sidebar/actions'
 import Sidebar from './Sidebar'
@@ -10,7 +11,7 @@ const mapState = state => {
   return {
     address: wallet.address,
     balance: wallet.balance,
-    isLoading: isLoading(state),
+    isLoading: isLoading(state) || isLoadingParcels(state),
     isOpen: isOpen(state)
   }
 }

--- a/webapp/src/modules/address/sagas.js
+++ b/webapp/src/modules/address/sagas.js
@@ -8,7 +8,7 @@ import {
   FETCH_ADDRESS_CONTRIBUTIONS_FAILURE
 } from './actions'
 
-import { FETCH_PARCELS_SUCCESS } from 'modules/parcels/actions'
+import { MERGE_PARCELS } from 'modules/parcels/actions'
 
 import api from 'lib/api'
 
@@ -41,7 +41,7 @@ function* handleAddressParcelsRequest(action) {
 
 function* handleAddressParcelsSuccess(action) {
   yield put({
-    type: FETCH_PARCELS_SUCCESS,
+    type: MERGE_PARCELS,
     parcels: action.parcels
   })
 }

--- a/webapp/src/modules/parcels/actions.js
+++ b/webapp/src/modules/parcels/actions.js
@@ -6,6 +6,8 @@ export const EDIT_PARCEL_REQUEST = '[Request] Edit Parcel requested'
 export const EDIT_PARCEL_SUCCESS = '[Success] Parcel edited'
 export const EDIT_PARCEL_FAILURE = '[Failure] Failure to edit parcel'
 
+export const MERGE_PARCELS = 'Merge Parcels'
+
 export function fetchParcels(nw, se) {
   return {
     type: FETCH_PARCELS_REQUEST,

--- a/webapp/src/modules/parcels/reducer.js
+++ b/webapp/src/modules/parcels/reducer.js
@@ -2,7 +2,8 @@ import {
   FETCH_PARCELS_REQUEST,
   FETCH_PARCELS_SUCCESS,
   FETCH_PARCELS_FAILURE,
-  EDIT_PARCEL_SUCCESS
+  EDIT_PARCEL_SUCCESS,
+  MERGE_PARCELS
 } from './actions'
 import { TRANSFER_PARCEL_SUCCESS } from 'modules/transfer/actions'
 import { buildCoordinate } from 'lib/utils'
@@ -10,7 +11,7 @@ import { toParcelObject } from './utils'
 
 const INITIAL_STATE = {
   data: {},
-  loading: false,
+  loading_count: 0,
   error: null
 }
 
@@ -19,14 +20,14 @@ export default function reducer(state = INITIAL_STATE, action) {
     case FETCH_PARCELS_REQUEST: {
       return {
         ...state,
-        loading: true
+        loading_count: state.loading_count + 1
       }
     }
     case FETCH_PARCELS_SUCCESS: {
       return {
         ...state,
         error: null,
-        loading: false,
+        loading_count: state.loading_count - 1,
         data: {
           ...state.data,
           ...toParcelObject(action.parcels)
@@ -36,8 +37,17 @@ export default function reducer(state = INITIAL_STATE, action) {
     case FETCH_PARCELS_FAILURE: {
       return {
         ...state,
-        loading: false,
+        loading_count: state.loading_count - 1,
         error: action.error
+      }
+    }
+    case MERGE_PARCELS: {
+      return {
+        ...state,
+        data: {
+          ...state.data,
+          ...toParcelObject(action.parcels)
+        }
       }
     }
     case EDIT_PARCEL_SUCCESS: {
@@ -72,5 +82,5 @@ export default function reducer(state = INITIAL_STATE, action) {
 
 export const getState = state => state.parcels
 export const getParcels = state => getState(state).data
-export const isLoading = state => getState(state).loading
+export const isLoading = state => getState(state).loading_count > 0
 export const getError = state => getState(state).error

--- a/webapp/src/modules/ui/map/sagas.js
+++ b/webapp/src/modules/ui/map/sagas.js
@@ -1,9 +1,9 @@
-import { takeLatest, put } from 'redux-saga/effects'
+import { takeEvery, put } from 'redux-saga/effects'
 import { FETCH_PARCELS_REQUEST } from 'modules/parcels/actions'
 import { CHANGE_RANGE } from './actions'
 
 export default function* saga() {
-  yield takeLatest(CHANGE_RANGE, handleChangeRange)
+  yield takeEvery(CHANGE_RANGE, handleChangeRange)
 }
 
 function* handleChangeRange(action) {


### PR DESCRIPTION
This keeps the decentraland logo in loader mode if there are pending requests to `GET /parcels`, before this, if the user dragged the map for a while, say, for 4 times, 4 requests would be sent, but as soon as the first request comes back that would unset the loader.

I changed the boolean `loading` prop to `loading_count` and made each `FETCH_PARCELS_REQUEST` increment it, and each `FETCH_PARCELS_FAILURE` or `FETCH_PARCELS_SUCCESS` decrement it.

We were using `FETCH_PARCELS_SUCCESS` to merge the addresses returned by `/addresses/:address/parcels` into the state, but this was screwing up the `loading_count`, so I added a new `MERGE_PARCELS` action that merges them into the app state without touching the count.

