### PR TITLE
chore: fixed and added missing translations

### DIFF
--- a/src/Translation/locales/en.json
+++ b/src/Translation/locales/en.json
@@ -40,7 +40,9 @@
     "owner": "Owner: {owner}",
     "no_owner": "No Owner",
     "your_parcel": "Your parcel",
-    "on_sale": "On Sale: "
+    "on_sale": "On Sale: ",
+    "loading": "Loading",
+    "road": "Road"
   },
   "marketplace": {
     "empty": "Oops... nothing found here.",
@@ -153,7 +155,7 @@
     "disapproved":
       "You unauthorized the {marketplace_contract_link} to operate MANA on your behalf",
     "authorize":
-      "You have {action} the {marketplace_contract_link} to operate LAND on your behalf",
+      "You {action} the {marketplace_contract_link} to operate LAND on your behalf",
     "edit":
       "You edited {parcel_link} with the name \"{name}\" and description \"{description}\"",
     "transfer": "You transfered {parcel_link} to {owner_link}",
@@ -197,7 +199,8 @@
       "Authorize the {marketplace_contract_link} to operate LAND on your behalf"
   },
   "derivation_path": {
-    "supported": "We only support paths that start with {paths} for the time being"
+    "supported":
+      "We only support paths that start with {paths} for the time being"
   },
   "color_key": {
     "title": "Color key",
@@ -209,7 +212,8 @@
     "plaza": "Plaza",
     "unowned": "Unowned",
     "loading": "Loading",
-    "on_sale": "On sale"
+    "on_sale": "On sale",
+    "go_back": "Go back"
   },
   "sign_in": {
     "options":

--- a/src/Translation/locales/es.json
+++ b/src/Translation/locales/es.json
@@ -40,7 +40,9 @@
     "owner": "Dueño: {owner}",
     "no_owner": "Sin Dueño",
     "your_parcel": "Tu parcela",
-    "on_sale": "En Venta: "
+    "on_sale": "En Venta: ",
+    "loading": "Cargando",
+    "road": "Carretera"
   },
   "marketplace": {
     "empty": "Oops... no encontramos nada aquí.",
@@ -201,7 +203,8 @@
       "Autorizar al {marketplace_contract_link} a operar MANA por tu cuenta"
   },
   "derivation_path": {
-    "supported": "Por el momento solo soportamos derivation paths que comienzan con {paths}"
+    "supported":
+      "Por el momento solo soportamos derivation paths que comienzan con {paths}"
   },
   "color_key": {
     "title": "Mapa de colores",
@@ -213,7 +216,8 @@
     "plaza": "Plaza",
     "unowned": "Sin dueño",
     "loading": "Cargando",
-    "on_sale": "En venta"
+    "on_sale": "En venta",
+    "go_back": "Volver"
   },
   "sign_in": {
     "options":

--- a/src/Translation/locales/fr.json
+++ b/src/Translation/locales/fr.json
@@ -41,7 +41,9 @@
     "owner": "Propriétaire : {owner}",
     "no_owner": "Aucun propriétaire",
     "your_parcel": "Votre parcelle",
-    "on_sale": "A vendre: "
+    "on_sale": "A vendre: ",
+    "loading": "Chargement",
+    "road": "Route"
   },
   "marketplace": {
     "empty": "Oops... rien ne semble correspondre.",
@@ -205,7 +207,8 @@
       "Autorise le {marketplace_contract_link} à gerer les LANDs en votre nom."
   },
   "derivation_path": {
-    "supported": "Nous ne prenons en charge que les chemins commençant par {paths} pour le moment"
+    "supported":
+      "Nous ne prenons en charge que les chemins commençant par {paths} pour le moment"
   },
   "color_key": {
     "title": "Code couleur",
@@ -217,7 +220,8 @@
     "plaza": "Places",
     "unowned": "Libres",
     "loading": "Chargement",
-    "on_sale": "À vendre"
+    "on_sale": "À vendre",
+    "go_back": "Retourner"
   },
   "sign_in": {
     "options":

--- a/src/Translation/locales/ko.json
+++ b/src/Translation/locales/ko.json
@@ -37,10 +37,12 @@
     "my_land": "나의 토지"
   },
   "atlas": {
-    "owner": "소유자 : {소유자}",
+    "owner": "소유자 : {owner}",
     "no_owner": "소유자 없음",
     "your_parcel": "당신의 토지",
-    "on_sale": "판매 중 :"
+    "on_sale": "판매 중 :",
+    "loading": "로드 중",
+    "road": "도로"
   },
   "marketplace": {
     "empty": "죄송합니다. 여기에는 아무것도 없습니다.",
@@ -205,7 +207,8 @@
     "plaza": "광장",
     "unowned": "소유자가 없는",
     "loading": "로드 중",
-    "on_sale": "판매 중"
+    "on_sale": "판매 중",
+    "go_back": "돌아 가라."
   },
   "sign_in": {
     "options":

--- a/src/Translation/locales/zh.json
+++ b/src/Translation/locales/zh.json
@@ -40,7 +40,9 @@
     "owner": "所有者：{owner}",
     "no_owner": "没有所有者",
     "your_parcel": "您的地块",
-    "on_sale": "出售中："
+    "on_sale": "出售中：",
+    "loading": "载入中",
+    "road": "路"
   },
   "marketplace": {
     "empty": "噢......这里没有任何东西。",
@@ -147,7 +149,7 @@
     "completed": "已完成"
   },
   "transaction": {
-    "approved": "您已批准{mana}MANA供{虚拟市场}{marketplace_contract_link}使用",
+    "approved": "您授权{marketplace_contract_link}以您的名义操作MANA",
     "disapproved": "您未经授权{marketplace_contract_link}以您的名义操作MANA",
     "authorize": "您有{action} {marketplace_contract_link}以您的名义操作LAND",
     "edit":
@@ -195,7 +197,8 @@
     "plaza": "广场",
     "unowned": "无主",
     "loading": "加载中",
-    "on_sale": "出售"
+    "on_sale": "出售",
+    "go_back": "回去"
   },
   "sign_in": {
     "options":

--- a/webapp/src/components/ColorKeyPage/ColorKeyPage.js
+++ b/webapp/src/components/ColorKeyPage/ColorKeyPage.js
@@ -52,7 +52,7 @@ export default function ColorKey() {
         </div>
       </div>
       <Link to={locations.parcelMapDetail(0, 0)}>
-        <Button>Go Back</Button>
+        <Button>{t('color_key.go_back')}</Button>
       </Link>
     </StaticPage>
   )

--- a/webapp/src/lib/parcelUtils.js
+++ b/webapp/src/lib/parcelUtils.js
@@ -56,7 +56,7 @@ export function getParcelAttributes(id, x, y, wallet, parcels, districts) {
   const parcel = parcels[id]
   if (!parcel) {
     return {
-      label: 'Loading...',
+      label: t('atlas.loading') + '...',
       description: null,
       color: 'white',
       backgroundColor:
@@ -68,7 +68,7 @@ export function getParcelAttributes(id, x, y, wallet, parcels, districts) {
   if (isDistrict(parcel)) {
     if (isRoad(parcel.district_id)) {
       return {
-        label: 'Road',
+        label: t('atlas.road'),
         description: null,
         color: 'white',
         backgroundColor: COLORS.roads


### PR DESCRIPTION
Fixed a broken tranlsation in Chinese (`transaction.approved`) and another one in Korean (`atlas.owner`) and added missing translations on atlas page and color key.