### PR TITLE
chore: avoid vscode searchs on symlinks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "prettier.printWidth": 80,
   "prettier.singleQuote": true,
   "prettier.semi": false,
+  "search.followSymlinks": false,
   "editor.tabSize": 2,
   "editor.formatOnSave": true
 }


### PR DESCRIPTION
If you find on all files of the project with VSCode you will get triplicates results if found on shared folder because we know have symlinks on src paths. 