### PR TITLE
fix: add missing wallet parameter to MapRenderer on ParcelCanvas

### DIFF
--- a/shared/map/render/Map.js
+++ b/shared/map/render/Map.js
@@ -13,7 +13,8 @@ export class Map {
     center,
     parcels,
     publications,
-    selected
+    selected,
+    wallet
   }) {
     ctx.fillStyle = COLORS.background
     ctx.fillRect(0, 0, width, height)
@@ -31,7 +32,7 @@ export class Map {
         const rx = cx - offsetX
         const ry = cy - offsetY
         const id = buildCoordinate(px, py)
-        const color = getColor(id, px, py, parcels, publications)
+        const color = getColor(id, px, py, parcels, publications, wallet)
         const parcel = parcels[id]
 
         const connectedLeft = parcel ? parcel.connectedLeft : false

--- a/webapp/src/components/ParcelPreview/ParcelCanvas/ParcelCanvas.js
+++ b/webapp/src/components/ParcelPreview/ParcelCanvas/ParcelCanvas.js
@@ -477,7 +477,7 @@ export default class ParcelPreview extends React.PureComponent {
     if (!this.canvas) {
       return '🦄'
     }
-    const { width, height, parcels, publications } = this.props
+    const { width, height, parcels, publications, wallet } = this.props
 
     const { nw, se, pan, size, center } = this.state
     const { x, y } = center
@@ -494,7 +494,8 @@ export default class ParcelPreview extends React.PureComponent {
       center,
       parcels,
       publications,
-      selected: this.getSelected()
+      selected: this.getSelected(),
+      wallet
     })
   }
 


### PR DESCRIPTION
The marketplace is now showing wallet parcels on red 