### PR TITLE
fix: reset page when sorting

### DIFF
--- a/webapp/src/components/MarketplacePage/MarketplacePage.js
+++ b/webapp/src/components/MarketplacePage/MarketplacePage.js
@@ -83,7 +83,10 @@ export default class MarketplacePage extends React.PureComponent {
       return
     }
     const options = getOptionsFromSortType(data.value)
-    this.navigateTo(options)
+    this.navigateTo({
+      ...options,
+      page: 1
+    })
   }
 
   renderLoading() {

--- a/webapp/src/lib/parcelUtils.js
+++ b/webapp/src/lib/parcelUtils.js
@@ -78,7 +78,7 @@ export function getParcelAttributes(id, x, y, wallet, parcels, districts) {
       return {
         label: 'Genesis Plaza',
         description: null,
-        color: 'white',
+        color: 'black',
         backgroundColor: COLORS.plaza
       }
     }


### PR DESCRIPTION
This PR makes the page go back to 1 when sorting on the Marketplace page.

Also it improves the contrast of the text on the Genesis Plaza tooltips (black over green instead of white over green).