### PR TITLE
fix: safeguard against undefined reference in leaflet _onPanTransitionEnd

### DIFF
--- a/webapp/src/components/AtlasPage/Map/ParcelsMap/ParcelsMap.js
+++ b/webapp/src/components/AtlasPage/Map/ParcelsMap/ParcelsMap.js
@@ -25,6 +25,14 @@ const MAP_ID = 'map'
 
 L.Icon.Default.imagePath = 'https://cdnjs.com/ajax/libs/leaflet/1.0.3/images/'
 
+// I'm not proud of the following piece of code but
+// it will keep Rollbar from filling our inboxes:
+const original_onPanTransitionEnd = L.Map.prototype._onPanTransitionEnd
+L.Map.prototype._onPanTransitionEnd = function() {
+  if (!this._mapPane) return
+  return original_onPanTransitionEnd.apply(this, arguments)
+}
+
 export default class ParcelsMap extends React.Component {
   static propTypes = {
     wallet: walletType.isRequired,


### PR DESCRIPTION
This PR prevents the two most commons rollbar errors:

```
TypeError: Cannot read property 'classList' of undefined
1
File "../node_modules/leaflet/dist/leaflet-src.js" line 2654 col 1 in me
if (el.classList !== undefined) {
2
File "../node_modules/leaflet/dist/leaflet-src.js" line 4489 col 1 in n._onPanTransitionEnd
removeClass(this._mapPane, 'leaflet-pan-anim');
3
File "../node_modules/leaflet/dist/leaflet-src.js" line 593 col 1 in n.fire
l.fn.call(l.ctx || this, event);
4
File "../node_modules/leaflet/dist/leaflet-src.js" line 2965 col 1 in n._complete
this.fire('end');
5
File "../node_modules/leaflet/dist/leaflet-src.js" line 2943 col 1 in n._step
this._complete();
6
File "../node_modules/leaflet/dist/leaflet-src.js" line 2932 col 1 in n._animate
this._step();
```


and this:

```
TypeError: undefined is not an object (evaluating 'e.classList')
1
File "../node_modules/leaflet/dist/leaflet-src.js" line 2654 col 1 in me
if (el.classList !== undefined) {
2
File "../node_modules/leaflet/dist/leaflet-src.js" line 4489 col 1 in _onPanTransitionEnd
removeClass(this._mapPane, 'leaflet-pan-anim');
3
File "../node_modules/leaflet/dist/leaflet-src.js" line 593 col 1 in fire
l.fn.call(l.ctx || this, event);
4
File "../node_modules/leaflet/dist/leaflet-src.js" line 2965 col 1 in _complete
this.fire('end');
5
File "../node_modules/leaflet/dist/leaflet-src.js" line 2943 col 1 in _step
this._complete();
6
File "../node_modules/leaflet/dist/leaflet-src.js" line 2932 col 1 in _animate
this._step();
7
File "[native code]" line (unknown) in _animate
```