### PR TITLE
[fix] moved color codes button up so it doesnt overlap with intercom

### DIFF
--- a/webapp/src/components/HomePage/Sidebar/CollapsedSidebar/CollapsedSidebar.css
+++ b/webapp/src/components/HomePage/Sidebar/CollapsedSidebar/CollapsedSidebar.css
@@ -6,12 +6,12 @@
 }
 
 .CollapsedSidebar header {
-  background-color: #FCFCFC;
-  border-bottom: 1px solid #EDEDED;
+  background-color: #fcfcfc;
+  border-bottom: 1px solid #ededed;
 }
 
 .CollapsedSidebar .ColorCodesButton {
   left: 31%;
-  bottom: 100px;
+  bottom: 180px;
   position: absolute;
 }


### PR DESCRIPTION
moved color codes button up so it doesnt overlap with intercom

<img width="214" alt="screen shot 2018-01-31 at 8 14 39 pm" src="https://user-images.githubusercontent.com/2781777/35652669-6a289696-06c3-11e8-88a9-22044804fefe.png">
