### PR TITLE
chore: clean extra translations

### DIFF
--- a/scripts/translate.js
+++ b/scripts/translate.js
@@ -21,15 +21,17 @@ async function main() {
 
   const mainTranslations = await translation.fetch(DEFAULT_LOCALE)
   const availableLocales = await translation.getAvailableLocales()
+  const translations = []
+  translations[DEFAULT_LOCALE] = mainTranslations
 
   const mainKeys = Object.keys(mainTranslations)
   let missing = {}
   for (const locale of availableLocales) {
     if (locale !== DEFAULT_LOCALE) {
-      const translations = await translation.fetch(locale)
+      translations[locale] = await translation.fetch(locale)
       let requests = []
       for (const key of mainKeys) {
-        const hasTranslation = key in translations
+        const hasTranslation = key in translations[locale]
         if (!hasTranslation) {
           const defaultText = mainTranslations[key]
           const replacedKeys = {}
@@ -82,9 +84,8 @@ async function main() {
     )
     const currentTranslations = flat(require(localePath))
     // remove obsolete keys
-    const translations = await translation.fetch(DEFAULT_LOCALE)
-    let cleanedTranslations = Object.keys(await translation.fetch(locale))
-      .filter(key => key in translations)
+    let cleanedTranslations = Object.keys(translations[locale])
+      .filter(key => key in mainTranslations)
       .reduce((acc, key) => {
         acc[key] = currentTranslations[key]
         return acc

--- a/src/Translation/locales/es.json
+++ b/src/Translation/locales/es.json
@@ -47,10 +47,6 @@
     "invalid":
       "El derivation path es incorrecto. Debe seguir el siguiente patrón 44'/60|61'/x'/n"
   },
-  "estate": {
-    "acquired_at": "Adquirido en {date}",
-    "created_at": "Creado en {date}"
-  },
   "estate_edit": {
     "description": "Descripción",
     "edit_estate": "Editar propiedad",
@@ -285,7 +281,6 @@
     "on_sale": "En Venta"
   },
   "publication": {
-    "acquired_at": "Adquirida en {date}",
     "canceled": "Cancelada",
     "sold": "Vendida",
     "view": "Ver"

--- a/src/Translation/locales/fr.json
+++ b/src/Translation/locales/fr.json
@@ -48,10 +48,6 @@
     "invalid":
       "Vous avez défini un mauvais chemin de dérivation pour votre portefeuille. Votre chemin de dérivation doit suivre le modèle 44 '/ 60 | 61' / x '/ n"
   },
-  "estate": {
-    "acquired_at": "Acquis à {date}",
-    "created_at": "Créé à {date}"
-  },
   "estate_edit": {
     "description": "La description",
     "edit_estate": "Modifier le domaine",
@@ -287,7 +283,6 @@
     "on_sale": "A vendre"
   },
   "publication": {
-    "acquired_at": "Acquis à {date}",
     "canceled": "Annulé",
     "sold": "Vendu",
     "view": "Vue"

--- a/src/Translation/locales/ko.json
+++ b/src/Translation/locales/ko.json
@@ -47,10 +47,6 @@
     "invalid":
       "지갑에 대해 잘못된 파생 경로를 설정했습니다. 파생 경로는 패턴 44 '/ 60 | 61'/ x '/ n을 따라야합니다."
   },
-  "estate": {
-    "acquired_at": "TK0에서 획득",
-    "created_at": "만든 {date}"
-  },
   "estate_edit": {
     "description": "기술",
     "edit_estate": "부동산 편집",
@@ -278,7 +274,6 @@
     "on_sale": "판매 중"
   },
   "publication": {
-    "acquired_at": "{date}에 인수 됨",
     "canceled": "취소 됨",
     "sold": "판매 됨",
     "view": "보기"

--- a/src/Translation/locales/zh.json
+++ b/src/Translation/locales/zh.json
@@ -47,10 +47,6 @@
     "invalid":
       "您为钱包设置了错误的派生路径。 你的派生路径必须遵循模式 44'/60|61'/x'/n"
   },
-  "estate": {
-    "acquired_at": "在{date}获得",
-    "created_at": "创建于{date}"
-  },
   "estate_edit": {
     "description": "描述",
     "edit_estate": "编辑地产",
@@ -274,7 +270,6 @@
     "on_sale": "出售"
   },
   "publication": {
-    "acquired_at": "在{date}收购",
     "canceled": "已取消",
     "sold": "已售出",
     "view": "查看"


### PR DESCRIPTION
Tests on master are not working cause there are extra keys on non-default locales.

When keys on `en.json` are deleted and translate script is executed it only adds new keys to other locales but doesn't delete extra ones.

This PR adds the clean functionality.