### PR TITLE
[Fix] Prevent navigating to the current location

### DIFF
--- a/webapp/src/locations.js
+++ b/webapp/src/locations.js
@@ -6,7 +6,8 @@ export const locations = {
     `/address/${address}/${tab}`,
 
   parcelMap: '/:x/:y',
-  parcelMapDetail: (x, y, marker) => `/${x}/${y}` + (marker ? `?marker=${marker}` : ''),
+  parcelMapDetail: (x, y, marker) =>
+    `/${x}/${y}` + (marker ? `?marker=${marker}` : ''),
 
   marketplace: '/marketplace',
 

--- a/webapp/src/modules/location/sagas.js
+++ b/webapp/src/modules/location/sagas.js
@@ -1,4 +1,4 @@
-import { takeLatest, put } from 'redux-saga/effects'
+import { takeLatest, put, select } from 'redux-saga/effects'
 import { push } from 'react-router-redux'
 import { NAVIGATE_TO } from './actions'
 
@@ -7,5 +7,8 @@ export function* locationSaga() {
 }
 
 function* handleNavigateTo(action) {
-  yield put(push(action.url))
+  const { pathname, search } = yield select(state => state.router.location)
+  if (pathname + search !== action.url) {
+    yield put(push(action.url))
+  }
 }


### PR DESCRIPTION
Prevent firing multiple `"Navigate to url"` actions to the same url. It happens for example when you go to the atlas page from a parcel detail page, then you have to click "back" three times in order to go to the previous page. It also happens inside the atlas map, if you drag the map three times and you click back it should take you to the previous position, but sometimes you have to click back several times. After this change it works ok.