### PR TITLE
fix: prevent showing spinner if it's not needed

### DIFF
--- a/webapp/src/components/Parcel/Parcel.js
+++ b/webapp/src/components/Parcel/Parcel.js
@@ -78,8 +78,20 @@ export default class Parcel extends React.PureComponent {
   }
 
   render() {
-    const { parcel, wallet, isConnecting, children } = this.props
-    if (isConnecting || this.isNavigatingAway || !parcel) {
+    const {
+      parcel,
+      wallet,
+      isConnecting,
+      children,
+      ownerOnly,
+      ownerNotAllowed
+    } = this.props
+    const shouldBeConnected = ownerOnly || ownerNotAllowed
+    if (
+      (shouldBeConnected && isConnecting) ||
+      this.isNavigatingAway ||
+      !parcel
+    ) {
       return (
         <div>
           <Loader active size="massive" />


### PR DESCRIPTION
This PR changes the `<Parcel>` component to show the `<Loading>` spinner only if it needed to be connected to Ethereum to determine wether the `children` is accessible or not. 

This makes the `ParcelDetailPage` render right away while connecting, but it doesn't change the behaviour of other pages like `BuyParcelPage`, `TransferParcelPage` or any of those that use the `ownerOnly` prop.

