### PR TITLE
[Feature] View only mode

### DIFF
--- a/webapp/src/Routes.js
+++ b/webapp/src/Routes.js
@@ -16,6 +16,7 @@ import BuyParcelPage from 'components/BuyParcelPage'
 import CancelSalePage from 'components/CancelSalePage'
 import ActivityPage from 'components/ActivityPage'
 import SettingsPage from 'components/SettingsPage'
+import SignInPage from 'components/SignInPage'
 
 import ColorKeyPage from 'components/ColorKeyPage'
 import PrivacyPage from 'components/PrivacyPage'
@@ -47,6 +48,7 @@ export default function Routes() {
         <Route exact path={locations.colorCodes} component={ColorKeyPage} />
         <Route exact path={locations.privacy} component={PrivacyPage} />
         <Route exact path={locations.parcelMap} component={AtlasPage} />
+        <Route exact path={locations.signIn} component={SignInPage} />
         <Route exact path={locations.walletError} component={WalletErrorPage} />
         <Route exact path={locations.serverError} component={ServerError} />
         <Route exact path={locations.error} component={WalletErrorPage} />

--- a/webapp/src/Routes.js
+++ b/webapp/src/Routes.js
@@ -3,6 +3,8 @@ import { Switch, Route, Redirect } from 'react-router-dom'
 
 import { locations } from 'locations'
 
+import Wallet from 'components/Wallet'
+
 import AtlasPage from 'components/AtlasPage'
 import ParcelDetailPage from 'components/ParcelDetailPage'
 import MarketplacePage from 'components/MarketplacePage'
@@ -28,31 +30,33 @@ import Modal from 'components/Modal'
 import Toast from 'components/Toast'
 
 export default function Routes() {
-  return [
-    <Switch key="1">
-      <Route exact path={locations.root} component={AtlasPage} />
-      <Route exact path={locations.parcel} component={ParcelDetailPage} />
-      <Route exact path={locations.marketplace} component={MarketplacePage} />
-      <Route exact path={locations.profile} component={ProfilePage} />
-      <Route exact path={locations.sell} component={PublishPage} />
-      <Route exact path={locations.edit} component={EditParcelPage} />
-      <Route exact path={locations.transfer} component={TransferParcelPage} />
-      <Route exact path={locations.buy} component={BuyParcelPage} />
-      <Route exact path={locations.cancelSale} component={CancelSalePage} />
-      <Route exact path={locations.activity} component={ActivityPage} />
-      <Route exact path={locations.settings} component={SettingsPage} />
-      <Route exact path={locations.colorCodes} component={ColorKeyPage} />
-      <Route exact path={locations.privacy} component={PrivacyPage} />
-      <Route exact path={locations.parcelMap} component={AtlasPage} />
-      <Route exact path={locations.walletError} component={WalletErrorPage} />
-      <Route exact path={locations.serverError} component={ServerError} />
-      <Route exact path={locations.error} component={WalletErrorPage} />
+  return (
+    <Wallet>
+      <Switch>
+        <Route exact path={locations.root} component={AtlasPage} />
+        <Route exact path={locations.parcel} component={ParcelDetailPage} />
+        <Route exact path={locations.marketplace} component={MarketplacePage} />
+        <Route exact path={locations.profile} component={ProfilePage} />
+        <Route exact path={locations.sell} component={PublishPage} />
+        <Route exact path={locations.edit} component={EditParcelPage} />
+        <Route exact path={locations.transfer} component={TransferParcelPage} />
+        <Route exact path={locations.buy} component={BuyParcelPage} />
+        <Route exact path={locations.cancelSale} component={CancelSalePage} />
+        <Route exact path={locations.activity} component={ActivityPage} />
+        <Route exact path={locations.settings} component={SettingsPage} />
+        <Route exact path={locations.colorCodes} component={ColorKeyPage} />
+        <Route exact path={locations.privacy} component={PrivacyPage} />
+        <Route exact path={locations.parcelMap} component={AtlasPage} />
+        <Route exact path={locations.walletError} component={WalletErrorPage} />
+        <Route exact path={locations.serverError} component={ServerError} />
+        <Route exact path={locations.error} component={WalletErrorPage} />
 
-      <Redirect to={locations.root} />
-    </Switch>,
-    <Modal key="2" />,
-    <Toast key="3" />,
-    <Intercom key="4" />,
-    <GoogleAnalytics key="5" />
-  ]
+        <Redirect to={locations.root} />
+      </Switch>,
+      <Modal />
+      <Toast />
+      <Intercom />
+      <GoogleAnalytics />
+    </Wallet>
+  )
 }

--- a/webapp/src/Routes.js
+++ b/webapp/src/Routes.js
@@ -52,9 +52,8 @@ export default function Routes() {
         <Route exact path={locations.walletError} component={WalletErrorPage} />
         <Route exact path={locations.serverError} component={ServerError} />
         <Route exact path={locations.error} component={WalletErrorPage} />
-
         <Redirect to={locations.root} />
-      </Switch>,
+      </Switch>
       <Modal />
       <Toast />
       <Intercom />

--- a/webapp/src/components/ActivityPage/ActivityPage.container.js
+++ b/webapp/src/components/ActivityPage/ActivityPage.container.js
@@ -5,7 +5,7 @@ import {
   getPendingTransactions,
   getTransactionHistory
 } from 'modules/transaction/selectors'
-import { getWallet, isLoading } from 'modules/wallet/selectors'
+import { isConnecting, isConnected } from 'modules/wallet/selectors'
 
 import ActivityPage from './ActivityPage'
 
@@ -18,7 +18,8 @@ const mapState = state => {
     pendingTransactions,
     transactionHistory,
     isEmpty: totalSent <= 0,
-    isLoading: isLoading(state) || !getWallet(state).address
+    isLoading: isConnecting(state),
+    isConnected: isConnected(state)
   }
 }
 

--- a/webapp/src/components/ActivityPage/ActivityPage.container.js
+++ b/webapp/src/components/ActivityPage/ActivityPage.container.js
@@ -6,7 +6,6 @@ import {
   getTransactionHistory
 } from 'modules/transaction/selectors'
 import { getWallet, isLoading } from 'modules/wallet/selectors'
-import { connectWalletRequest } from 'modules/wallet/actions'
 
 import ActivityPage from './ActivityPage'
 
@@ -23,8 +22,6 @@ const mapState = state => {
   }
 }
 
-const mapDispatch = dispatch => ({
-  onConnect: () => dispatch(connectWalletRequest())
-})
+const mapDispatch = dispatch => ({})
 
 export default withRouter(connect(mapState, mapDispatch)(ActivityPage))

--- a/webapp/src/components/ActivityPage/ActivityPage.css
+++ b/webapp/src/components/ActivityPage/ActivityPage.css
@@ -1,6 +1,3 @@
-.ActivityPage {
-}
-
 .ActivityPage .container {
   padding-top: 20px;
 }
@@ -24,4 +21,9 @@
   font-size: 16px;
   text-align: center;
   color: var(--gray);
+}
+.ActivityPage .sign-in {
+  display: block;
+  text-align: center;
+  margin-top: 50px !important;
 }

--- a/webapp/src/components/ActivityPage/ActivityPage.js
+++ b/webapp/src/components/ActivityPage/ActivityPage.js
@@ -17,7 +17,8 @@ export default class ActivityPage extends React.PureComponent {
     pendingTransactions: PropTypes.arrayOf(transactionType),
     transactionHistory: PropTypes.arrayOf(transactionType),
     isEmpty: PropTypes.bool.isRequired,
-    isLoading: PropTypes.bool.isRequired
+    isLoading: PropTypes.bool.isRequired,
+    isConnected: PropTypes.bool.isRequired
   }
 
   renderLoading() {
@@ -71,18 +72,33 @@ export default class ActivityPage extends React.PureComponent {
     )
   }
 
+  renderNotConnected() {
+    return (
+      <p className="sign-in">
+        You need to <Link to={locations.signIn}>Sign In</Link> to access this
+        page
+      </p>
+    )
+  }
+
   render() {
-    const { isEmpty, isLoading } = this.props
+    const { isEmpty, isLoading, isConnected } = this.props
+
+    let content = null
+    if (isLoading) {
+      content = this.renderLoading()
+    } else if (!isConnected) {
+      content = this.renderNotConnected()
+    } else if (isEmpty) {
+      content = this.renderEmpty()
+    } else {
+      content = this.renderTransactionLists()
+    }
 
     return (
       <div className="ActivityPage">
         <Navbar />
-
-        <Container text>
-          {isLoading
-            ? this.renderLoading()
-            : isEmpty ? this.renderEmpty() : this.renderTransactionLists()}
-        </Container>
+        <Container text>{content}</Container>
       </div>
     )
   }

--- a/webapp/src/components/ActivityPage/ActivityPage.js
+++ b/webapp/src/components/ActivityPage/ActivityPage.js
@@ -17,12 +17,7 @@ export default class ActivityPage extends React.PureComponent {
     pendingTransactions: PropTypes.arrayOf(transactionType),
     transactionHistory: PropTypes.arrayOf(transactionType),
     isEmpty: PropTypes.bool.isRequired,
-    isLoading: PropTypes.bool.isRequired,
-    onConnect: PropTypes.func.isRequired
-  }
-
-  componentWillMount() {
-    this.props.onConnect()
+    isLoading: PropTypes.bool.isRequired
   }
 
   renderLoading() {

--- a/webapp/src/components/AtlasPage/AtlasPage.container.js
+++ b/webapp/src/components/AtlasPage/AtlasPage.container.js
@@ -1,7 +1,6 @@
 import { connect } from 'react-redux'
 
 import { getWallet, isLoading } from 'modules/wallet/selectors'
-import { connectWalletRequest } from 'modules/wallet/actions'
 import { openModal } from 'modules/ui/actions'
 
 import AtlasPage from './AtlasPage'
@@ -13,9 +12,6 @@ const mapState = state => {
   }
 }
 
-const mapDispatch = dispatch => ({
-  onConnect: () => dispatch(connectWalletRequest()),
-  onFirstVisit: () => dispatch(openModal('TermsModal'))
-})
+const mapDispatch = dispatch => ({})
 
 export default connect(mapState, mapDispatch)(AtlasPage)

--- a/webapp/src/components/AtlasPage/AtlasPage.container.js
+++ b/webapp/src/components/AtlasPage/AtlasPage.container.js
@@ -1,14 +1,13 @@
 import { connect } from 'react-redux'
 
-import { getWallet, isLoading } from 'modules/wallet/selectors'
-import { openModal } from 'modules/ui/actions'
+import { getWallet, isConnecting } from 'modules/wallet/selectors'
 
 import AtlasPage from './AtlasPage'
 
 const mapState = state => {
   return {
     wallet: getWallet(state),
-    isLoading: isLoading(state)
+    isLoading: isConnecting(state)
   }
 }
 

--- a/webapp/src/components/AtlasPage/AtlasPage.js
+++ b/webapp/src/components/AtlasPage/AtlasPage.js
@@ -13,18 +13,7 @@ import './AtlasPage.css'
 export default class AtlasPage extends React.PureComponent {
   static propTypes = {
     wallet: walletType,
-    isLoading: PropTypes.bool,
-    onConnect: PropTypes.func
-  }
-
-  componentWillMount() {
-    const { onConnect, onFirstVisit } = this.props
-
-    onConnect()
-
-    if (!localStorage.getItem('seenTermsModal')) {
-      onFirstVisit()
-    }
+    isLoading: PropTypes.bool
   }
 
   isReady() {

--- a/webapp/src/components/AtlasPage/AtlasPage.js
+++ b/webapp/src/components/AtlasPage/AtlasPage.js
@@ -1,8 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { localStorage } from 'lib/localStorage'
-
 import Navbar from 'components/Navbar'
 import MapComponent from './Map'
 import Minimap from './Minimap'
@@ -16,18 +14,13 @@ export default class AtlasPage extends React.PureComponent {
     isLoading: PropTypes.bool
   }
 
-  isReady() {
-    const { isLoading, wallet } = this.props
-    return !isLoading && !!wallet.address
-  }
-
   render() {
-    const isReady = this.isReady()
+    const { isLoading } = this.props
     return (
       <div className="AtlasPage">
         <Navbar />
-        <MapComponent isReady={isReady} />
-        {isReady && <Minimap />}
+        <MapComponent isReady={!isLoading} />
+        {!isLoading && <Minimap />}
       </div>
     )
   }

--- a/webapp/src/components/BuyParcelPage/BuyParcelPage.container.js
+++ b/webapp/src/components/BuyParcelPage/BuyParcelPage.container.js
@@ -2,7 +2,7 @@ import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import { push } from 'react-router-redux'
 import { getParams } from 'modules/location/selectors'
-import { getWallet } from 'modules/wallet/selectors'
+import { getWallet, isConnected, isConnecting } from 'modules/wallet/selectors'
 import { getPublications, getLoading } from 'modules/publication/selectors'
 import { findPublicationByCoordinates } from 'modules/publication/utils'
 import { BUY_REQUEST, buyRequest } from 'modules/publication/actions'
@@ -22,7 +22,9 @@ const mapState = (state, ownProps) => {
     x,
     y,
     isDisabled: isLoadingType(getLoading(state), BUY_REQUEST),
-    wallet: getWallet(state)
+    wallet: getWallet(state),
+    isConnected: isConnected(state),
+    isLoading: isConnecting(state)
   }
 }
 

--- a/webapp/src/components/BuyParcelPage/BuyParcelPage.css
+++ b/webapp/src/components/BuyParcelPage/BuyParcelPage.css
@@ -19,3 +19,9 @@
 .BuyParcelPage button + button {
   margin-left: 15px !important;
 }
+
+.BuyParcelPage .sign-in {
+  display: block;
+  text-align: center;
+  margin-top: 50px !important;
+}

--- a/webapp/src/components/BuyParcelPage/BuyParcelPage.js
+++ b/webapp/src/components/BuyParcelPage/BuyParcelPage.js
@@ -1,7 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
-import { Container, Header, Grid, Button, Message } from 'semantic-ui-react'
+import {
+  Loader,
+  Container,
+  Header,
+  Grid,
+  Button,
+  Message
+} from 'semantic-ui-react'
 import Navbar from 'components/Navbar'
 import ParcelName from 'components/ParcelName'
 import Parcel from 'components/Parcel'
@@ -17,6 +24,8 @@ export default class BuyParcelPage extends React.PureComponent {
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired,
     isDisabled: PropTypes.bool.isRequired,
+    isLoading: PropTypes.bool.isRequired,
+    isConnected: PropTypes.bool.isRequired,
     onConfirm: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired
   }
@@ -27,7 +36,38 @@ export default class BuyParcelPage extends React.PureComponent {
   }
 
   render() {
-    const { wallet, x, y, publication, isDisabled, onCancel } = this.props
+    const {
+      wallet,
+      x,
+      y,
+      publication,
+      isDisabled,
+      onCancel,
+      isConnected,
+      isLoading
+    } = this.props
+
+    if (isLoading) {
+      return <Loader active size="massive" />
+    }
+
+    if (!isConnected) {
+      return (
+        <div className="BuyParcelPage">
+          <Navbar />
+          <Container text textAlign="center">
+            <Header as="h2" size="huge" className="title">
+              Buy LAND
+            </Header>
+            <p className="sign-in">
+              You need to <Link to={locations.signIn}>Sign In</Link> to access
+              this page
+            </p>
+          </Container>
+        </div>
+      )
+    }
+
     const { approvedBalance } = wallet
 
     const isNotEnough = publication && approvedBalance < +publication.price

--- a/webapp/src/components/BuyParcelPage/BuyParcelPage.js
+++ b/webapp/src/components/BuyParcelPage/BuyParcelPage.js
@@ -35,43 +35,31 @@ export default class BuyParcelPage extends React.PureComponent {
     onConfirm(publication)
   }
 
-  render() {
-    const {
-      wallet,
-      x,
-      y,
-      publication,
-      isDisabled,
-      onCancel,
-      isConnected,
-      isLoading
-    } = this.props
+  renderLoading() {
+    return <Loader active size="massive" />
+  }
 
-    if (isLoading) {
-      return <Loader active size="massive" />
-    }
+  renderNotConnected() {
+    return (
+      <div className="BuyParcelPage">
+        <Navbar />
+        <Container text textAlign="center">
+          <Header as="h2" size="huge" className="title">
+            Buy LAND
+          </Header>
+          <p className="sign-in">
+            You need to <Link to={locations.signIn}>Sign In</Link> to access
+            this page
+          </p>
+        </Container>
+      </div>
+    )
+  }
 
-    if (!isConnected) {
-      return (
-        <div className="BuyParcelPage">
-          <Navbar />
-          <Container text textAlign="center">
-            <Header as="h2" size="huge" className="title">
-              Buy LAND
-            </Header>
-            <p className="sign-in">
-              You need to <Link to={locations.signIn}>Sign In</Link> to access
-              this page
-            </p>
-          </Container>
-        </div>
-      )
-    }
-
+  renderPage() {
+    const { wallet, x, y, publication, isDisabled, onCancel } = this.props
     const { approvedBalance } = wallet
-
     const isNotEnough = publication && approvedBalance < +publication.price
-
     return (
       <div className="BuyParcelPage">
         <Navbar />
@@ -158,5 +146,19 @@ export default class BuyParcelPage extends React.PureComponent {
         </Parcel>
       </div>
     )
+  }
+
+  render() {
+    const { isConnected, isLoading } = this.props
+
+    if (isLoading) {
+      return this.renderLoading()
+    }
+
+    if (!isConnected) {
+      return this.renderNotConnected()
+    }
+
+    return this.renderPage()
   }
 }

--- a/webapp/src/components/GoogleAnalytics/GoogleAnalytics.container.js
+++ b/webapp/src/components/GoogleAnalytics/GoogleAnalytics.container.js
@@ -1,10 +1,11 @@
 import { connect } from 'react-redux'
-import { getAddress } from 'modules/wallet/selectors'
+import { getAddress, isConnected } from 'modules/wallet/selectors'
 import GoogleAnalytics from './GoogleAnalytics'
 
 const mapState = state => {
   return {
-    address: getAddress(state)
+    address: getAddress(state),
+    isConnected: isConnected(state)
   }
 }
 

--- a/webapp/src/components/GoogleAnalytics/GoogleAnalytics.js
+++ b/webapp/src/components/GoogleAnalytics/GoogleAnalytics.js
@@ -3,12 +3,14 @@ import PropTypes from 'prop-types'
 
 export default class GoogleAnalytics extends React.PureComponent {
   static propTypes = {
-    address: PropTypes.string
+    address: PropTypes.string,
+    isConnected: PropTypes.bool,
+    isConnecting: PropTypes.bool
   }
 
   constructor(props) {
     super(props)
-    this.configurated = false
+    this.isConfigured = false
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -18,7 +20,8 @@ export default class GoogleAnalytics extends React.PureComponent {
   }
 
   shouldConfig() {
-    return !this.configurated && !!this.props.address
+    const { isConnected } = this.props
+    return !this.isConfigured && isConnected
   }
 
   config() {
@@ -35,7 +38,7 @@ export default class GoogleAnalytics extends React.PureComponent {
       user_id: address
     })
 
-    this.configurated = true
+    this.isConfigured = true
   }
 
   render() {

--- a/webapp/src/components/MarketplacePage/MarketplacePage.container.js
+++ b/webapp/src/components/MarketplacePage/MarketplacePage.container.js
@@ -1,7 +1,6 @@
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import { push } from 'react-router-redux'
-import { connectWalletRequest } from 'modules/wallet/actions'
 import { fetchPublicationsRequest } from 'modules/publication/actions'
 import { isLoading } from 'modules/publication/selectors'
 import { getPublications, getTotal } from 'modules/ui/marketplace/selectors'
@@ -29,7 +28,6 @@ const mapState = (state, { location }) => {
 }
 
 const mapDispatch = (dispatch, { location }) => ({
-  onConnect: () => dispatch(connectWalletRequest()),
   onFetchPublications: () =>
     dispatch(fetchPublicationsRequest(getOptionsFromRouter(location))),
   onNavigate: url => dispatch(push(url))

--- a/webapp/src/components/MarketplacePage/MarketplacePage.js
+++ b/webapp/src/components/MarketplacePage/MarketplacePage.js
@@ -37,13 +37,11 @@ export default class MarketplacePage extends React.PureComponent {
     sortBy: PropTypes.string.isRequired,
     sortOrder: PropTypes.string.isRequired,
     onNavigate: PropTypes.func.isRequired,
-    onConnect: PropTypes.func.isRequired,
     onFetchPublications: PropTypes.func.isRequired
   }
 
   componentWillMount() {
-    const { onConnect, onFetchPublications } = this.props
-    onConnect()
+    const { onFetchPublications } = this.props
     onFetchPublications()
   }
 

--- a/webapp/src/components/Navbar/Navbar.container.js
+++ b/webapp/src/components/Navbar/Navbar.container.js
@@ -5,6 +5,7 @@ import { getWallet } from 'modules/wallet/selectors'
 import { getLocation } from 'modules/location/selectors'
 import { getCenter } from 'modules/ui/selectors'
 import { isLoading } from 'modules/ui/loading/selectors'
+import { isConnected } from 'modules/wallet/selectors'
 import { isLoading as isLoadingParcels } from 'modules/parcels/selectors'
 import { getPendingTransactions } from 'modules/transaction/selectors'
 
@@ -22,6 +23,7 @@ const mapState = state => {
     wallet,
     center,
     isLoading: isLoading(state) || isLoadingParcels(state),
+    isConnected: isConnected(state),
     activityBadge: getPendingTransactions(state).length
   }
 }

--- a/webapp/src/components/Navbar/Navbar.css
+++ b/webapp/src/components/Navbar/Navbar.css
@@ -46,21 +46,24 @@
   height: 52px;
 }
 
-.Navbar .navbar-menu .item {
+.Navbar .navbar-menu .item,
+.Navbar .navbar-account .item {
   color: var(--purple);
   transition: none;
 }
 
 .Navbar .navbar-menu .ui.menu .item.active,
-.Navbar .navbar-menu .ui.menu .item:hover {
+.Navbar .navbar-menu .ui.menu .item:hover,
+.Navbar .navbar-account .ui.menu .item.active,
+.Navbar .navbar-account .ui.menu .item:hover {
   background-color: var(--purple);
-  color: #FFF;
+  color: #fff;
   transition: none;
 }
 
 /* Same as Label color="white" found on Label.css */
 .Navbar .navbar-menu .ui.menu .item:hover .label {
-  background-color: #FFF !important;
+  background-color: #fff !important;
   color: var(--purple) !important;
   transition: none;
 }

--- a/webapp/src/components/Navbar/Navbar.js
+++ b/webapp/src/components/Navbar/Navbar.js
@@ -41,6 +41,10 @@ export default class Navbar extends React.PureComponent {
         onNavigate(locations.activity)
         return
       }
+      case NAVBAR_PAGES.signIn: {
+        onNavigate(locations.signIn)
+        return
+      }
       default:
         return
     }
@@ -108,7 +112,19 @@ export default class Navbar extends React.PureComponent {
           </Menu>
         </div>
         <div className="navbar-account">
-          <Account wallet={wallet} />
+          {isConnected ? (
+            <Account wallet={wallet} />
+          ) : (
+            <Menu secondary>
+              <Menu.Item
+                name="signIn"
+                active={activePage === NAVBAR_PAGES.signIn}
+                onClick={this.handleItemClick}
+              >
+                Sign In
+              </Menu.Item>
+            </Menu>
+          )}
         </div>
       </div>
     )

--- a/webapp/src/components/Navbar/Navbar.js
+++ b/webapp/src/components/Navbar/Navbar.js
@@ -18,12 +18,8 @@ export default class Navbar extends React.PureComponent {
     center: coordsType,
     activePage: PropTypes.oneOf(Object.values(NAVBAR_PAGES)),
     isLoading: PropTypes.bool,
+    isConnected: PropTypes.bool,
     activityBadge: PropTypes.number
-  }
-
-  isConnected() {
-    const { wallet } = this.props
-    return !!wallet && !!wallet.address
   }
 
   handleItemClick = (event, data) => {
@@ -61,7 +57,7 @@ export default class Navbar extends React.PureComponent {
   }
 
   render() {
-    const { wallet, activePage, isLoading } = this.props
+    const { wallet, activePage, isLoading, isConnected } = this.props
     return (
       <div className="Navbar" role="navigation">
         <div className="navbar-header">
@@ -91,20 +87,24 @@ export default class Navbar extends React.PureComponent {
             >
               Marketplace
             </Menu.Item>
-            <Menu.Item
-              name="profile"
-              active={activePage === NAVBAR_PAGES.profile}
-              onClick={this.handleItemClick}
-            >
-              My Land
-            </Menu.Item>
-            <Menu.Item
-              name="activity"
-              active={activePage === NAVBAR_PAGES.activity}
-              onClick={this.handleItemClick}
-            >
-              Activity{this.renderActivityBadge()}
-            </Menu.Item>
+            {isConnected ? (
+              <React.Fragment>
+                <Menu.Item
+                  name="profile"
+                  active={activePage === NAVBAR_PAGES.profile}
+                  onClick={this.handleItemClick}
+                >
+                  My Land
+                </Menu.Item>
+                <Menu.Item
+                  name="activity"
+                  active={activePage === NAVBAR_PAGES.activity}
+                  onClick={this.handleItemClick}
+                >
+                  Activity{this.renderActivityBadge()}
+                </Menu.Item>
+              </React.Fragment>
+            ) : null}
           </Menu>
         </div>
         <div className="navbar-account">

--- a/webapp/src/components/Navbar/utils.js
+++ b/webapp/src/components/Navbar/utils.js
@@ -16,6 +16,8 @@ export function getActivePage({ pathname, wallet }) {
     currentPage = NAVBAR_PAGES.activity
   } else if (pathname === locations.settings) {
     currentPage = NAVBAR_PAGES.settings
+  } else if (pathname === locations.signIn) {
+    currentPage = NAVBAR_PAGES.signIn
   }
 
   return currentPage

--- a/webapp/src/components/Parcel/Parcel.container.js
+++ b/webapp/src/components/Parcel/Parcel.container.js
@@ -4,7 +4,7 @@ import { push } from 'react-router-redux'
 import { fetchParcelRequest } from 'modules/parcels/actions'
 import {
   getWallet,
-  isLoading as isWalletLoading
+  isConnecting as isWalletConnecting
 } from 'modules/wallet/selectors'
 import {
   isLoading as isAddressLoading,
@@ -21,7 +21,7 @@ const mapState = (state, { x, y }) => {
 
   const wallet = getWallet(state)
   const addresses = getAddresses(state)
-  let isConnecting = isWalletLoading(state) || isAddressLoading(state)
+  let isConnecting = isWalletConnecting(state) || isAddressLoading(state)
   if (
     wallet &&
     wallet.address &&

--- a/webapp/src/components/Parcel/Parcel.container.js
+++ b/webapp/src/components/Parcel/Parcel.container.js
@@ -1,7 +1,6 @@
 import { connect } from 'react-redux'
 import { locations } from 'locations'
 import { push } from 'react-router-redux'
-import { connectWalletRequest } from 'modules/wallet/actions'
 import { fetchParcelRequest } from 'modules/parcels/actions'
 import {
   getWallet,
@@ -46,7 +45,6 @@ const mapState = (state, { x, y }) => {
 }
 
 const mapDispatch = (dispatch, { x, y }) => ({
-  onConnect: () => dispatch(connectWalletRequest()),
   onFetchParcel: () => dispatch(fetchParcelRequest(x, y)),
   onAccessDenied: () => dispatch(push(locations.parcelDetail(x, y)))
 })

--- a/webapp/src/components/Parcel/Parcel.js
+++ b/webapp/src/components/Parcel/Parcel.js
@@ -12,7 +12,6 @@ export default class Parcel extends React.PureComponent {
     isLoading: PropTypes.bool,
     ownerOnly: PropTypes.bool,
     onAccessDenied: PropTypes.func.isRequired,
-    onConnect: PropTypes.func.isRequired,
     children: PropTypes.func.isRequired
   }
 
@@ -29,8 +28,7 @@ export default class Parcel extends React.PureComponent {
   }
 
   componentWillMount() {
-    const { onConnect, parcel, isLoading, onFetchParcel } = this.props
-    onConnect()
+    const { parcel, isLoading, onFetchParcel } = this.props
     if (!parcel && !isLoading) {
       onFetchParcel()
     }

--- a/webapp/src/components/ParcelDetailPage/ParcelDetail/ParcelPublication/ParcelPublication.container.js
+++ b/webapp/src/components/ParcelDetailPage/ParcelDetail/ParcelPublication/ParcelPublication.container.js
@@ -1,0 +1,13 @@
+import { connect } from 'react-redux'
+import { isConnected } from 'modules/wallet/selectors'
+import ParcelPublication from './ParcelPublication'
+
+const mapState = (state, { parcel }) => {
+  return {
+    isConnected: isConnected(state)
+  }
+}
+
+const mapDispatch = dispatch => ({})
+
+export default connect(mapState, mapDispatch)(ParcelPublication)

--- a/webapp/src/components/ParcelDetailPage/ParcelDetail/ParcelPublication/ParcelPublication.js
+++ b/webapp/src/components/ParcelDetailPage/ParcelDetail/ParcelPublication/ParcelPublication.js
@@ -11,11 +11,12 @@ export default class ParcelName extends React.PureComponent {
   static propTypes = {
     publication: publicationType.isRequired,
     isOwner: PropTypes.bool,
+    isConnected: PropTypes.bool,
     onBuy: PropTypes.func.isRequired
   }
 
   render() {
-    const { publication, isOwner, onBuy } = this.props
+    const { publication, isOwner, onBuy, isConnected } = this.props
     return (
       <Grid.Row>
         <Grid.Column width={4}>
@@ -27,7 +28,7 @@ export default class ParcelName extends React.PureComponent {
           <p>{distanceInWordsToNow(publication.expires_at)}</p>
         </Grid.Column>
         <Grid.Column width={2} textAlign="right">
-          {!isOwner ? (
+          {!isOwner && isConnected ? (
             <Button primary onClick={onBuy}>
               Buy
             </Button>

--- a/webapp/src/components/ParcelDetailPage/ParcelDetail/ParcelPublication/index.js
+++ b/webapp/src/components/ParcelDetailPage/ParcelDetail/ParcelPublication/index.js
@@ -1,3 +1,3 @@
-import ParcelPublication from './ParcelPublication'
+import ParcelPublication from './ParcelPublication.container'
 
 export default ParcelPublication

--- a/webapp/src/components/ProfilePage/ProfilePage.container.js
+++ b/webapp/src/components/ProfilePage/ProfilePage.container.js
@@ -1,7 +1,6 @@
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import { push } from 'react-router-redux'
-import { connectWalletRequest } from 'modules/wallet/actions'
 import { fetchAddress } from 'modules/address/actions'
 import { getLoading } from 'modules/address/selectors'
 import { getWallet } from 'modules/wallet/selectors'
@@ -65,7 +64,6 @@ const mapState = (state, { location, match }) => {
 }
 
 const mapDispatch = (dispatch, { match }) => ({
-  onConnect: () => dispatch(connectWalletRequest()),
   onFetchAddress: () => dispatch(fetchAddress(match.params.address)),
   onNavigate: url => dispatch(push(url))
 })

--- a/webapp/src/components/ProfilePage/ProfilePage.js
+++ b/webapp/src/components/ProfilePage/ProfilePage.js
@@ -35,13 +35,11 @@ export default class ProfilePage extends React.PureComponent {
     isLoading: PropTypes.bool,
     isEmpty: PropTypes.bool,
     isOwner: PropTypes.bool,
-    onNavigate: PropTypes.func.isRequired,
-    onConnect: PropTypes.func.isRequired
+    onNavigate: PropTypes.func.isRequired
   }
 
   componentWillMount() {
-    const { onConnect, onFetchAddress } = this.props
-    onConnect()
+    const { onFetchAddress } = this.props
     onFetchAddress()
   }
 

--- a/webapp/src/components/SettingsPage/SettingsPage.container.js
+++ b/webapp/src/components/SettingsPage/SettingsPage.container.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux'
 
-import { getWallet, isLoading, getError } from 'modules/wallet/selectors'
+import { getWallet, isConnecting, isConnected } from 'modules/wallet/selectors'
 import {
   approveManaRequest,
   authorizeLandRequest,
@@ -11,8 +11,8 @@ import SettingsPage from './SettingsPage'
 const mapState = state => {
   return {
     wallet: getWallet(state),
-    isLoading: isLoading(state),
-    hasError: !!getError(state)
+    isLoading: isConnecting(state),
+    isConnected: isConnected(state)
   }
 }
 

--- a/webapp/src/components/SettingsPage/SettingsPage.container.js
+++ b/webapp/src/components/SettingsPage/SettingsPage.container.js
@@ -2,7 +2,6 @@ import { connect } from 'react-redux'
 
 import { getWallet, isLoading, getError } from 'modules/wallet/selectors'
 import {
-  connectWalletRequest,
   approveManaRequest,
   authorizeLandRequest,
   updateDerivationPath
@@ -18,7 +17,6 @@ const mapState = state => {
 }
 
 const mapDispatch = dispatch => ({
-  onConnect: () => dispatch(connectWalletRequest()),
   onApproveMana: mana => dispatch(approveManaRequest(mana)),
   onAuthorizeLand: isAuthorized => dispatch(authorizeLandRequest(isAuthorized)),
   onUpdateDerivationPath: derivationPath =>

--- a/webapp/src/components/SettingsPage/SettingsPage.css
+++ b/webapp/src/components/SettingsPage/SettingsPage.css
@@ -12,3 +12,9 @@
   margin-top: 30px;
   margin-bottom: 0;
 }
+
+.SettingsPage .sign-in {
+  display: block;
+  text-align: center;
+  margin-top: 50px;
+}

--- a/webapp/src/components/SettingsPage/SettingsPage.js
+++ b/webapp/src/components/SettingsPage/SettingsPage.js
@@ -1,12 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-
+import { Link } from 'react-router-dom'
 import { Container, Grid, Header, Loader } from 'semantic-ui-react'
 import Navbar from 'components/Navbar'
 import SettingsForm from './SettingsForm'
 
 import { walletType } from 'components/types'
 import { getManaToApprove } from 'modules/wallet/utils'
+import { locations } from 'locations'
 
 import './SettingsPage.css'
 
@@ -14,7 +15,7 @@ export default class SettingsPage extends React.PureComponent {
   static propTypes = {
     wallet: walletType,
     isLoading: PropTypes.bool,
-    hasError: PropTypes.bool,
+    isConnected: PropTypes.bool,
     onApproveMana: PropTypes.func,
     onAuthorizeLand: PropTypes.func,
     onUpdateDerivationPath: PropTypes.func
@@ -55,7 +56,7 @@ export default class SettingsPage extends React.PureComponent {
   }
 
   render() {
-    const { isLoading, hasError, wallet } = this.props
+    const { isLoading, isConnected, wallet } = this.props
     const {
       address,
       type,
@@ -64,21 +65,20 @@ export default class SettingsPage extends React.PureComponent {
       isLandAuthorized
     } = wallet
 
+    if (isLoading) {
+      return <Loader active size="massive" />
+    }
+
     return (
       <div className="SettingsPage">
         <Navbar />
+        <Container text>
+          <Header as="h1" size="huge" textAlign="center" className="title">
+            Settings
+          </Header>
 
-        {isLoading || !address ? (
-          <Loader active size="massive" />
-        ) : hasError ? (
-          <p>Whoops, error</p>
-        ) : (
-          <Container text>
-            <Header as="h1" size="huge" textAlign="center" className="title">
-              Settings
-            </Header>
-
-            <Grid.Column>
+          <Grid.Column>
+            {isConnected ? (
               <SettingsForm
                 address={address}
                 walletType={type}
@@ -91,9 +91,14 @@ export default class SettingsPage extends React.PureComponent {
                 authorizeTransaction={this.getAuthorizeTransaction()}
                 onLandAuthorizedChange={this.handleLandAuthorization}
               />
-            </Grid.Column>
-          </Container>
-        )}
+            ) : (
+              <p className="sign-in">
+                You need to <Link to={locations.signIn}>Sign In</Link> to access
+                this page
+              </p>
+            )}
+          </Grid.Column>
+        </Container>
       </div>
     )
   }

--- a/webapp/src/components/SettingsPage/SettingsPage.js
+++ b/webapp/src/components/SettingsPage/SettingsPage.js
@@ -15,14 +15,9 @@ export default class SettingsPage extends React.PureComponent {
     wallet: walletType,
     isLoading: PropTypes.bool,
     hasError: PropTypes.bool,
-    onConnect: PropTypes.func,
     onApproveMana: PropTypes.func,
     onAuthorizeLand: PropTypes.func,
     onUpdateDerivationPath: PropTypes.func
-  }
-
-  componentWillMount() {
-    this.props.onConnect()
   }
 
   handleManaApproval = e => {

--- a/webapp/src/components/SignInPage/SignInPage.js
+++ b/webapp/src/components/SignInPage/SignInPage.js
@@ -1,0 +1,41 @@
+import React from 'react'
+
+import StaticPage from 'components/StaticPage'
+
+export default class SignInPage extends React.PureComponent {
+  render() {
+    return (
+      <StaticPage>
+        <div className="message">
+          <p>
+            Download&nbsp;
+            <a
+              href="https://metamask.io"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Metamask
+            </a>
+            &nbsp; or&nbsp;
+            <a
+              href="https://github.com/ethereum/mist"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Mist
+            </a>
+            &nbsp; or access with your&nbsp;<a
+              href="https://www.ledgerwallet.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Ledger Nano S
+            </a>{' '}
+            to use the Marketplace.
+          </p>
+          <p>Make sure your account is unlocked.</p>
+        </div>
+      </StaticPage>
+    )
+  }
+}

--- a/webapp/src/components/SignInPage/index.js
+++ b/webapp/src/components/SignInPage/index.js
@@ -1,0 +1,3 @@
+import SignInPage from './SignInPage'
+
+export default SignInPage

--- a/webapp/src/components/Wallet/Wallet.container.js
+++ b/webapp/src/components/Wallet/Wallet.container.js
@@ -1,0 +1,13 @@
+import { connect } from 'react-redux'
+import { connectWalletRequest } from 'modules/wallet/actions'
+import { openModal } from 'modules/ui/actions'
+import Wallet from './Wallet'
+
+const mapState = state => ({})
+
+const mapDispatch = dispatch => ({
+  onConnect: () => dispatch(connectWalletRequest()),
+  onFirstVisit: () => dispatch(openModal('TermsModal'))
+})
+
+export default connect(mapState, mapDispatch)(Wallet)

--- a/webapp/src/components/Wallet/Wallet.container.js
+++ b/webapp/src/components/Wallet/Wallet.container.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux'
 import { connectWalletRequest } from 'modules/wallet/actions'
+import { fetchDistrictsRequest } from 'modules/districts/actions'
 import { openModal } from 'modules/ui/actions'
 import Wallet from './Wallet'
 
@@ -7,6 +8,7 @@ const mapState = state => ({})
 
 const mapDispatch = dispatch => ({
   onConnect: () => dispatch(connectWalletRequest()),
+  onFetchDistricts: () => dispatch(fetchDistrictsRequest()),
   onFirstVisit: () => dispatch(openModal('TermsModal'))
 })
 

--- a/webapp/src/components/Wallet/Wallet.js
+++ b/webapp/src/components/Wallet/Wallet.js
@@ -6,18 +6,21 @@ export default class Wallet extends React.PureComponent {
   static propTypes = {
     children: PropTypes.node.isRequired,
     onConnect: PropTypes.func.isRequired,
+    onFetchDistricts: PropTypes.func.isRequired,
     onFirstVisit: PropTypes.func.isRequired
   }
 
   static defaultProps = {
     children: null,
     onConnect: () => {},
+    onFetchDistricts: () => {},
     onFirstVisit: () => {}
   }
 
   componentWillMount() {
-    const { onConnect, onFirstVisit } = this.props
+    const { onConnect, onFetchDistricts, onFirstVisit } = this.props
     onConnect()
+    onFetchDistricts()
     if (!localStorage.getItem('seenTermsModal')) {
       onFirstVisit()
     }

--- a/webapp/src/components/Wallet/Wallet.js
+++ b/webapp/src/components/Wallet/Wallet.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { localStorage } from 'lib/localStorage'
 
 export default class Wallet extends React.PureComponent {
   static propTypes = {

--- a/webapp/src/components/Wallet/Wallet.js
+++ b/webapp/src/components/Wallet/Wallet.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default class Wallet extends React.PureComponent {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    onConnect: PropTypes.func.isRequired,
+    onFirstVisit: PropTypes.func.isRequired
+  }
+
+  static defaultProps = {
+    children: null,
+    onConnect: () => {},
+    onFirstVisit: () => {}
+  }
+
+  componentWillMount() {
+    const { onConnect, onFirstVisit } = this.props
+    onConnect()
+    if (!localStorage.getItem('seenTermsModal')) {
+      onFirstVisit()
+    }
+  }
+
+  render() {
+    const { children } = this.props
+    return children
+  }
+}

--- a/webapp/src/components/Wallet/index.js
+++ b/webapp/src/components/Wallet/index.js
@@ -1,0 +1,3 @@
+import Wallet from './Wallet.container'
+
+export default Wallet

--- a/webapp/src/locations.js
+++ b/webapp/src/locations.js
@@ -37,7 +37,9 @@ export const locations = {
 
   error: '/error',
   walletError: '/walletError',
-  serverError: '/serverError'
+  serverError: '/serverError',
+
+  signIn: '/sign-in'
 }
 
 export const PROFILE_PAGE_TABS = Object.freeze({

--- a/webapp/src/locations.js
+++ b/webapp/src/locations.js
@@ -53,5 +53,6 @@ export const NAVBAR_PAGES = Object.freeze({
   activity: 'activity',
   atlas: 'atlas',
   profile: 'profile',
-  settings: 'settings'
+  settings: 'settings',
+  signIn: 'signIn'
 })

--- a/webapp/src/modules/wallet/sagas.js
+++ b/webapp/src/modules/wallet/sagas.js
@@ -8,9 +8,6 @@ import {
   put
 } from 'redux-saga/effects'
 import { eth } from 'decentraland-commons'
-import { replace } from 'react-router-redux'
-
-import { locations } from 'locations'
 import {
   CONNECT_WALLET_REQUEST,
   APPROVE_MANA_REQUEST,
@@ -41,8 +38,8 @@ export function* walletSaga() {
 
 function* handleConnectWalletRequest(action = {}) {
   while (yield select(isStorageLoading)) yield delay(5)
-
   try {
+    yield put(fetchDistrictsRequest())
     if (!eth.isConnected()) {
       const { derivationPath } = yield select(getData)
 
@@ -76,18 +73,15 @@ function* handleConnectWalletRequest(action = {}) {
       type,
       derivationPath
     }
-
     yield handleConnectWalletSuccess(address)
     yield put(connectWalletSuccess(wallet))
   } catch (error) {
-    yield put(replace(locations.walletError))
     yield put(connectWalletFailure(error.message))
   }
 }
 
 function* handleConnectWalletSuccess(address) {
   yield put(fetchAddress(address))
-  yield put(fetchDistrictsRequest())
   yield put(watchLoadingTransactions())
 }
 

--- a/webapp/src/modules/wallet/sagas.js
+++ b/webapp/src/modules/wallet/sagas.js
@@ -24,7 +24,6 @@ import {
 import { getData } from './selectors'
 import { isLoading as isStorageLoading } from 'modules/storage/selectors'
 import { fetchAddress } from 'modules/address/actions'
-import { fetchDistrictsRequest } from 'modules/districts/actions'
 import { watchLoadingTransactions } from 'modules/transaction/actions'
 
 import { connectEthereumWallet, getMarketplaceAddress } from './utils'
@@ -39,7 +38,6 @@ export function* walletSaga() {
 function* handleConnectWalletRequest(action = {}) {
   while (yield select(isStorageLoading)) yield delay(5)
   try {
-    yield put(fetchDistrictsRequest())
     if (!eth.isConnected()) {
       const { derivationPath } = yield select(getData)
 

--- a/webapp/src/modules/wallet/selectors.js
+++ b/webapp/src/modules/wallet/selectors.js
@@ -1,14 +1,21 @@
 import { createSelector } from 'reselect'
-import { APPROVE_MANA_SUCCESS, AUTHORIZE_LAND_SUCCESS } from './actions'
+import {
+  APPROVE_MANA_SUCCESS,
+  AUTHORIZE_LAND_SUCCESS,
+  CONNECT_WALLET_REQUEST
+} from './actions'
 import { getAddresses } from 'modules/address/selectors'
 import { getTransactionsByType } from 'modules/transaction/selectors'
+import { isLoadingType } from 'modules/loading/selectors'
 
 export const getState = state => state.wallet
 export const getData = state => getState(state).data
-export const isLoading = state => getState(state).loading.length > 0
+export const getLoading = state => getState(state).loading
 export const getError = state => getState(state).error
 export const getAddress = state => getData(state).address
 export const isConnected = state => !!getData(state).address
+export const isConnecting = state =>
+  isLoadingType(getLoading(state), CONNECT_WALLET_REQUEST)
 export const getWallet = createSelector(
   getData,
   getAddresses,


### PR DESCRIPTION
**UPDATED:** Rebased with master!

In this PR:

* The UI handles the wallet errors gracefully and allows the user to browse the website even if they are not connected to Ethereum.

* The wallet connection logic has been abstracted into a separate `Wallet` component instead of having each page do the connection.

* I added a "Sign In" page that will act as a placeholder for now until we make the real one (I need some designs and a copy for that)

* The `/activity`, `/settings` and `/:x/:y/buy` are not accesible via UI but if the user access them by typing the url in the browser it will show them a warning pointing them to the Sign In page.

![no-wallet](https://user-images.githubusercontent.com/2781777/37210038-ff155f62-2385-11e8-9cab-f2a8b2dbefb0.gif)