### PR TITLE
fix: broken redirect

### DIFF
--- a/webapp/src/components/AtlasPage/Map/Map.container.js
+++ b/webapp/src/components/AtlasPage/Map/Map.container.js
@@ -25,8 +25,8 @@ const mapState = (state, { match, location }) => {
   return {
     isLoading: isConnecting(state),
     center: {
-      x: parseInt(match.params.x, 10),
-      y: parseInt(match.params.y, 10)
+      x: parseInt(match.params.x, 10) || 0,
+      y: parseInt(match.params.y, 10) || 0
     },
     selected
   }


### PR DESCRIPTION
Every url that has to two parts, like `addressStats/0x1234`, will end up matching our `/:x/:y` route, and our map is going to try to use those parts as coords, and converting `"addressStats` to number thru a parseInt will end up in NaN, which is what's causing [rollbar issue 330](https://rollbar.com/decentraland/Marketplace/items/330/?item_page=0&#instances)

This fixes the problem for any url that has two parts and one (or both) of them is NaN
