### PR TITLE
fix: Remove un-used translation

### DIFF
--- a/webapp/src/components/BuyParcelPage/BuyParcelPage.js
+++ b/webapp/src/components/BuyParcelPage/BuyParcelPage.js
@@ -105,8 +105,6 @@ export default class BuyParcelPage extends React.PureComponent {
                 </React.Fragment>
               ) : (
                 <React.Fragment>
-                  <span>{t('parcel_buy.should_approve')}</span>
-                  <br />
                   {t_html('parcel_buy.please_approve', {
                     settings_link: (
                       <Link to={locations.settings}>


### PR DESCRIPTION
Simplified the message, looks like this:

![image](https://user-images.githubusercontent.com/692077/37565287-168b18b2-2aa7-11e8-81fb-9a1a15ef37e2.png)
