### PR TITLE
fix: homepage scroll

### DIFF
--- a/webapp/src/components/HomePage/HomePage.css
+++ b/webapp/src/components/HomePage/HomePage.css
@@ -6,7 +6,7 @@
 .HomePage .hero-text,
 .HomePage .hero-image {
   position: absolute;
-  height: calc(100vh - 400px);
+  height: calc(100vh - 440px);
   top: calc(0px - var(--navbar-height));
   left: 0px;
   right: 0px;
@@ -44,7 +44,7 @@
 }
 
 .HomePage .gap {
-  height: calc(100vh - 460px);
+  height: calc(100vh - 500px);
   min-height: 125px;
 }
 
@@ -72,15 +72,13 @@
   height: 294px;
 }
 
-.HomePage .publications-scroller .ui.card:first-child {
-  margin-top: 1em;
-}
-
 .HomePage .publications-scroller .ParcelCard {
   flex: none;
   width: 224px !important;
   margin-right: 25px;
   overflow: initial;
+  margin-top: 0px;
+  margin-bottom: 0px;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
This PR fixes two things in the homepage:

- After adding the tutorial link, the footer started to show up below the fold, adding a scrollbar to the full page when it should not have scroll.

- After the refactor around `.ParcelCard` the "Newest LAND" slider started to have a vertical scrollbar that should not be there.

Here's a GIF of what's in production now and how this PR fixes it:

![broken-homepage](https://user-images.githubusercontent.com/2781777/41483225-b05c48b0-70ae-11e8-97b6-0b71f1e0f846.gif)
