### PR TITLE
feat: add endpoint to get asset related info

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -215,7 +215,7 @@ export async function getAssetId(req) {
   const parcel = await Parcel.findOne({ asset_id: strAssetId })
 
   if (!parcel) {
-    throw new Error(`Could not find a valid asset for the ID "${strAssetId}"`)
+    throw new Error(`Could not find a valid asset for the ID "${hexAssetId}"`)
   }
 
   const obj = utils.pick(parcel, ['id', 'owner', 'created_at', 'updated_at'])

--- a/src/server.js
+++ b/src/server.js
@@ -202,6 +202,30 @@ export async function getPublication(req) {
   return publication
 }
 
+/**
+ * Returns the asset information by ID
+ * @param  {string} hexAssetId
+ * @return {object}
+ */
+app.get('/api/assets/:hexAssetId', server.handleRequest(getAssetId))
+
+export async function getAssetId(req) {
+  const hexAssetId = server.extractFromReq(req, 'hexAssetId')
+  const strAssetId = eth.utils.toBigNumber(hexAssetId).toString()
+  const parcel = await Parcel.findOne({ asset_id: strAssetId })
+
+  if (!parcel) {
+    throw new Error(`Could not find a valid asset for the ID "${strAssetId}"`)
+  }
+
+  const obj = utils.pick(parcel, ['id', 'owner', 'created_at', 'updated_at'])
+  obj.description = parcel.data.description
+  obj.name = parcel.data.name || `Parcel (${parcel.id})`
+  obj.img_url = `/api/parcels/${parcel.x}/${parcel.y}/preview`
+
+  return obj
+}
+
 /* Start the server only if run directly */
 if (require.main === module) {
   Promise.resolve()


### PR DESCRIPTION
1) Some debatable things are: should it be part of the /parcels resources or not? As the query was not by (x,y) and the return is a bit more generic than exactly a parcel I created /assets, give me your opinion about this, please.

2) Test a parcel with no metadata: `http://localhost:5000/api/assets/0`
3) Test a parcel with metadata: `http://localhost:5000/api/assets/0xffffffffffffffffffffffffffffffc90000000000000000000000000000007b`
