### PR TITLE
fix: intercom position and size

### DIFF
--- a/webapp/src/components/Footer/Footer.css
+++ b/webapp/src/components/Footer/Footer.css
@@ -18,7 +18,7 @@
   justify-content: space-evenly;
   align-items: center;
   flex: 1 0 auto;
-  padding: 0 20px;
+  padding: 0 20px 0px 85px;
 }
 
 .Footer .footer-column.left {

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -187,3 +187,12 @@ button[disabled]:hover {
 button {
   cursor: pointer;
 }
+
+/* ------------ 
+  Intercom  */
+
+.intercom-launcher-frame,
+.intercom-launcher-discovery-frame {
+  bottom: 10px !important;
+  transform: scale(0.8) !important;
+}


### PR DESCRIPTION
This fixes the position and size of the Intercom launcher on the footer. ~The background color needs to be set to `#202433` from the Interdom's admin panel.~ [Done](https://github.com/decentraland/marketplace/pull/109#issuecomment-374010077).

<img width="500" alt="screen shot 2018-03-18 at 12 39 11 pm" src="https://user-images.githubusercontent.com/2781777/37567755-2ea840f2-2aaa-11e8-9511-b38de558dca5.png">

