### PR TITLE
feat: redesign

### DIFF
--- a/src/Translation/locales/en.json
+++ b/src/Translation/locales/en.json
@@ -24,6 +24,7 @@
     "authorized": "Authorized",
     "unauthorized": "Unauthorized",
     "wallet_address": "Wallet address",
+    "balance": "Balance",
     "for": "for",
     "sign_in": "Sign In",
     "sign_in_notice": "You need to {sign_in_link} to access this page",
@@ -94,13 +95,13 @@
   },
   "parcel_edit": {
     "edit_land": "Edit LAND",
-    "set_name_and_desc": "Set a name and description for {parcel_name}",
+    "set_name_and_desc": "Set a name and description for {parcel_name}.",
     "name": "Name",
     "description": "Description"
   },
   "parcel_transfer": {
     "transfer_land": "Transfer LAND",
-    "about_to_transfer": "You're about to transfer {parcel_name}",
+    "about_to_transfer": "You're about to transfer {parcel_name}.",
     "irreversible":
       "Remember that transferring LAND is an irreversible operation.",
     "check_address": "Please check the address carefully",
@@ -112,7 +113,7 @@
   },
   "parcel_buy": {
     "buy_land": "Buy LAND",
-    "about_to_buy": "You are about to buy {parcel_name} {parcel_price}",
+    "about_to_buy": "You are about to buy {parcel_name} {parcel_price}.",
     "approved_balance": "Your approved balance is {approved_balance}",
     "needs_at_least": "You need at least {mana} in order to buy this LAND.",
     "didnt_approve": "You haven't authorized MANA usage",
@@ -122,7 +123,7 @@
   },
   "parcel_publish": {
     "list_land": "List LAND for sale",
-    "set_land_price": "Set a price and an expiration date for {parcel_name}",
+    "set_land_price": "Set a price and an expiration date for {parcel_name}.",
     "price": "Price",
     "price_placeholder": "Price in MANA for this LAND",
     "expiration": "Expiration",
@@ -138,10 +139,9 @@
     }
   },
   "parcel_cancel": {
-    "cancel_land": "Cancel LAND Sale",
-    "currently_on_sale": "is currently on sale for {value}.",
-    "about_to_cancel": "You are about to cancel this sale.",
-    "not_for_sale": "is not for sale."
+    "cancel_land": "Cancel Sale",
+    "about_to_cancel": "You are about to cancel the sale of {parcel}.",
+    "not_for_sale": "The parcel {parcel} is not for sale."
   },
   "activity": {
     "no_activity": "You have no activity yet.",
@@ -196,7 +196,8 @@
     "you_authorized":
       "You have authorized the {marketplace_contract_link} to operate LAND on your behalf",
     "authorize":
-      "Authorize the {marketplace_contract_link} to operate LAND on your behalf"
+      "Authorize the {marketplace_contract_link} to operate LAND on your behalf",
+    "authorization": "Authorization"
   },
   "derivation_path": {
     "supported":

--- a/src/Translation/locales/es.json
+++ b/src/Translation/locales/es.json
@@ -24,6 +24,7 @@
     "authorized": "Autorizado",
     "unauthorized": "No autorizado",
     "wallet_address": "Dirección de billetera",
+    "balance": "Balance",
     "for": "para",
     "sign_in": "Conectar",
     "sign_in_notice": "Necesitas {sign_in_link} para acceder a esta página",
@@ -142,9 +143,8 @@
   },
   "parcel_cancel": {
     "cancel_land": "Cancelar la venta de LAND",
-    "currently_on_sale": "está actualmente en venta por {value}.",
-    "about_to_cancel": "Estas por cancelar esta venta.",
-    "not_for_sale": "no está para la venta."
+    "about_to_cancel": "Estás por cancelar la venta de {parcel}.",
+    "not_for_sale": "La parcela {parcel} no está en venta."
   },
   "activity": {
     "no_activity": "No tienes actividad por el momento.",
@@ -200,7 +200,8 @@
     "you_authorized":
       "Has autorizado al {marketplace_contract_link} a operar MANA por tu cuenta",
     "authorize":
-      "Autorizar al {marketplace_contract_link} a operar MANA por tu cuenta"
+      "Autorizar al {marketplace_contract_link} a operar MANA por tu cuenta",
+    "authorization": "Autorización"
   },
   "derivation_path": {
     "supported":

--- a/src/Translation/locales/fr.json
+++ b/src/Translation/locales/fr.json
@@ -24,6 +24,7 @@
     "authorized": "Autorisé",
     "unauthorized": "Non autorisé",
     "wallet_address": "Adresse du porte-feuille",
+    "balance": "Balance",
     "for": "pour",
     "sign_in": "Se connecter",
     "sign_in_notice":
@@ -144,9 +145,8 @@
   },
   "parcel_cancel": {
     "cancel_land": "Annuler la vente de la LAND",
-    "currently_on_sale": "est actuellement en vente pour {value}.",
-    "about_to_cancel": "Vous êtes sur le point d'annuler cette vente.",
-    "not_for_sale": "n'est pas à vendre"
+    "about_to_cancel": "Vous êtes sur le point d'annuler la vente de {parcel}.",
+    "not_for_sale": "La parcelle {parcel} n'est pas à vendre."
   },
   "activity": {
     "no_activity": "Vous n'avez pas encore d'activité.",
@@ -204,7 +204,8 @@
     "you_authorized":
       "Vous avez autorisé le {marketplace_contract_link} à gerer les LANDs en votre nom.",
     "authorize":
-      "Autorise le {marketplace_contract_link} à gerer les LANDs en votre nom."
+      "Autorise le {marketplace_contract_link} à gerer les LANDs en votre nom.",
+    "authorization": "Autorisation"
   },
   "derivation_path": {
     "supported":

--- a/src/Translation/locales/ko.json
+++ b/src/Translation/locales/ko.json
@@ -24,6 +24,7 @@
     "authorized": "허가",
     "unauthorized": "무단",
     "wallet_address": "지갑 주소",
+    "balance": "밸런스",
     "for": "에 대한",
     "sign_in": "로그인",
     "sign_in_notice": "이 페이지에 액세스하려면 {sign_in_link}해야합니다.",
@@ -140,8 +141,8 @@
   "parcel_cancel": {
     "cancel_land": "토지 판매 취소",
     "currently_on_sale": "현재 {value}에 판매 중입니다.",
-    "about_to_cancel": "당신은이 판매를 취소하려고합니다.",
-    "not_for_sale": "판매용이 아닙니다."
+    "about_to_cancel": "{parcel}의 판매를 취소하려고합니다.",
+    "not_for_sale": "소포 {parcel}은 판매용이 아닙니다."
   },
   "activity": {
     "no_activity": "아직 활동이 없습니다.",
@@ -192,7 +193,8 @@
     "authorize_land_check": "선택하면 시장 계약에 대한 토지 사용을 허가합니다",
     "you_authorized": "{marketplace_contract_link}을(를) 승인했습니다.",
     "authorize":
-      "{marketplace_contract_link}에게 귀하를 대신하여 토지를 운영하도록 승인하십시오."
+      "{marketplace_contract_link}에게 귀하를 대신하여 토지를 운영하도록 승인하십시오.",
+    "authorization": "권한 부여"
   },
   "derivation_path": {
     "supported": "당분간 {경로}로 시작하는 경로 만 지원합니다."

--- a/src/Translation/locales/zh.json
+++ b/src/Translation/locales/zh.json
@@ -24,6 +24,7 @@
     "authorized": "已授权",
     "unauthorized": "未授权",
     "wallet_address": "钱包地址",
+    "balance": "平衡",
     "for": "对于",
     "sign_in": "登录",
     "sign_in_notice": "您需要{sign_in_link}才能访问此页面",
@@ -139,8 +140,8 @@
   "parcel_cancel": {
     "cancel_land": "取消土地出售",
     "currently_on_sale": "目前正以价格{value}出售。",
-    "about_to_cancel": "您即将取消这次销售。",
-    "not_for_sale": "不出售。"
+    "about_to_cancel": "您即将取消{parcel}的销售。",
+    "not_for_sale": "包裹{parcel}不出售。"
   },
   "activity": {
     "no_activity": "您还没有活动。",
@@ -182,7 +183,8 @@
     "unauthorize_land_check": "取消勾选取消授权市场合约的虚拟土地使用",
     "authorize_land_check": "勾选并授权虚拟市场合约的土地使用",
     "you_authorized": "您已授权{marketplace_contract_link}以您的名义操作LAND",
-    "authorize": "授权{marketplace_contract_link}在您的行为中操作LAND"
+    "authorize": "授权{marketplace_contract_link}在您的行为中操作LAND",
+    "authorization": "授权"
   },
   "derivation_path": {
     "supported": "我们暂时只支持以{paths}开头的路径"

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -18,7 +18,6 @@
     "axios": "^0.17.0",
     "date-fns": "^1.29.0",
     "decentraland-commons": "3.6.0",
-    "dotenv": "^5.0.1",
     "ethereum-blockies": "^0.1.1",
     "history": "^4.7.2",
     "leaflet": "^1.3.0",

--- a/webapp/src/components/ActivityPage/Transaction/Transaction.css
+++ b/webapp/src/components/ActivityPage/Transaction/Transaction.css
@@ -45,6 +45,7 @@
 .Transaction .transaction-icon {
   height: 100%;
   float: right;
+  margin-top: 10px;
 }
 
 @media (max-width: 768px) {

--- a/webapp/src/components/ActivityPage/Transaction/Transaction.js
+++ b/webapp/src/components/ActivityPage/Transaction/Transaction.js
@@ -46,7 +46,7 @@ export default class Transaction extends React.PureComponent {
   renderMarketplaceLink() {
     return (
       <EtherscanLink address={getMarketplaceAddress()}>
-        Marketplace contract
+        Marketplace
       </EtherscanLink>
     )
   }

--- a/webapp/src/components/AddressBlock/AddressBlock.container.js
+++ b/webapp/src/components/AddressBlock/AddressBlock.container.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
 import { getWallet } from 'modules/wallet/selectors'
 
-import AddressLink from './AddressLink'
+import AddressBlock from './AddressBlock'
 
 const mapState = (state, { address }) => {
   const wallet = getWallet(state)
@@ -12,4 +12,4 @@ const mapState = (state, { address }) => {
 
 const mapDispatch = dispatch => ({})
 
-export default connect(mapState, mapDispatch)(AddressLink)
+export default connect(mapState, mapDispatch)(AddressBlock)

--- a/webapp/src/components/AddressBlock/AddressBlock.css
+++ b/webapp/src/components/AddressBlock/AddressBlock.css
@@ -1,9 +1,9 @@
-.AddressLink {
+.AddressBlock {
   position: relative;
   display: inline-flex;
   flex: 1 0 auto;
 }
 
-.AddressLink .Blockie {
+.AddressBlock .Blockie {
   border-radius: 5px;
 }

--- a/webapp/src/components/AddressBlock/AddressBlock.js
+++ b/webapp/src/components/AddressBlock/AddressBlock.js
@@ -7,9 +7,9 @@ import Blockie from 'components/Blockie'
 import { shortenAddress } from 'lib/utils'
 import { t } from 'modules/translation/utils'
 
-import './AddressLink.css'
+import './AddressBlock.css'
 
-export default class AddressLink extends React.Component {
+export default class AddressBlock extends React.Component {
   static propTypes = {
     address: PropTypes.string.isRequired,
     link: PropTypes.string,
@@ -52,7 +52,7 @@ export default class AddressLink extends React.Component {
 
     return (
       <div
-        className={`AddressLink ${className}`}
+        className={`AddressBlock ${className}`}
         data-balloon-pos="up"
         data-balloon={
           hasTooltip

--- a/webapp/src/components/AddressBlock/index.js
+++ b/webapp/src/components/AddressBlock/index.js
@@ -1,0 +1,3 @@
+import AddressBlock from './AddressBlock.container'
+
+export default AddressBlock

--- a/webapp/src/components/AddressLink/AddressLink.js
+++ b/webapp/src/components/AddressLink/AddressLink.js
@@ -16,6 +16,7 @@ export default class AddressLink extends React.Component {
     size: PropTypes.number,
     scale: PropTypes.number,
     hasTooltip: PropTypes.bool,
+    hasLink: PropTypes.bool,
     isUser: PropTypes.bool,
     className: PropTypes.string
   }
@@ -25,6 +26,7 @@ export default class AddressLink extends React.Component {
     size: 6,
     scale: 3,
     hasTooltip: true,
+    hasLink: true,
     className: ''
   }
 
@@ -35,9 +37,18 @@ export default class AddressLink extends React.Component {
       size,
       scale,
       hasTooltip,
+      hasLink,
       isUser,
       className
     } = this.props
+
+    if (address == null) {
+      return null
+    }
+
+    const blockie = (
+      <Blockie seed={address.toLowerCase()} size={size} scale={scale} />
+    )
 
     return (
       <div
@@ -49,10 +60,12 @@ export default class AddressLink extends React.Component {
             : null
         }
       >
-        {address && (
+        {hasLink ? (
           <Link to={link ? link : locations.profilePage(address)}>
-            <Blockie seed={address.toLowerCase()} size={size} scale={scale} />
+            {blockie}
           </Link>
+        ) : (
+          blockie
         )}
       </div>
     )

--- a/webapp/src/components/AddressLink/index.js
+++ b/webapp/src/components/AddressLink/index.js
@@ -1,3 +1,0 @@
-import AddressLink from './AddressLink.container'
-
-export default AddressLink

--- a/webapp/src/components/BuyParcelPage/BuyParcelPage.js
+++ b/webapp/src/components/BuyParcelPage/BuyParcelPage.js
@@ -1,20 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
-import {
-  Loader,
-  Container,
-  Header,
-  Grid,
-  Button,
-  Message
-} from 'semantic-ui-react'
-import ParcelName from 'components/ParcelName'
+import { Loader, Container, Header, Grid, Message } from 'semantic-ui-react'
+import ParcelModal from 'components/ParcelModal'
 import Parcel from 'components/Parcel'
 import Mana from 'components/Mana'
 import { walletType } from 'components/types'
 import { locations } from 'locations'
-import { formatMana } from 'lib/utils'
+import { formatMana, buildCoordinate } from 'lib/utils'
 import { t, t_html } from 'modules/translation/utils'
 
 import './BuyParcelPage.css'
@@ -139,55 +132,41 @@ export default class BuyParcelPage extends React.PureComponent {
         {(parcel, isOwner) => (
           <div className="BuyParcelPage">
             {this.renderMessage(isNotEnoughMana, isNotEnoughApproved)}
-            <Container text textAlign="center">
-              <Header as="h2" size="huge" className="title">
-                {t('parcel_buy.buy_land')}
-              </Header>
-              <span className="subtitle">
-                {t_html('parcel_buy.about_to_buy', {
-                  parcel_name: <ParcelName parcel={parcel} />,
-                  parcel_price: publication ? (
-                    <React.Fragment>
-                      &nbsp;{t('global.for')}&nbsp;&nbsp;
-                      <span
-                        style={{
-                          display: 'inline-block',
-                          transform: 'translateY(5px)'
-                        }}
-                      >
-                        <Mana
-                          amount={parseFloat(publication.price, 10)}
-                          size={18}
-                        />
-                      </span>
-                    </React.Fragment>
-                  ) : (
-                    ''
-                  )
-                })}
-              </span>
-            </Container>
-            <br />
-            <Container text>
-              <Grid.Column className="text-center">
-                <Button onClick={onCancel} type="button">
-                  {t('global.cancel')}
-                </Button>
-                <Button
-                  onClick={this.handleConfirm}
-                  type="button"
-                  primary
-                  disabled={
-                    isDisabled ||
-                    isOwner ||
-                    isNotEnoughMana ||
-                    isNotEnoughApproved
-                  }
-                >
-                  {t('global.confirm')}
-                </Button>
-              </Grid.Column>
-            </Container>
+            <ParcelModal
+              x={x}
+              y={y}
+              title={t('parcel_buy.buy_land')}
+              subtitle={t_html('parcel_buy.about_to_buy', {
+                parcel_name: (
+                  <Link to={locations.parcelDetail(x, y)}>
+                    {buildCoordinate(x, y)}
+                  </Link>
+                ),
+                parcel_price: publication ? (
+                  <React.Fragment>
+                    &nbsp;{t('global.for')}&nbsp;&nbsp;
+                    <span
+                      style={{
+                        display: 'inline-block',
+                        transform: 'translateY(3px)'
+                      }}
+                    >
+                      <Mana
+                        amount={parseFloat(publication.price, 10)}
+                        size={14}
+                      />
+                    </span>
+                  </React.Fragment>
+                ) : (
+                  ''
+                )
+              })}
+              onCancel={onCancel}
+              onConfirm={this.handleConfirm}
+              isDisabled={
+                isDisabled || isOwner || isNotEnoughMana || isNotEnoughApproved
+              }
+            />
           </div>
         )}
       </Parcel>

--- a/webapp/src/components/CancelSalePage/CancelSalePage.css
+++ b/webapp/src/components/CancelSalePage/CancelSalePage.css
@@ -1,15 +1,2 @@
-.CancelSalePage .subtitle {
-  color: white;
-  font-weight: 100;
-  font-size: 1.2em;
-  margin: 20px;
-  display: inline-block;
-}
-
-.CancelSalePage .subtitle + .subtitle {
-  margin-top: 0px;
-}
-
-.CancelSalePage button + button {
-  margin-left: 15px !important;
+.CancelSalePage {
 }

--- a/webapp/src/components/CancelSalePage/CancelSalePage.js
+++ b/webapp/src/components/CancelSalePage/CancelSalePage.js
@@ -1,12 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-
-import { Container, Header, Grid, Button } from 'semantic-ui-react'
-import ParcelName from 'components/ParcelName'
+import { Link } from 'react-router-dom'
 import Parcel from 'components/Parcel'
-
-import { formatMana } from 'lib/utils'
-import { t } from 'modules/translation/utils'
+import ParcelModal from 'components/ParcelModal'
+import { buildCoordinate } from 'lib/utils'
+import { t, t_html } from 'modules/translation/utils'
+import { locations } from 'locations'
 
 import './CancelSalePage.css'
 
@@ -24,6 +23,26 @@ export default class CancelSalePage extends React.PureComponent {
     onConfirm(publication)
   }
 
+  renderSubtitle = () => {
+    const { x, y, publication } = this.props
+    const parcel = (
+      <Link to={locations.parcelDetail(x, y)}>{buildCoordinate(x, y)}</Link>
+    )
+    return (
+      <React.Fragment>
+        {publication ? (
+          <React.Fragment>
+            {t_html('parcel_cancel.about_to_cancel', { parcel })}
+          </React.Fragment>
+        ) : (
+          <React.Fragment>
+            {t_html('parcel_cancel.not_for_sale', { parcel })}
+          </React.Fragment>
+        )}
+      </React.Fragment>
+    )
+  }
+
   render() {
     const { x, y, publication, isDisabled, onCancel } = this.props
 
@@ -31,46 +50,15 @@ export default class CancelSalePage extends React.PureComponent {
       <Parcel x={x} y={y} ownerOnly>
         {parcel => (
           <div className="CancelSalePage">
-            <Container text textAlign="center">
-              <Header as="h2" size="huge" className="title">
-                {t('parcel_cancel.cancel_land')}
-              </Header>
-              <span className="subtitle">
-                <ParcelName parcel={parcel} />&nbsp;&nbsp;
-                {publication ? (
-                  <React.Fragment>
-                    {t('parcel_cancel.currently_on_sale', {
-                      value: formatMana(publication.price)
-                    })}
-                  </React.Fragment>
-                ) : (
-                  <React.Fragment>
-                    {t('parcel_cancel.not_for_sale')}
-                  </React.Fragment>
-                )}
-              </span>
-              {publication ? (
-                <span className="subtitle">
-                  {t('parcel_cancel.about_to_cancel')}
-                </span>
-              ) : null}
-            </Container>
-            <br />
-            <Container text>
-              <Grid.Column className="text-center">
-                <Button onClick={onCancel} type="button">
-                  {t('global.cancel')}
-                </Button>
-                <Button
-                  onClick={this.handleConfirm}
-                  type="button"
-                  negative
-                  disabled={isDisabled || !publication}
-                >
-                  {t('global.confirm')}
-                </Button>
-              </Grid.Column>
-            </Container>
+            <ParcelModal
+              x={x}
+              y={y}
+              title={t('parcel_cancel.cancel_land')}
+              subtitle={this.renderSubtitle()}
+              onCancel={onCancel}
+              onConfirm={this.handleConfirm}
+              isDisabled={isDisabled || !publication}
+            />
           </div>
         )}
       </Parcel>

--- a/webapp/src/components/CancelSalePage/CancelSalePage.js
+++ b/webapp/src/components/CancelSalePage/CancelSalePage.js
@@ -28,19 +28,9 @@ export default class CancelSalePage extends React.PureComponent {
     const parcel = (
       <Link to={locations.parcelDetail(x, y)}>{buildCoordinate(x, y)}</Link>
     )
-    return (
-      <React.Fragment>
-        {publication ? (
-          <React.Fragment>
-            {t_html('parcel_cancel.about_to_cancel', { parcel })}
-          </React.Fragment>
-        ) : (
-          <React.Fragment>
-            {t_html('parcel_cancel.not_for_sale', { parcel })}
-          </React.Fragment>
-        )}
-      </React.Fragment>
-    )
+    return publication
+      ? t_html('parcel_cancel.about_to_cancel', { parcel })
+      : t_html('parcel_cancel.not_for_sale', { parcel })
   }
 
   render() {

--- a/webapp/src/components/EditParcelPage/EditParcelForm/EditParcelForm.css
+++ b/webapp/src/components/EditParcelPage/EditParcelForm/EditParcelForm.css
@@ -1,5 +1,5 @@
-.EditParcelForm .ui.button {
-  padding: 12px 42px;
+.EditParcelForm {
+  min-width: 400px;
 }
 
 .EditParcelForm .ui.button + .ui.button {

--- a/webapp/src/components/EditParcelPage/EditParcelForm/EditParcelForm.js
+++ b/webapp/src/components/EditParcelPage/EditParcelForm/EditParcelForm.js
@@ -92,7 +92,7 @@ export default class EditParcelForm extends React.PureComponent {
           <TxStatus.Idle isIdle={isTxIdle} />
         </Form.Field>
         <br />
-        <div className="text-center">
+        <div>
           <Button type="button" onClick={this.handleCancel}>
             {t('global.cancel')}
           </Button>

--- a/webapp/src/components/EditParcelPage/EditParcelPage.js
+++ b/webapp/src/components/EditParcelPage/EditParcelPage.js
@@ -1,14 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-
-import { Container, Header, Grid } from 'semantic-ui-react'
+import { Link } from 'react-router-dom'
 import Parcel from 'components/Parcel'
-import ParcelName from 'components/ParcelName'
+import ParcelModal from 'components/ParcelModal'
 import TxStatus from 'components/TxStatus'
 import EditParcelForm from './EditParcelForm'
 import { t, t_html } from 'modules/translation/utils'
+import { locations } from 'locations'
 
 import './EditParcelPage.css'
+import { buildCoordinate } from '../../lib/utils'
 
 export default class EditParcelPage extends React.PureComponent {
   static propTypes = {
@@ -26,28 +27,27 @@ export default class EditParcelPage extends React.PureComponent {
       <Parcel x={x} y={y} ownerOnly>
         {parcel => (
           <div className="EditParcelPage">
-            <Container text textAlign="center">
-              <Header as="h2" size="huge" className="title">
-                {t('parcel_edit.edit_land')}
-              </Header>
-              <span className="subtitle">
-                {t_html('parcel_edit.set_name_and_desc', {
-                  parcel_name: <ParcelName parcel={parcel} />
-                })}
-              </span>
-            </Container>
-            <br />
-            <Container text>
-              <Grid.Column>
-                <EditParcelForm
-                  parcel={parcel}
-                  isTxIdle={isTxIdle}
-                  onSubmit={onSubmit}
-                  onCancel={onCancel}
-                />
-                <TxStatus.Parcel parcel={parcel} />
-              </Grid.Column>
-            </Container>
+            <ParcelModal
+              x={x}
+              y={y}
+              title={t('parcel_edit.edit_land')}
+              subtitle={t_html('parcel_edit.set_name_and_desc', {
+                parcel_name: (
+                  <Link to={locations.parcelDetail(x, y)}>
+                    {buildCoordinate(x, y)}
+                  </Link>
+                )
+              })}
+              hasCustomFooter
+            >
+              <EditParcelForm
+                parcel={parcel}
+                isTxIdle={isTxIdle}
+                onSubmit={onSubmit}
+                onCancel={onCancel}
+              />
+              <TxStatus.Parcel parcel={parcel} />
+            </ParcelModal>
           </div>
         )}
       </Parcel>

--- a/webapp/src/components/Mana/Mana.css
+++ b/webapp/src/components/Mana/Mana.css
@@ -9,3 +9,13 @@
 .Mana .ManaIcon {
   margin-right: 0.4em;
 }
+
+.Mana.disabled {
+  color: var(--gray);
+}
+
+.Mana.disabled .ManaIcon {
+  filter: gray; /* IE6-9 */
+  -webkit-filter: grayscale(1); /* Google Chrome, Safari 6+ & Opera 15+ */
+  filter: grayscale(1); /* Microsoft Edge and Firefox 35+ */
+}

--- a/webapp/src/components/Mana/Mana.js
+++ b/webapp/src/components/Mana/Mana.js
@@ -9,13 +9,16 @@ export default class Mana extends React.PureComponent {
     icon: PropTypes.node,
     unit: PropTypes.string,
     size: PropTypes.number,
-    scale: PropTypes.number
+    scale: PropTypes.number,
+    disabled: PropTypes.bool,
+    children: PropTypes.node
   }
 
   static defaultProps = {
     unit: '',
     size: 14,
-    scale: 1.2
+    scale: 1.2,
+    disabled: false
   }
 
   getLocalizedAmount() {
@@ -27,7 +30,7 @@ export default class Mana extends React.PureComponent {
   }
 
   render() {
-    const { size, scale, unit } = this.props
+    const { size, scale, unit, disabled } = this.props
 
     const iconSize = Math.round(size * scale)
     const icon = this.props.icon || <Icon width={iconSize} height={iconSize} />
@@ -35,10 +38,10 @@ export default class Mana extends React.PureComponent {
       fontSize: size
     }
     const amount = this.getLocalizedAmount()
-
+    const classes = `Mana ` + (disabled ? ' disabled' : '')
     return (
       <span
-        className="Mana"
+        className={classes}
         style={style}
         title={amount ? `${amount} MANA` : ''}
       >

--- a/webapp/src/components/MarketplacePage/MarketplacePage.container.js
+++ b/webapp/src/components/MarketplacePage/MarketplacePage.container.js
@@ -21,6 +21,7 @@ const mapState = (state, { location }) => {
     sortOrder,
     page,
     pages: Math.ceil(total / PAGE_SIZE),
+    total,
     isEmpty: publications.length === 0,
     publications,
     isLoading: isLoading(state)

--- a/webapp/src/components/MarketplacePage/MarketplacePage.css
+++ b/webapp/src/components/MarketplacePage/MarketplacePage.css
@@ -30,3 +30,7 @@
   background-color: var(--background) !important;
   opacity: 0.8 !important;
 }
+
+.MarketplacePage .ui.label.active {
+  background-color: var(--primary);
+}

--- a/webapp/src/components/MarketplacePage/MarketplacePage.js
+++ b/webapp/src/components/MarketplacePage/MarketplacePage.js
@@ -7,7 +7,8 @@ import {
   Card,
   Dropdown,
   Pagination,
-  Loader
+  Loader,
+  Label
 } from 'semantic-ui-react'
 import Publication from './Publication'
 
@@ -28,6 +29,7 @@ export default class MarketplacePage extends React.PureComponent {
     publications: PropTypes.arrayOf(publicationType),
     page: PropTypes.number.isRequired,
     pages: PropTypes.number.isRequired,
+    total: PropTypes.number.isRequired,
     sortBy: PropTypes.string.isRequired,
     sortOrder: PropTypes.string.isRequired,
     onNavigate: PropTypes.func.isRequired,
@@ -117,18 +119,27 @@ export default class MarketplacePage extends React.PureComponent {
   }
 
   render() {
-    const { page, pages, isLoading, isEmpty, sortBy, sortOrder } = this.props
+    const {
+      total,
+      page,
+      pages,
+      isLoading,
+      isEmpty,
+      sortBy,
+      sortOrder
+    } = this.props
     const sortType = getSortTypeFromOptions({ sortBy, sortOrder })
 
     return (
       <div className="MarketplacePage">
         <Container>
           <Menu pointing secondary>
-            <Menu.Item
-              name={t('global.parcels')}
-              active
-              onClick={this.handleItemClick}
-            />
+            <Menu.Item active onClick={this.handleItemClick}>
+              {t('global.parcels')}
+              <Label className="active" size="tiny">
+                {total.toLocaleString()}
+              </Label>
+            </Menu.Item>
             <Menu.Menu position="right">
               <Menu.Item>
                 <Dropdown

--- a/webapp/src/components/Navbar/Account/Account.css
+++ b/webapp/src/components/Navbar/Account/Account.css
@@ -8,6 +8,6 @@
   margin-right: 25px;
 }
 
-.Account .AddressLink {
+.Account .AddressBlock {
   height: 36px;
 }

--- a/webapp/src/components/Navbar/Account/Account.js
+++ b/webapp/src/components/Navbar/Account/Account.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
-import AddressLink from 'components/AddressLink'
+import AddressBlock from 'components/AddressBlock'
 import { walletType } from 'components/types'
 import Mana from 'components/Mana'
 import { locations } from 'locations'
@@ -21,7 +21,7 @@ export default class Account extends React.PureComponent {
         <Link to={locations.settings}>
           <Mana amount={wallet.balance} />
         </Link>
-        <AddressLink
+        <AddressBlock
           scale={6}
           link={locations.settings}
           address={wallet.address}

--- a/webapp/src/components/Navbar/Account/Account.js
+++ b/webapp/src/components/Navbar/Account/Account.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 import AddressLink from 'components/AddressLink'
 import { walletType } from 'components/types'
 import Mana from 'components/Mana'
@@ -17,7 +18,9 @@ export default class Account extends React.PureComponent {
     }
     return (
       <span className="Account">
-        <Mana amount={wallet.balance} />
+        <Link to={locations.settings}>
+          <Mana amount={wallet.balance} />
+        </Link>
         <AddressLink
           scale={6}
           link={locations.settings}

--- a/webapp/src/components/Navbar/Navbar.container.js
+++ b/webapp/src/components/Navbar/Navbar.container.js
@@ -1,7 +1,12 @@
 import { connect } from 'react-redux'
+import { goBack } from 'react-router-redux'
 
 import { getWallet } from 'modules/wallet/selectors'
-import { getLocation, isStaticPage } from 'modules/location/selectors'
+import {
+  getLocation,
+  isStaticPage,
+  isModalPage
+} from 'modules/location/selectors'
 import { getCenter } from 'modules/ui/selectors'
 import { isConnected } from 'modules/wallet/selectors'
 import { isLoading } from 'modules/ui/loading/selectors'
@@ -26,12 +31,14 @@ const mapState = state => {
     isStatic,
     isLoading: isLoading(state) || isLoadingParcels(state),
     isConnected: isConnected(state),
+    isModal: isModalPage(state),
     activityBadge: getPendingTransactions(state, wallet.address).length
   }
 }
 
 const mapDispatch = dispatch => ({
-  onNavigate: url => dispatch(navigateTo(url))
+  onNavigate: url => dispatch(navigateTo(url)),
+  onBack: () => dispatch(goBack())
 })
 
 export default connect(mapState, mapDispatch)(Navbar)

--- a/webapp/src/components/Navbar/Navbar.css
+++ b/webapp/src/components/Navbar/Navbar.css
@@ -4,18 +4,18 @@
   align-items: center;
   height: var(--navbar-height);
   justify-content: center;
-  padding: 0px 40px;
+  padding: 0px 25px;
   background-color: var(--background);
 }
 
 .Navbar .navbar-header {
   position: absolute;
-  left: 40px;
+  left: 25px;
 }
 
 .Navbar .navbar-account {
   position: absolute;
-  right: 40px;
+  right: 25px;
   display: flex;
   align-items: center;
 }
@@ -25,14 +25,27 @@
   width: 56px;
   height: 56px;
   float: left;
+  background-color: #d7d1c7;
+  border-radius: 30px;
+}
+
+.Navbar .navbar-back {
+  color: white;
+  background-color: var(--dark-gray);
+  padding: 18px 14px;
+  border-radius: 36px;
+  width: 56px;
+  height: 56px;
+  display: block;
+  cursor: pointer;
 }
 
 .Navbar .navbar-icon .Icon-decentraland-loading {
-  width: 74px;
-  height: 74px;
+  width: 77px;
+  height: 77px;
   position: absolute;
-  top: -9px;
-  left: -9px;
+  top: -10px;
+  left: -11px;
 }
 
 .Navbar .navbar-logo > h1 {
@@ -44,8 +57,11 @@
 }
 
 .Navbar .navbar-logo .Icon-decentraland {
-  width: 56px;
-  height: 56px;
+  width: 58px;
+  height: 58px;
+  left: -1px;
+  top: -1px;
+  position: relative;
 }
 
 .Navbar .navbar-menu .item,
@@ -75,7 +91,7 @@
   position: relative;
   width: 43px;
   height: 33px;
-  margin-right: 10px !important;
+  margin-right: 30px !important;
   margin-bottom: 0px;
 }
 
@@ -107,7 +123,7 @@
     justify-content: flex-start;
   }
 
-  .Navbar .navbar-header {
+  .Navbar .navbar-header:not(.navbar-modal) {
     display: none;
   }
 

--- a/webapp/src/components/Navbar/Navbar.js
+++ b/webapp/src/components/Navbar/Navbar.js
@@ -20,7 +20,8 @@ export default class Navbar extends React.PureComponent {
     activePage: PropTypes.oneOf(Object.values(NAVBAR_PAGES)),
     isLoading: PropTypes.bool,
     isConnected: PropTypes.bool,
-    activityBadge: PropTypes.number
+    activityBadge: PropTypes.number,
+    onBack: PropTypes.func
   }
 
   getNavigationPaths() {
@@ -56,6 +57,19 @@ export default class Navbar extends React.PureComponent {
     )
   }
 
+  renderModalPage() {
+    const { onBack } = this.props
+    return (
+      <div className="Navbar" role="navigation">
+        <div className="navbar-header navbar-modal">
+          <span className="navbar-back" onClick={onBack}>
+            <Icon name="chevron left" size="large" className="back" />
+          </span>
+        </div>
+      </div>
+    )
+  }
+
   renderLogoHeader() {
     const { isLoading } = this.props
     return (
@@ -73,11 +87,15 @@ export default class Navbar extends React.PureComponent {
   }
 
   render() {
-    const { wallet, activePage, isConnected, isStatic } = this.props
+    const { wallet, activePage, isConnected, isStatic, isModal } = this.props
     const navigationPaths = this.getNavigationPaths()
 
     if (isStatic) {
       return this.renderStaticPage()
+    }
+
+    if (isModal) {
+      return this.renderModalPage()
     }
 
     return (

--- a/webapp/src/components/ParcelDetailPage/ParcelDetail/ParcelDetail.js
+++ b/webapp/src/components/ParcelDetailPage/ParcelDetail/ParcelDetail.js
@@ -64,7 +64,9 @@ export default class ParcelDetail extends React.PureComponent {
         </Grid.Row>
         {isOwner ? (
           <Grid.Row>
-            <ParcelActions parcel={parcel} />
+            <Grid.Column>
+              <ParcelActions parcel={parcel} />
+            </Grid.Column>
           </Grid.Row>
         ) : null}
         {publication ? (

--- a/webapp/src/components/ParcelDetailPage/ParcelDetail/ParcelOwner/ParcelOwner.css
+++ b/webapp/src/components/ParcelDetailPage/ParcelDetail/ParcelOwner/ParcelOwner.css
@@ -19,7 +19,7 @@
   color: var(--gray);
 }
 
-.ParcelOwner .AddressLink {
+.ParcelOwner .AddressBlock {
   height: 24px;
   margin-left: 10px;
 }

--- a/webapp/src/components/ParcelDetailPage/ParcelDetail/ParcelOwner/ParcelOwner.js
+++ b/webapp/src/components/ParcelDetailPage/ParcelDetail/ParcelOwner/ParcelOwner.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { parcelType, districtType } from 'components/types'
 import { getDistrict, isDistrict } from 'lib/parcelUtils'
 import isEmpty from 'lodash/isEmpty'
-import AddressLink from 'components/AddressLink'
+import AddressBlock from 'components/AddressBlock'
 import { t, t_html } from 'modules/translation/utils'
 
 import './ParcelOwner.css'
@@ -48,7 +48,7 @@ export default class ParcelOwner extends React.PureComponent {
       return (
         <span className="ParcelOwner is-address">
           <span>{t('global.owned_by')}</span>
-          <AddressLink address={parcel.owner} scale={4} />
+          <AddressBlock address={parcel.owner} scale={4} />
         </span>
       )
     }

--- a/webapp/src/components/ParcelModal/ParcelModal.css
+++ b/webapp/src/components/ParcelModal/ParcelModal.css
@@ -1,0 +1,54 @@
+.ParcelModal {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: center;
+}
+
+.ParcelModal .modal-column {
+  display: flex;
+  flex-flow: column nowrap;
+  flex: none;
+}
+
+.ParcelModal .modal-preview {
+  width: 217px;
+  height: 217px;
+  border-radius: 20px;
+  overflow: hidden;
+  box-shadow: 0px 5px 15px 5px rgba(0, 0, 0, 0.3);
+}
+
+.ParcelModal .modal-title {
+  margin: 0px 50px;
+}
+
+.ParcelModal .modal-subtitle {
+  color: var(--gray);
+  font-weight: 100;
+  font-size: 1em;
+  margin: 15px 50px;
+  display: inline-block;
+}
+
+.ParcelModal .modal-buttons {
+  margin: 0px 50px;
+}
+
+.ParcelModal .modal-buttons button + button {
+  margin-left: 20px;
+}
+
+.ParcelModal .modal-children {
+  margin: 0px 0px 0px 50px;
+}
+
+@media (max-width: 768px) {
+  .ParcelModal {
+    flex-flow: column nowrap;
+  }
+
+  .ParcelModal .modal-preview {
+    width: calc(100% - 4em);
+    margin: 2em;
+  }
+}

--- a/webapp/src/components/ParcelModal/ParcelModal.js
+++ b/webapp/src/components/ParcelModal/ParcelModal.js
@@ -1,0 +1,83 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Button, Grid, Header } from 'semantic-ui-react'
+import ParcelPreview from 'components/ParcelPreview'
+import { t } from 'modules/translation/utils'
+import './ParcelModal.css'
+
+export default class ParcelModal extends React.PureComponent {
+  static propTypes = {
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
+    isDisabled: PropTypes.bool,
+    hasCustomFooter: PropTypes.bool,
+    cancelLabel: PropTypes.string,
+    confirmLabel: PropTypes.string,
+    children: PropTypes.node
+  }
+
+  static defaultProps = {
+    isDisabled: false,
+    hasCustomFooter: false,
+    onCancel: () => {},
+    onConfirm: () => {}
+  }
+
+  render() {
+    const {
+      x,
+      y,
+      title,
+      subtitle,
+      isDisabled,
+      hasCustomFooter,
+      cancelLabel,
+      confirmLabel,
+      onCancel,
+      onConfirm,
+      children
+    } = this.props
+
+    return (
+      <div className="ParcelModal">
+        <div className="modal-column">
+          <div className="modal-preview">
+            <ParcelPreview x={x} y={y} />
+          </div>
+        </div>
+        <div className="modal-column">
+          <div>
+            <Header as="h4" size="large" className="modal-title">
+              {title}
+            </Header>
+            <span className="modal-subtitle">{subtitle}</span>
+          </div>
+          <br />
+          {children ? (
+            <React.Fragment>
+              <div className="modal-children">{children}</div>
+              <br />
+            </React.Fragment>
+          ) : null}
+          {hasCustomFooter ? null : (
+            <div>
+              <Grid.Column className="modal-buttons">
+                <Button onClick={onCancel} type="button">
+                  {cancelLabel || t('global.cancel')}
+                </Button>
+                <Button
+                  onClick={onConfirm}
+                  type="button"
+                  primary
+                  disabled={isDisabled}
+                >
+                  {confirmLabel || t('global.confirm')}
+                </Button>
+              </Grid.Column>
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+}

--- a/webapp/src/components/ParcelModal/index.js
+++ b/webapp/src/components/ParcelModal/index.js
@@ -1,0 +1,3 @@
+import ParcelModal from './ParcelModal'
+
+export default ParcelModal

--- a/webapp/src/components/ProfilePage/ProfilePage.container.js
+++ b/webapp/src/components/ProfilePage/ProfilePage.container.js
@@ -2,7 +2,7 @@ import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import { PROFILE_PAGE_TABS } from 'locations'
 import { getLoading } from 'modules/address/selectors'
-import { getWallet } from 'modules/wallet/selectors'
+import { getWallet, isConnecting } from 'modules/wallet/selectors'
 import { getAddresses } from 'modules/address/selectors'
 import { fetchAddress } from 'modules/address/actions'
 import { navigateTo } from 'modules/location/actions'
@@ -59,7 +59,8 @@ const mapState = (state, { location, match }) => {
     pages,
     isLoading,
     isEmpty,
-    isOwner: wallet.address === address
+    isOwner: wallet.address === address,
+    isConnecting: isConnecting(state)
   }
 }
 

--- a/webapp/src/components/ProfilePage/ProfilePage.css
+++ b/webapp/src/components/ProfilePage/ProfilePage.css
@@ -42,7 +42,7 @@
   color: #aaa;
 }
 
-.ProfilePage .profile-owner .AddressLink {
+.ProfilePage .profile-owner .AddressBlock {
   height: 25px;
   margin-left: 5px;
 }
@@ -63,7 +63,7 @@
   justify-content: flex-start;
 }
 
-.ProfilePage .profile-header .AddressLink {
+.ProfilePage .profile-header .AddressBlock {
   flex: none;
 }
 

--- a/webapp/src/components/ProfilePage/ProfilePage.css
+++ b/webapp/src/components/ProfilePage/ProfilePage.css
@@ -56,6 +56,23 @@
   background-color: var(--red) !important;
 }
 
+.ProfilePage .profile-header > div {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.ProfilePage .profile-header .AddressLink {
+  flex: none;
+}
+
+.ProfilePage .profile-header .profile-address {
+  color: white;
+  font-size: 20px;
+  margin-left: 20px;
+}
+
 @media (max-width: 768px) {
   .ProfilePage .profile-menu .menu.secondary .item {
     border-color: transparent !important;

--- a/webapp/src/components/ProfilePage/ProfilePage.js
+++ b/webapp/src/components/ProfilePage/ProfilePage.js
@@ -10,7 +10,7 @@ import {
   Loader,
   Label
 } from 'semantic-ui-react'
-import AddressLink from 'components/AddressLink'
+import AddressBlock from 'components/AddressBlock'
 import Publication from 'components/MarketplacePage/Publication'
 import Parcel from './Parcel'
 import Contribution from './Contribution'
@@ -166,7 +166,7 @@ export default class ProfilePage extends React.PureComponent {
         {isOwner || isConnecting ? null : (
           <Container className="profile-header">
             <div>
-              <AddressLink scale={16} address={address} hasTooltip={false} />
+              <AddressBlock scale={16} address={address} hasTooltip={false} />
               <span className="profile-address">{shortenAddress(address)}</span>
             </div>
           </Container>

--- a/webapp/src/components/ProfilePage/ProfilePage.js
+++ b/webapp/src/components/ProfilePage/ProfilePage.js
@@ -17,6 +17,7 @@ import Contribution from './Contribution'
 import { parcelType, contributionType, publicationType } from 'components/types'
 import { t } from 'modules/translation/utils'
 import { buildUrl } from './utils'
+import { shortenAddress } from 'lib/utils'
 
 import './ProfilePage.css'
 
@@ -35,6 +36,7 @@ export default class ProfilePage extends React.PureComponent {
     isLoading: PropTypes.bool,
     isEmpty: PropTypes.bool,
     isOwner: PropTypes.bool,
+    isConnecting: PropTypes.bool,
     onNavigate: PropTypes.func.isRequired
   }
 
@@ -156,10 +158,19 @@ export default class ProfilePage extends React.PureComponent {
       parcels,
       contributions,
       publications,
-      isOwner
+      isOwner,
+      isConnecting
     } = this.props
     return (
       <div className="ProfilePage">
+        {isOwner || isConnecting ? null : (
+          <Container className="profile-header">
+            <div>
+              <AddressLink scale={16} address={address} hasTooltip={false} />
+              <span className="profile-address">{shortenAddress(address)}</span>
+            </div>
+          </Container>
+        )}
         <Container className="profile-menu">
           <Menu pointing secondary stackable>
             <Menu.Item
@@ -186,14 +197,6 @@ export default class ProfilePage extends React.PureComponent {
               {t('profile_page.on_sale')}
               {this.renderBadge(publications, PROFILE_PAGE_TABS.publications)}
             </Menu.Item>
-            {isOwner ? null : (
-              <Menu.Menu position="right">
-                <span className="profile-owner">
-                  <span>{t('global.owned_by')}</span>&nbsp;
-                  <AddressLink address={address} scale={4} />
-                </span>
-              </Menu.Menu>
-            )}
           </Menu>
         </Container>
         <Container className="profile-grid">

--- a/webapp/src/components/PublishPage/PublicationForm/PublicationForm.css
+++ b/webapp/src/components/PublishPage/PublicationForm/PublicationForm.css
@@ -1,5 +1,5 @@
-.PublicationForm .ui.button {
-  padding: 12px 42px;
+.PublicationForm {
+  min-width: 400px;
 }
 
 .PublicationForm .ui.button + .ui.button {

--- a/webapp/src/components/PublishPage/PublicationForm/PublicationForm.js
+++ b/webapp/src/components/PublishPage/PublicationForm/PublicationForm.js
@@ -169,7 +169,7 @@ export default class PublicationForm extends React.PureComponent {
           </Message>
         ) : null}
         <br />
-        <div className="text-center">
+        <div>
           <Button disabled={isPending} onClick={onCancel} type="button">
             {t('global.cancel')}
           </Button>

--- a/webapp/src/components/PublishPage/PublishPage.js
+++ b/webapp/src/components/PublishPage/PublishPage.js
@@ -3,17 +3,17 @@ import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 
 import { locations } from 'locations'
-import { Container, Header, Grid, Message } from 'semantic-ui-react'
+import { Container, Message } from 'semantic-ui-react'
 import PublicationForm from './PublicationForm'
-import ParcelName from 'components/ParcelName'
 import Parcel from 'components/Parcel'
+import ParcelModal from 'components/ParcelModal'
 import TxStatus from 'components/TxStatus'
 
 import { publicationType, walletType } from 'components/types'
 import { isOpen } from 'modules/publication/utils'
 import { t, t_html } from 'modules/translation/utils'
 
-import { formatMana } from 'lib/utils'
+import { formatMana, buildCoordinate } from 'lib/utils'
 
 import './PublishPage.css'
 
@@ -66,30 +66,29 @@ export default class PublishPage extends React.PureComponent {
                 />
               </Container>
             ) : null}
-            <Container text textAlign="center">
-              <Header as="h2" size="huge" className="title">
-                {t('parcel_publish.list_land')}
-              </Header>
-              <span className="subtitle">
-                {t_html('parcel_publish.set_land_price', {
-                  parcel_name: <ParcelName parcel={parcel} />
-                })}
-              </span>
-            </Container>
-            <br />
-            <Container text>
-              <Grid.Column>
-                <PublicationForm
-                  parcel={parcel}
-                  publication={publication}
-                  isTxIdle={isTxIdle}
-                  onPublish={onPublish}
-                  onCancel={onCancel}
-                  isDisabled={!isLandAuthorized}
-                />
-                <TxStatus.Parcel parcel={parcel} />
-              </Grid.Column>
-            </Container>
+            <ParcelModal
+              x={x}
+              y={y}
+              title={t('parcel_publish.list_land')}
+              subtitle={t_html('parcel_publish.set_land_price', {
+                parcel_name: (
+                  <Link to={locations.parcelDetail(x, y)}>
+                    {buildCoordinate(x, y)}
+                  </Link>
+                )
+              })}
+              hasCustomFooter
+            >
+              <PublicationForm
+                parcel={parcel}
+                publication={publication}
+                isTxIdle={isTxIdle}
+                onPublish={onPublish}
+                onCancel={onCancel}
+                isDisabled={!isLandAuthorized}
+              />
+              <TxStatus.Parcel parcel={parcel} />
+            </ParcelModal>
           </div>
         )}
       </Parcel>

--- a/webapp/src/components/SettingsPage/SettingsForm/SettingsForm.css
+++ b/webapp/src/components/SettingsPage/SettingsForm/SettingsForm.css
@@ -1,5 +1,4 @@
 .SettingsForm {
-  margin: 30px 0;
 }
 
 .SettingsForm .tx-pending .authorize-detail {
@@ -11,23 +10,45 @@
 }
 
 .SettingsForm.form .field > label,
-.SettingsForm .ui.dropdown>.text {
+.SettingsForm .ui.dropdown > .text {
   font-size: 16px;
 }
 
 .SettingsForm.form .ui.checkbox {
-  margin-top: 5px;
+  margin-top: 1px;
   margin-right: 10px;
   float: left;
 }
 
 .SettingsForm .authorize-detail {
-  font-size: 18px;
-  margin-bottom: 0;
+  font-size: 16px;
   overflow: hidden;
+  display: inline;
 }
 
 .SettingsForm .TxStatusText {
   font-size: 16px;
   font-style: italic;
+}
+
+.SettingsForm .Mana {
+  font-size: 16px !important;
+  margin-top: 8px;
+}
+
+.SettingsForm #wallet-address {
+  color: white;
+  font-size: 16px;
+  margin-top: 8px;
+}
+
+.SettingsForm .authorization-checks {
+  margin: 50px 0px;
+}
+
+.SettingsForm .authorization-checks label {
+  color: var(--gray);
+  font-weight: 400;
+  font-size: 16px;
+  margin-bottom: 1em;
 }

--- a/webapp/src/components/SettingsPage/SettingsForm/SettingsForm.js
+++ b/webapp/src/components/SettingsPage/SettingsForm/SettingsForm.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { wallets, txUtils } from 'decentraland-commons'
-
+import Mana from 'components/Mana'
 import { Form, Checkbox } from 'semantic-ui-react'
 import EtherscanLink from 'components/EtherscanLink'
 import TxStatus from 'components/TxStatus'
@@ -15,6 +15,7 @@ import './SettingsForm.css'
 export default class SettingsForm extends React.PureComponent {
   static propTypes = {
     address: PropTypes.string,
+    balance: PropTypes.number,
     walletType: PropTypes.string,
     walletDerivationPath: PropTypes.string,
     onDerivationPathChange: PropTypes.func,
@@ -41,6 +42,7 @@ export default class SettingsForm extends React.PureComponent {
   render() {
     const {
       address,
+      balance,
       walletType,
       walletDerivationPath,
       onDerivationPathChange,
@@ -68,63 +70,68 @@ export default class SettingsForm extends React.PureComponent {
           </Form.Field>
         ) : null}
 
-        <Form.Field
-          id="wallet-address"
-          control="input"
-          type="text"
-          label={t('global.wallet_address')}
-          disabled={true}
-          value={address}
-        />
-
         <Form.Field>
-          <Checkbox
-            checked={manaApproved > 0}
-            disabled={isApprovePending}
-            onChange={onManaApprovedChange}
-          />
-          <div className="authorize-detail">
-            {manaApproved > 0
-              ? t_html('settings.mana_approved', {
-                  marketplace_contract_link: this.renderMarketplaceLink()
-                })
-              : t_html('settings.approve_mana', {
-                  marketplace_contract_link: this.renderMarketplaceLink()
-                })}
-
-            {isApprovePending && (
-              <TxStatus.Text
-                txHash={approveTransaction.hash}
-                txStatus={approveTransaction.status}
-              />
-            )}
-          </div>
+          <label htmlFor="wallet-address">{t('global.wallet_address')}</label>
+          <label id="wallet-address">{address}</label>
         </Form.Field>
 
         <Form.Field>
-          <Checkbox
-            checked={isLandAuthorized}
-            disabled={isAuthorizePending}
-            onChange={onLandAuthorizedChange}
-          />
-
-          <div className="authorize-detail">
-            {isLandAuthorized
-              ? t_html('settings.you_authorized', {
-                  marketplace_contract_link: this.renderMarketplaceLink()
-                })
-              : t_html('settings.authorize', {
-                  marketplace_contract_link: this.renderMarketplaceLink()
-                })}
-
-            {isAuthorizePending && (
-              <TxStatus.Text
-                txHash={authorizeTransaction.hash}
-                txStatus={authorizeTransaction.status}
-              />
-            )}
-          </div>
+          <label htmlFor="mana-balance">{t('global.balance')}</label>
+          <span id="mana-balance">
+            <Mana amount={balance} unit="MANA" />
+          </span>
         </Form.Field>
+        <div className="authorization-checks">
+          <label>{t('settings.authorization')}</label>
+          <Form.Field>
+            <Checkbox
+              checked={manaApproved > 0}
+              disabled={isApprovePending}
+              onChange={onManaApprovedChange}
+            />
+            <div className="authorize-detail">
+              {manaApproved > 0
+                ? t_html('settings.mana_approved', {
+                    marketplace_contract_link: this.renderMarketplaceLink()
+                  })
+                : t_html('settings.approve_mana', {
+                    marketplace_contract_link: this.renderMarketplaceLink()
+                  })}
+
+              {isApprovePending && (
+                <TxStatus.Text
+                  txHash={approveTransaction.hash}
+                  txStatus={approveTransaction.status}
+                />
+              )}
+            </div>
+          </Form.Field>
+
+          <Form.Field>
+            <Checkbox
+              checked={isLandAuthorized}
+              disabled={isAuthorizePending}
+              onChange={onLandAuthorizedChange}
+            />
+
+            <div className="authorize-detail">
+              {isLandAuthorized
+                ? t_html('settings.you_authorized', {
+                    marketplace_contract_link: this.renderMarketplaceLink()
+                  })
+                : t_html('settings.authorize', {
+                    marketplace_contract_link: this.renderMarketplaceLink()
+                  })}
+
+              {isAuthorizePending && (
+                <TxStatus.Text
+                  txHash={authorizeTransaction.hash}
+                  txStatus={authorizeTransaction.status}
+                />
+              )}
+            </div>
+          </Form.Field>
+        </div>
       </Form>
     )
   }

--- a/webapp/src/components/SettingsPage/SettingsPage.css
+++ b/webapp/src/components/SettingsPage/SettingsPage.css
@@ -32,7 +32,7 @@
   display: inline-block;
 }
 
-.SettingsPage .AddressLink {
+.SettingsPage .AddressBlock {
   margin-right: 40px;
   box-shadow: 0px 5px 15px 5px rgba(0, 0, 0, 0.3);
 }

--- a/webapp/src/components/SettingsPage/SettingsPage.css
+++ b/webapp/src/components/SettingsPage/SettingsPage.css
@@ -16,3 +16,23 @@
   text-align: center;
   margin-top: 50px;
 }
+
+.SettingsPage .row {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: center;
+}
+
+.SettingsPage .column {
+  display: inline-block;
+  padding: 1em;
+}
+
+.SettingsPage form {
+  display: inline-block;
+}
+
+.SettingsPage .AddressLink {
+  margin-right: 40px;
+  box-shadow: 0px 5px 15px 5px rgba(0, 0, 0, 0.3);
+}

--- a/webapp/src/components/SettingsPage/SettingsPage.js
+++ b/webapp/src/components/SettingsPage/SettingsPage.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom'
 
 import { locations } from 'locations'
 import { Container, Loader } from 'semantic-ui-react'
-import AddressLink from 'components/AddressLink'
+import AddressBlock from 'components/AddressBlock'
 import SettingsForm from './SettingsForm'
 
 import { walletType } from 'components/types'
@@ -77,7 +77,7 @@ export default class SettingsPage extends React.PureComponent {
         <Container content>
           <div className="row">
             <div className="column">
-              <AddressLink
+              <AddressBlock
                 address={address}
                 hasTooltip={false}
                 hasLink={false}

--- a/webapp/src/components/SettingsPage/SettingsPage.js
+++ b/webapp/src/components/SettingsPage/SettingsPage.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 
 import { locations } from 'locations'
-import { Container, Grid, Header, Loader } from 'semantic-ui-react'
+import { Container, Loader } from 'semantic-ui-react'
+import AddressLink from 'components/AddressLink'
 import SettingsForm from './SettingsForm'
 
 import { walletType } from 'components/types'
@@ -56,6 +57,7 @@ export default class SettingsPage extends React.PureComponent {
     const { isLoading, isConnected, wallet } = this.props
     const {
       address,
+      balance,
       type,
       derivationPath,
       approvedBalance,
@@ -72,35 +74,42 @@ export default class SettingsPage extends React.PureComponent {
 
     return (
       <div className="SettingsPage">
-        <Container text>
-          <Header as="h1" size="huge" textAlign="center" className="title">
-            {t('global.settings')}
-          </Header>
-
-          <Grid.Column>
-            {isConnected ? (
-              <SettingsForm
+        <Container content>
+          <div className="row">
+            <div className="column">
+              <AddressLink
                 address={address}
-                walletType={type}
-                walletDerivationPath={derivationPath}
-                onDerivationPathChange={this.handleDerivationPathChange}
-                manaApproved={approvedBalance}
-                approveTransaction={this.getApproveTransaction()}
-                onManaApprovedChange={this.handleManaApproval}
-                isLandAuthorized={isLandAuthorized}
-                authorizeTransaction={this.getAuthorizeTransaction()}
-                onLandAuthorizedChange={this.handleLandAuthorization}
+                hasTooltip={false}
+                hasLink={false}
+                scale={30}
               />
-            ) : (
-              <p className="sign-in">
-                {t_html('global.sign_in_notice', {
-                  sign_in_link: (
-                    <Link to={locations.signIn}>{t('global.sign_in')}</Link>
-                  )
-                })}
-              </p>
-            )}
-          </Grid.Column>
+            </div>
+            <div className="column">
+              {isConnected ? (
+                <SettingsForm
+                  address={address}
+                  balance={balance}
+                  walletType={type}
+                  walletDerivationPath={derivationPath}
+                  onDerivationPathChange={this.handleDerivationPathChange}
+                  manaApproved={approvedBalance}
+                  approveTransaction={this.getApproveTransaction()}
+                  onManaApprovedChange={this.handleManaApproval}
+                  isLandAuthorized={isLandAuthorized}
+                  authorizeTransaction={this.getAuthorizeTransaction()}
+                  onLandAuthorizedChange={this.handleLandAuthorization}
+                />
+              ) : (
+                <p className="sign-in">
+                  {t_html('global.sign_in_notice', {
+                    sign_in_link: (
+                      <Link to={locations.signIn}>{t('global.sign_in')}</Link>
+                    )
+                  })}
+                </p>
+              )}
+            </div>
+          </div>
         </Container>
       </div>
     )

--- a/webapp/src/components/SignInPage/SignInPage.js
+++ b/webapp/src/components/SignInPage/SignInPage.js
@@ -46,7 +46,7 @@ export default class SignInPage extends React.PureComponent {
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    Metamask
+                    MetaMask
                   </a>
                 ),
                 mist_link: (

--- a/webapp/src/components/TransferParcelPage/TransferParcelForm/TransferParcelForm.css
+++ b/webapp/src/components/TransferParcelPage/TransferParcelForm/TransferParcelForm.css
@@ -1,9 +1,14 @@
-.TransferParcelForm .ui.button {
-  padding: 12px 42px;
-}
-
 .TransferParcelForm .ui.button + .ui.button {
   margin-left: 20px;
+}
+
+.TransferParcelForm .ui.input.address-input {
+  max-width: 450px !important;
+  display: block;
+}
+
+.TransferParcelForm .ui.input.address-input input {
+  width: 100% !important;
 }
 
 .TransferParcelForm .transfer-warning {

--- a/webapp/src/components/TransferParcelPage/TransferParcelForm/TransferParcelForm.js
+++ b/webapp/src/components/TransferParcelPage/TransferParcelForm/TransferParcelForm.js
@@ -136,7 +136,7 @@ export default class TransferParcelForm extends React.PureComponent {
 
           <br />
 
-          <div className="text-center">
+          <div>
             <Button type="button" onClick={this.handleCancel}>
               {t('global.cancel')}
             </Button>

--- a/webapp/src/components/TransferParcelPage/TransferParcelPage.css
+++ b/webapp/src/components/TransferParcelPage/TransferParcelPage.css
@@ -1,4 +1,1 @@
-.TransferParcelPage .subtitle {
-  color: white;
-  font-weight: 100;
-}
+

--- a/webapp/src/components/TransferParcelPage/TransferParcelPage.js
+++ b/webapp/src/components/TransferParcelPage/TransferParcelPage.js
@@ -1,13 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-
-import { Container, Header, Grid, Message } from 'semantic-ui-react'
+import { Link } from 'react-router-dom'
+import { Container, Message } from 'semantic-ui-react'
 import Parcel from 'components/Parcel'
-import ParcelName from 'components/ParcelName'
+import ParcelModal from 'components/ParcelModal'
 import TxStatus from 'components/TxStatus'
 import { publicationType } from 'components/types'
-import { hasPublication } from 'lib/parcelUtils'
 import { t, t_html } from 'modules/translation/utils'
+import { hasPublication } from 'lib/parcelUtils'
+import { buildCoordinate } from 'lib/utils'
+import { locations } from 'locations'
 
 import TransferParcelForm from './TransferParcelForm'
 
@@ -28,6 +30,7 @@ export default class TransferParcelPage extends React.PureComponent {
   render() {
     const { x, y, isTxIdle, transferError, publications } = this.props
     const { onSubmit, onCancel, onCleanTransfer } = this.props
+
     return (
       <Parcel x={x} y={y} ownerOnly>
         {parcel => (
@@ -41,31 +44,29 @@ export default class TransferParcelPage extends React.PureComponent {
                 />
               </Container>
             ) : null}
-            <Container text textAlign="center">
-              <Header as="h2" size="huge" className="title">
-                {t('parcel_transfer.transfer_land')}
-              </Header>
-              <div className="subtitle">
-                {t_html('parcel_transfer.about_to_transfer', {
-                  parcel_name: <ParcelName parcel={parcel} />
-                })}
-                <br />
-              </div>
-            </Container>
-            <br />
-            <Container text>
-              <Grid.Column>
-                <TransferParcelForm
-                  parcel={parcel}
-                  isTxIdle={isTxIdle}
-                  transferError={transferError}
-                  onSubmit={onSubmit}
-                  onCancel={onCancel}
-                  onCleanTransfer={onCleanTransfer}
-                />
-                <TxStatus.Parcel parcel={parcel} />
-              </Grid.Column>
-            </Container>
+            <ParcelModal
+              x={x}
+              y={y}
+              title={t('parcel_transfer.transfer_land')}
+              subtitle={t_html('parcel_transfer.about_to_transfer', {
+                parcel_name: (
+                  <Link to={locations.parcelDetail(x, y)}>
+                    {buildCoordinate(x, y)}
+                  </Link>
+                )
+              })}
+              hasCustomFooter
+            >
+              <TransferParcelForm
+                parcel={parcel}
+                isTxIdle={isTxIdle}
+                transferError={transferError}
+                onSubmit={onSubmit}
+                onCancel={onCancel}
+                onCleanTransfer={onCleanTransfer}
+              />
+              <TxStatus.Parcel parcel={parcel} />
+            </ParcelModal>
           </div>
         )}
       </Parcel>

--- a/webapp/src/modules/location/selectors.js
+++ b/webapp/src/modules/location/selectors.js
@@ -7,3 +7,21 @@ export const getParams = state => getState(state).params
 
 export const isStaticPage = state =>
   STATIC_PAGES.includes(state.router && state.router.location.pathname)
+
+export const isModalPage = state => {
+  if (state.router && state.router.location.pathname) {
+    const lastPartOfUrl = state.router.location.pathname.split('/').pop()
+    switch (lastPartOfUrl) {
+      case 'edit':
+      case 'buy':
+      case 'sell':
+      case 'cancel-sale':
+      case 'transfer':
+      case 'settings':
+        return true
+      default:
+        return false
+    }
+  }
+  return false
+}

--- a/webapp/src/themes/components/Button.css
+++ b/webapp/src/themes/components/Button.css
@@ -2,7 +2,7 @@
   color: var(--primary);
   margin: 0 auto;
   padding: 10px 22px;
-  font-size: 16px;
+  font-size: 14px;
   border-radius: 50px;
   line-height: 1.42857143;
   border: 1px solid var(--red);

--- a/webapp/src/themes/components/Header.css
+++ b/webapp/src/themes/components/Header.css
@@ -1,6 +1,6 @@
 .ui.header {
   font-family: var(--font-family);
-  font-weight: 200;
+  font-weight: 400;
   color: white;
 }
 

--- a/webapp/src/themes/components/Message.css
+++ b/webapp/src/themes/components/Message.css
@@ -9,7 +9,7 @@
   color: var(--gray);
   box-shadow: 0 0px 0px 5px rgba(0, 0, 0, 0.5) !important;
   font-weight: 100 !important;
-  margin-bottom: 30px;
+  margin-bottom: 50px;
 }
 
 .ui.warning.message .content {


### PR DESCRIPTION
This PR applies the following design changes:

Navbar:

- Added background to loading animation
- Added support for "go back" mode (for modals and settings page)

Profile:

- Added profile Blockie (only for other users' profiles, it's not visible on My Land)

Marketplace: 

- Added number of parcels on sale in the tab

Settings:

- Two-column design with user Blockie

Edit:
Transfer:
Publish:
CancelSale:
Buy:

- Two column design with parcel preview, refactored those screens to use a `ParcelModal` component that contains the layout