### PR TITLE
fix: build

### DIFF
--- a/shared/asset.js
+++ b/shared/asset.js
@@ -1,5 +1,3 @@
-import { txUtils } from 'decentraland-eth'
-
 export function isExpired(expires_at) {
   return parseInt(expires_at, 10) < Date.now()
 }
@@ -8,7 +6,7 @@ export function hasStatus(obj, status) {
   return (
     obj &&
     obj.status === status &&
-    obj.tx_status === txUtils.TRANSACTION_STATUS.confirmed &&
+    obj.tx_status === 'confirmed' &&
     !isExpired(obj.expires_at)
   )
 }

--- a/shared/mortgage.js
+++ b/shared/mortgage.js
@@ -1,5 +1,3 @@
-import { eth } from 'decentraland-eth'
-
 export const MORTGAGE_STATUS = Object.freeze({
   open: 'open',
   claimed: 'claimed',
@@ -15,9 +13,8 @@ export function daysToSeconds(days) {
   return Math.ceil(days) * 24 * 60 * 60
 }
 
-export function getLoanMetadata() {
-  const mortgageManagerContract = eth.getContract('MortgageManager')
-  return `#mortgage #required-cosigner:${mortgageManagerContract.address}`
+export function getLoanMetadata(mortgageManagerContractAddress) {
+  return `#mortgage #required-cosigner:${mortgageManagerContractAddress}`
 }
 
 export function getActiveMortgagesByBorrower(mortgages, borrower) {

--- a/webapp/config/webpack.config.dev.js
+++ b/webapp/config/webpack.config.dev.js
@@ -118,7 +118,7 @@ module.exports = {
             loader: require.resolve('eslint-loader')
           }
         ],
-        include: paths.appSrc
+        include: [paths.appSrc, paths.appShared]
       },
       {
         // "oneOf" will traverse all following loaders until one will

--- a/webapp/config/webpack.config.prod.js
+++ b/webapp/config/webpack.config.prod.js
@@ -142,20 +142,7 @@ module.exports = {
           // Process JS with Babel.
           {
             test: /\.(js|jsx|mjs)$/,
-            include: [
-              paths.appSrc,
-              paths.appShared,
-              path.resolve(paths.appNodeModules, 'decentraland-eth'),
-              path.resolve(paths.appNodeModules, 'web3-provider-engine'),
-              path.resolve(
-                paths.appNodeModules,
-                '../../node_modules/decentraland-eth'
-              ),
-              path.resolve(
-                paths.appNodeModules,
-                '../../node_modules/web3-provider-engine'
-              )
-            ],
+            include: [paths.appSrc, paths.appShared],
             loader: require.resolve('babel-loader'),
             options: {
               compact: true
@@ -270,27 +257,7 @@ module.exports = {
     // It is absolutely essential that NODE_ENV was set to production here.
     // Otherwise React will be compiled in the very slow development mode.
     new webpack.DefinePlugin(env.stringified),
-    // Minify the code.
-    new webpack.optimize.UglifyJsPlugin({
-      compress: {
-        warnings: false,
-        // Disabled because of an issue with Uglify breaking seemingly valid code:
-        // https://github.com/facebookincubator/create-react-app/issues/2376
-        // Pending further investigation:
-        // https://github.com/mishoo/UglifyJS2/issues/2011
-        comparisons: false
-      },
-      mangle: {
-        safari10: true
-      },
-      output: {
-        comments: false,
-        // Turned on because emoji and regex is not minified properly using default
-        // https://github.com/facebookincubator/create-react-app/issues/2488
-        ascii_only: true
-      },
-      sourceMap: shouldUseSourceMap
-    }),
+
     // Note: this won't work without ExtractTextPlugin.extract(..) in `loaders`.
     new ExtractTextPlugin({
       filename: cssFilename

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Marketplace-webapp",
+  "name": "marketplace-webapp",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -17126,6 +17126,30 @@
       "version": "0.7.18",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
       "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+    },
+    "uglify-es": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+      "dev": true,
+      "requires": {
+        "commander": "2.13.0",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
     },
     "uglify-js": {
       "version": "3.3.28",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -12,6 +12,8 @@
     "analyze": "source-map-explorer build/static/js/main.*",
     "build":
       "NODE_ENV=production REACT_APP_VERSION=$(git rev-parse --short HEAD) node scripts/build.js",
+    "postbuild":
+      "export bundle_path=`ls ./build/static/js/*.js` && uglifyjs $bundle_path --compress --mangle reserved=['toParcelObject','normalizeParcel','connectParcels','isSameValue','getParcelPublications','buildCoordinate']  --output $bundle_path",
     "remotebuild":
       "REACT_APP_VERSION=$(git rev-parse --short HEAD) NODE_PATH=/tmp/auction/webapp/node_modules node scripts/build.js"
   },
@@ -91,7 +93,8 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
-    "source-map-explorer": "^1.5.0"
+    "source-map-explorer": "^1.5.0",
+    "uglify-es": "^3.3.9"
   },
   "jest": {
     "collectCoverageFrom": ["src/**/*.{js,jsx,mjs}"],

--- a/webapp/src/lib/webworker/WebWorkerFactory.js
+++ b/webapp/src/lib/webworker/WebWorkerFactory.js
@@ -1,13 +1,10 @@
 export class WebWorkerFactory {
   static create(WebWorkerFunction, dependencies = []) {
-    const onmessage = WebWorkerFunction.toString().replace(
-      WebWorkerFunction.name,
-      'onmessage'
-    )
-    const code = dependencies.reduce(
-      (code, dependency) => `${code}\n${dependency.toString()}`,
-      `var onmessage = ${onmessage}`
-    )
+    const code =
+      dependencies.reduce(
+        (code, [name, dependency]) => `${code}var ${name} = ${dependency}\n`,
+        ''
+      ) + `var onmessage = ${WebWorkerFunction}`
     const blob = new window.Blob([code], { type: 'application/javascript' })
     const worker = new window.Worker(window.URL.createObjectURL(blob))
     return new WebWorker(worker)

--- a/webapp/src/lib/webworker/webworker.js
+++ b/webapp/src/lib/webworker/webworker.js
@@ -10,12 +10,12 @@ import {
 } from 'shared/parcel'
 
 const WebWorkerDependencies = [
-  toParcelObject,
-  normalizeParcel,
-  connectParcels,
-  isSameValue,
-  getParcelPublications,
-  buildCoordinate
+  ['toParcelObject', toParcelObject],
+  ['normalizeParcel', normalizeParcel],
+  ['connectParcels', connectParcels],
+  ['isSameValue', isSameValue],
+  ['getParcelPublications', getParcelPublications],
+  ['buildCoordinate', buildCoordinate]
 ]
 
 export const webworker = WebWorkerFactory.create(

--- a/webapp/src/modules/mortgage/sagas.js
+++ b/webapp/src/modules/mortgage/sagas.js
@@ -71,12 +71,13 @@ function* handleCreateMortgageRequest(action) {
     const landRegistryContract = eth.getContract('LANDRegistry')
     const kyberOrcaleAddress = getKyberOracleAddress()
     const manaCurrency = eth.utils.fromAscii('MANA')
+    const mortageManagerContract = eth.getContract('MortgageManager')
 
     const landId = yield call(() =>
       landRegistryContract.encodeTokenId(parcel.x, parcel.y)
     )
     const borrower = yield select(getAddress)
-    const loanMetadata = getLoanMetadata()
+    const loanMetadata = getLoanMetadata(mortageManagerContract.address)
 
     let loanParams = [
       eth.utils.toWei(amount), // Amount requested


### PR DESCRIPTION
The production build is currently broken with a runtime error `Reference Error: exports is not defined`.
This is because `webpack.optimize.UglifyJsPlugin` fails to minify correctly the dependency `decentraland-eth`. I couldn't figure out why, I tried compiling `decentraland-eth` with both `tsc` and `babel` using `es2017` and `es5` and also tried exporting it as `commonjs`, `umd` and `amd` and the problem persisted on all the attempts.

This PR fixes it by introducing the following changes:

- Stopped using `webpack.optimize.UglifyJsPlugin` (this also allowed me to stop using `babel-loader` for `decentraland-eth` and `web3-provider-engine`)

- Minified the bundle in a `postbuild` step using `uglify-es`. This minifier works fine with `decentraland-eth` but screws up our WebWorker bundler (which was already kinda flimsy 😇 ) so I had to do some refactoring to make it work with it. It's far from ideal, probably we should explore using a `worker-loader` instead, but at this point if I have to deal with anything webpack-related I will cry 🤕. Suggestions are welcome.

Also I did some refactoring to remove the imports of `decentraland-eth` from `/shared` to avoid having webpack bundling the dependency twice, and added the `/shared` directory to the dev-server's linter. 

