### PR TITLE
fix: add handling of events passed as array

### DIFF
--- a/scripts/monitor/handlers/index.js
+++ b/scripts/monitor/handlers/index.js
@@ -4,6 +4,9 @@ import { BlockchainEvent } from '../../../src/BlockchainEvent'
 const log = new Log('handlers')
 
 export async function store(eventData) {
+  if (eventData.length) {
+    return Promise.all(eventData.map(store))
+  }
   if (eventData.removed) return
 
   const { event, transactionHash, blockNumber, logIndex } = eventData

--- a/scripts/monitor/index.js
+++ b/scripts/monitor/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env babel-node
 
-import { eth, Log } from 'decentraland-commons'
+import { env, eth, contracts, Log } from 'decentraland-commons'
 import * as handlers from './handlers'
 import { StoreCli } from './StoreCli'
 import { db } from '../../src/database'
@@ -17,7 +17,10 @@ Promise.resolve()
   })
   .then(() => {
     log.debug('Connecting to Ethereum node')
-    return eth.connect()
+    return eth.connect({
+      contracts: [contracts.LANDRegistry, contracts.Marketplace],
+      providerUrl: env.get('RPC_URL')
+    })
   })
   .then(() => {
     log.debug('Starting CLI')

--- a/scripts/renewBlockchainData.js
+++ b/scripts/renewBlockchainData.js
@@ -8,7 +8,7 @@ import { loadEnv } from './utils'
 
 const log = new Log('update')
 
-const BATCH_SIZE = parseInt(env.get('RENEW_BATCH_SIZE', 1000), 10)
+let BATCH_SIZE
 
 export async function renewBlockchainData() {
   log.info(`Using ${BATCH_SIZE} as batch size, configurable via BATCH_SIZE`)
@@ -75,6 +75,7 @@ async function updateParcelsData(parcels) {
 
 if (require.main === module) {
   loadEnv()
+  BATCH_SIZE = parseInt(env.get('RENEW_BATCH_SIZE', 1000), 10)
 
   Promise.resolve()
     .then(renewBlockchainData)


### PR DESCRIPTION
Updating the dependencies for `commons`, it seems that `eventData` might be an array of events. This change prevents this.

Also: Fix `monitor` as it wasn't connecting to `RPC_URL` for me