### PR TITLE
chore: HTTP API docs

### DIFF
--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -1,0 +1,361 @@
+# Decentraland HTTP API
+
+Base URL: `https://api.decentraland.org/v1`
+
+---
+
+## Table of Content
+
+* [Contributions](https://github.decentraland.org/marketplace/blob/master/docs/http-api.md#contributions)
+* [Districts](https://github.decentraland.org/marketplace/blob/master/docs/http-api.md#districts)
+* [Estates](https://github.decentraland.org/marketplace/blob/master/docs/http-api.md#estates)
+* TODO: Mortgages
+* [Map](https://github.decentraland.org/marketplace/blob/master/docs/http-api.md#map)
+* [Parcels](https://github.decentraland.org/marketplace/blob/master/docs/http-api.md#parcels)
+* [Publications](https://github.decentraland.org/marketplace/blob/master/docs/http-api.md#publications)
+* [Translations](https://github.decentraland.org/marketplace/blob/master/docs/http-api.md#translations)
+
+---
+
+## Contributions
+
+```
+GET /addresses/:address/contributions
+```
+
+### Description
+
+Returns all the contributions to districts for a given address
+
+### URI Params
+
+| name    | type   | description         |
+| ------- | ------ | ------------------- |
+| address | string | An Ethereum address |
+
+### Response Example
+
+```json
+{
+  "ok": true,
+  "data": [
+    {
+      "address": "0x374cc898638940452b6d7b34f6063170976026f0",
+      "district_id": "219ac351-e6ce-4e17-8b84-eb008afddf69",
+      "land_count": "5"
+    },
+    {
+      "address": "0x374cc898638940452b6d7b34f6063170976026f0",
+      "district_id": "d9bfa18a-c856-457d-8d85-e2dc3b7648a1",
+      "land_count": "15"
+    },
+    {
+      "address": "0x374cc898638940452b6d7b34f6063170976026f0",
+      "district_id": "f5d8e722-fdce-4d41-b38b-adfed2e0cf6c",
+      "land_count": "10"
+    }
+  ]
+}
+```
+
+---
+
+```
+GET /districts
+```
+
+Returns all the districts in Genesis City
+
+### Response Example
+
+```json
+{
+  "ok": true,
+  "data": [
+    {
+      "id": "106f1557-4a92-41a4-9f18-40fcb90b4031",
+      "name": "Dragon City",
+      "description":
+        "A perfect combination of China’s ancient culture and Western modernization, a reflection of both the Eastern and Western civilizations.",
+      "link": "https://github.com/decentraland/districts/issues/30",
+      "public": true,
+      "parcel_count": "6485",
+      "center": "105,-89"
+    },
+    {
+      "id": "219ac351-e6ce-4e17-8b84-eb008afddf69",
+      "name": "AETHERIAN project",
+      "description":
+        "Aetherian City will be one of the main attractions for visitors and dwellers of Decentraland, as it intends to be the largest cyberpunk-agglomeration of the metaverse.",
+      "link": "https://github.com/decentraland/districts/issues/33",
+      "public": true,
+      "parcel_count": "10005",
+      "center": "106,105"
+    }
+    //...
+  ]
+}
+```
+
+## Estates
+
+```
+GET /estates
+```
+
+### Description
+
+Returns a list of Estates, paginated, sorted, and filtered according to the query params used.
+
+| name       | type | default              | description                                                                          |
+| ---------- | ---- | -------------------- | ------------------------------------------------------------------------------------ |
+| status     | enum | `open`               | Filter parcels by publications status: `open`, `cancelled` or `sold`                 |
+| sort_by    | enum | `created_at`         | Property to order by: `price`, `created_at`, `block_time_updated_at` or `expires_at` |
+| sort_order | enum | depends on `sort_by` | The order to sort by: `asc` or `desc`                                                |
+| limit      | int  | `20`                 | The number of results to be retuned                                                  |
+| offset     | int  | `0`                  | The number of results to skip (used for pagination)                                  |
+
+### Response Example
+
+```json
+//TODO: Add `Response Example`
+```
+
+---
+
+```
+GET /addresses/:address/estates
+```
+
+### Description
+
+Returns all the Estates that belong to a given address
+
+### URI Params
+
+| name    | type   | description         |
+| ------- | ------ | ------------------- |
+| address | string | An Ethereum address |
+
+## Map
+
+```
+GET /api/map.png
+```
+
+### Description
+
+Returns a PNG of a section of the Genesis City map
+
+### Query Params
+
+| name         | type           | min       | max     | default | description                                                               |
+| ------------ | -------------- | --------- | ------- | ------- | ------------------------------------------------------------------------- |
+| width        | int            | 32        | 2048    | 500     | The width of the PNG image in pixels                                      |
+| height       | int            | 32        | 2048    | 500     | The height of the PNG image in pixels                                     |
+| size         | int            | 5         | 40      | 10      | The size of each parcel (i.e. 10 will render each parcel as 10x10 pixels) |
+| center       | coords         | -150,-150 | 150,150 | 0,0     | The coords on where to center the map                                     |
+| selected     | list of coords | N/A       | N/A     | N/A     | A list of coords separated by semicolons to render as "selected"          |
+| publications | boolean        | N/A       | N/A     | false   | If true, parcels that are on sale are highlighted                         |
+
+### Limits
+
+There's a limit of 15,000 parcels that can be rendered in a single PNG, if a request goes above this threshold the API will return a 500 with a message like this:
+
+```
+Too many parcels. You are trying to render 42436 parcels and the maximum allowed is 15000.
+```
+
+### Request Example:
+
+```
+GET /api/map.png?width=500&height=500&size=10&center=20,21&selected=20,20;20,21;20,22;20,23;19,21;21,21
+```
+
+### Result:
+
+![map-1](https://user-images.githubusercontent.com/2781777/40743488-0927f342-6428-11e8-942d-3ca36269d7dc.png)
+
+---
+
+```
+GET /api/parcels/:x/:y/map.png
+```
+
+### Description
+
+Returns a PNG of a piece of the map center on a given parcel
+
+### URI Params
+
+| name | type | min  | max | default | description               |
+| ---- | ---- | ---- | --- | ------- | ------------------------- |
+| x    | int  | -150 | 150 | 0       | The X coord of the parcel |
+| y    | int  | -150 | 150 | 0       | The Y coord of the parcel |
+
+### Query Params
+
+| name         | type    | min | max  | default | description                                                               |
+| ------------ | ------- | --- | ---- | ------- | ------------------------------------------------------------------------- |
+| width        | int     | 32  | 2048 | 500     | The width of the PNG image in pixels                                      |
+| height       | int     | 32  | 2048 | 500     | The height of the PNG image in pixels                                     |
+| size         | int     | 5   | 40   | 10      | The size of each parcel (i.e. 10 will render each parcel as 10x10 pixels) |
+| publications | boolean | N/A | N/A  | false   | If true, parcels that are on sale are highlighted                         |
+
+### Limits
+
+There's a limit of 15,000 parcels that can be rendered in a single PNG, if a request goes above this threshold the API will return a 500 with a message like this:
+
+```
+Too many parcels. You are trying to render 42436 parcels and the maximum allowed is 15000.
+```
+
+### Request Example:
+
+```
+GET /api/parcels/-36/-125/map.png?height=500&width=500&size=10&publications=true
+```
+
+### Result:
+
+![map-1](https://user-images.githubusercontent.com/2781777/41127253-9f1af8a0-6a80-11e8-9b26-ba630c85871c.png)
+
+---
+
+## Parcels
+
+```
+GET /parcels
+```
+
+Returns a list of parcels, paginated, sorted, and filtered according to the query params used.
+
+### Query Params
+
+| name       | type | default              | description                                                                          |
+| ---------- | ---- | -------------------- | ------------------------------------------------------------------------------------ |
+| status     | enum | `open`               | Filter parcels by publications status: `open`, `cancelled` or `sold`                 |
+| sort_by    | enum | `created_at`         | Property to order by: `price`, `created_at`, `block_time_updated_at` or `expires_at` |
+| sort_order | enum | depends on `sort_by` | The order to sort by: `asc` or `desc`                                                |
+| limit      | int  | `20`                 | The number of results to be retuned                                                  |
+| offset     | int  | `0`                  | The number of results to skip (used for pagination)                                  |
+
+### Response Example
+
+```json
+{
+  "ok": true,
+  "data": {
+    "parcels": [
+      {
+        "id": "-74,-52",
+        "x": -74,
+        "y": -52,
+        "auction_price": 2443,
+        "district_id": null,
+        "owner": "0xdeadbeeffaceb00c",
+        "data": {
+          "version": 0,
+          "name": "My Parcel",
+          "description": "My parcel is awesome",
+          "ipns": ""
+        },
+        "auction_owner": "0xdeadbeeffaceb00c",
+        "tags": {
+          "proximity": {
+            "plaza": {
+              "district_id": "55327350-d9f0-4cae-b0f3-8745a0431099",
+              "distance": 2
+            },
+            "road": {
+              "district_id": "f77140f9-c7b4-4787-89c9-9fa0e219b079",
+              "distance": 0
+            }
+          }
+        },
+        "last_transferred_at": null,
+        "in_estate": false,
+        "publication": {
+          "tx_hash": "0xdeadbeeffaceb00c",
+          "tx_status": "confirmed",
+          "owner": "0xdeadbeeffaceb00c",
+          "price": 60000,
+          "status": "open",
+          "buyer": null,
+          "contract_id": "0xdeadbeeffaceb00c",
+          "block_number": 5812730,
+          "expires_at": 1533081600000,
+          "block_time_created_at": 1529352925000,
+          "block_time_updated_at": null,
+          "type": "parcel",
+          "asset_id": "-74,-52",
+          "marketplace_id": "0xdeadbeeffaceb00c"
+        }
+      }
+      //..
+    ],
+    "total": 100
+  }
+}
+```
+
+---
+
+```
+GET /addresses/:address/parcels
+```
+
+### Description
+
+Returns all the parcels that belong to a given address
+
+## Publications
+
+```
+GET /parcels/:x/:y/publications
+```
+
+### Description
+
+Returns all the publications that ever existed for a given parcel
+
+### URI Params
+
+| name | type | min  | max | default | description               |
+| ---- | ---- | ---- | --- | ------- | ------------------------- |
+| x    | int  | -150 | 150 | 0       | The X coord of the parcel |
+| y    | int  | -150 | 150 | 0       | The Y coord of the parcel |
+
+---
+
+```
+GET /publications/:txHash
+```
+
+### Description
+
+Returns a specific publication by its transaction hash
+
+### URI Params
+
+| name   | type   | description                           |
+| ------ | ------ | ------------------------------------- |
+| txHash | string | The transaction hash of a publication |
+
+---
+
+## Translations
+
+```
+GET /translations/:locale
+```
+
+### Description
+
+Returns all the available translations for a given `locale`
+
+### URI Params
+
+| name   | type | description                                                  |
+| ------ | ---- | ------------------------------------------------------------ |
+| locale | enum | One of the following locales: `en`, `es`, `fr`, `ko` or `zh` |

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -92,7 +92,6 @@ Returns all the districts in Genesis City
       "parcel_count": "10005",
       "center": "106,105"
     }
-    //...
   ]
 }
 ```
@@ -292,9 +291,8 @@ Returns a list of parcels, paginated, sorted, and filtered according to the quer
           "marketplace_id": "0xdeadbeeffaceb00c"
         }
       }
-      //..
     ],
-    "total": 100
+    "total": 2
   }
 }
 ```

--- a/migrations/1519215027247_publications-add-status-buyer-owner.js
+++ b/migrations/1519215027247_publications-add-status-buyer-owner.js
@@ -1,9 +1,10 @@
 import { Publication } from '../src/Publication'
+import { PUBLICATION_STATUS } from '../shared/publication'
 
 exports.up = pgm => {
   const tableName = Publication.tableName
 
-  const publicationStatus = Object.values(Publication.STATUS)
+  const publicationStatus = Object.values(PUBLICATION_STATUS)
     .map(val => `'${val}'`)
     .join(', ')
 
@@ -11,7 +12,7 @@ exports.up = pgm => {
     status: {
       type: 'TEXT',
       notNull: true,
-      default: Publication.STATUS.open,
+      default: PUBLICATION_STATUS.open,
       check: `status IN (${publicationStatus})`
     },
     buyer: {

--- a/migrations/1526295211848_publications-add-asset-support.js
+++ b/migrations/1526295211848_publications-add-asset-support.js
@@ -1,4 +1,5 @@
 import { Publication } from '../src/Publication'
+import { PUBLICATION_TYPES } from '../shared/publication'
 
 const tableName = Publication.tableName
 
@@ -8,7 +9,7 @@ exports.up = pgm => {
   pgm.addColumns(tableName, {
     type: {
       type: 'TEXT',
-      default: Publication.TYPES.parcel,
+      default: PUBLICATION_TYPES.parcel,
       notNull: true
     },
     asset_id: {

--- a/migrations/1527536462876_mortgage-create.js
+++ b/migrations/1527536462876_mortgage-create.js
@@ -1,8 +1,9 @@
 import { txUtils } from 'decentraland-eth'
 import { Mortgage } from '../src/Mortgage'
+import { MORTGAGE_STATUS } from '../shared/mortgage'
 
 const tableName = Mortgage.tableName
-const mortgageStatus = Object.values(Mortgage.STATUS)
+const mortgageStatus = Object.values(MORTGAGE_STATUS)
   .map(val => `'${val}'`)
   .join(', ')
 
@@ -23,7 +24,7 @@ exports.up = pgm => {
       status: {
         type: 'TEXT',
         notNull: true,
-        default: Mortgage.STATUS.open,
+        default: MORTGAGE_STATUS.open,
         check: `status IN (${mortgageStatus})`
       },
       asset_id: { type: 'TEXT', notNull: true },

--- a/scripts/monitor/processEvents.js
+++ b/scripts/monitor/processEvents.js
@@ -7,6 +7,7 @@ import { BlockTimestampService } from '../../src/BlockTimestamp'
 import { Mortgage } from '../../src/Mortgage'
 import { MarketplaceEvent } from '../../src/MarketplaceEvent'
 import { isDuplicatedConstraintError } from '../../src/database'
+import { MORTGAGE_STATUS } from '../../shared/mortgage'
 
 const log = new Log('processEvents')
 
@@ -51,7 +52,7 @@ async function processNoParcelRelatedEvents(event) {
         log.info(`[${name}] Cancelling Mortgage ${_id}`)
         await Mortgage.update(
           {
-            status: Mortgage.STATUS.cancelled,
+            status: MORTGAGE_STATUS.cancelled,
             block_time_updated_at
           },
           {
@@ -237,7 +238,7 @@ async function processParcelRelatedEvents(assetId, event) {
       try {
         await Mortgage.insert({
           tx_status: txUtils.TRANSACTION_STATUS.confirmed,
-          status: Mortgage.STATUS.open,
+          status: MORTGAGE_STATUS.open,
           is_due_at: duesIn.toNumber(),
           expires_at: expiresAt.toNumber(),
           mortgage_id: parseInt(mortgageId, 10),

--- a/scripts/monitor/processEvents.js
+++ b/scripts/monitor/processEvents.js
@@ -8,6 +8,7 @@ import { Mortgage } from '../../src/Mortgage'
 import { MarketplaceEvent } from '../../src/MarketplaceEvent'
 import { isDuplicatedConstraintError } from '../../src/database'
 import { MORTGAGE_STATUS } from '../../shared/mortgage'
+import { PUBLICATION_STATUS } from '../../shared/publication'
 
 const log = new Log('processEvents')
 
@@ -107,14 +108,14 @@ async function processParcelRelatedEvents(assetId, event) {
         Publication.delete({
           asset_id: parcelId,
           owner: seller.toLowerCase(),
-          status: Publication.STATUS.open
+          status: PUBLICATION_STATUS.open
         })
       ])
 
       try {
         await Publication.insert({
           tx_status: txUtils.TRANSACTION_STATUS.confirmed,
-          status: Publication.STATUS.open,
+          status: PUBLICATION_STATUS.open,
           owner: seller.toLowerCase(),
           buyer: null,
           price: eth.utils.fromWei(priceInWei),
@@ -153,7 +154,7 @@ async function processParcelRelatedEvents(assetId, event) {
       await Promise.all([
         Publication.update(
           {
-            status: Publication.STATUS.sold,
+            status: PUBLICATION_STATUS.sold,
             buyer: winner.toLowerCase(),
             price: eth.utils.fromWei(totalPrice),
             block_time_updated_at
@@ -178,7 +179,7 @@ async function processParcelRelatedEvents(assetId, event) {
       )
 
       await Publication.update(
-        { status: Publication.STATUS.cancelled, block_time_updated_at },
+        { status: PUBLICATION_STATUS.cancelled, block_time_updated_at },
         { contract_id }
       )
       break

--- a/scripts/sanityCheck.js
+++ b/scripts/sanityCheck.js
@@ -11,6 +11,7 @@ import { processEvent } from './monitor/processEvents'
 import { MonitorCli } from './monitor/MonitorCli'
 import { main as indexMissingEvents } from './monitor/program'
 import { parseCLICoords, loadEnv } from './utils'
+import { PUBLICATION_STATUS } from '../shared/publication'
 
 const log = new Log('sanity-check')
 
@@ -139,7 +140,7 @@ async function getPublicationInconsistencies(parcel) {
         contractId
       ].join(' ')
     }
-  } else if (publication && publication.status === Publication.STATUS.open) {
+  } else if (publication && publication.status === PUBLICATION_STATUS.open) {
     // Check for hanging publication in db
     errors = `${id} open in db and null in blockchain`
   }

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -7,6 +7,7 @@ import faker from 'faker'
 import { loadEnv } from './utils'
 import { db } from '../src/database'
 import { Publication } from '../src/Publication'
+import { PUBLICATION_STATUS } from '../shared/publication'
 
 const log = new Log('seed')
 
@@ -118,7 +119,7 @@ function getRandomColumnValue(columnName, tableName) {
         tableName === Publication.tableName &&
         columnName === 'status'
       ) {
-        value = faker.random.objectElement(Publication.STATUS)
+        value = faker.random.objectElement(PUBLICATION_STATUS)
       } else {
         value = faker.random.words()
       }

--- a/src/Asset/Asset.js
+++ b/src/Asset/Asset.js
@@ -30,18 +30,17 @@ export class Asset {
   async filter(filters) {
     const { status, type, sort, pagination } = filters.sanitize()
     const tx_status = txUtils.TRANSACTION_STATUS.confirmed
-
     const [assets, total] = await Promise.all([
       db.query(
         SQL`SELECT model.*, row_to_json(pub.*) as publication
-          FROM ${raw(Publication.tableName)} as pub
-          JOIN ${raw(this.tableName)} as model ON model.id = pub.asset_id
-          WHERE status = ${status}
-            AND tx_status = ${tx_status}
-            AND type = ${type}
-            AND ${PublicationQueries.whereisActive()}
-          ORDER BY pub.${raw(sort.by)} ${raw(sort.order)}
-          LIMIT ${raw(pagination.limit)} OFFSET ${raw(pagination.offset)}`
+      FROM ${raw(Publication.tableName)} as pub
+      JOIN ${raw(this.tableName)} as model ON model.id = pub.asset_id
+      WHERE tx_status = ${tx_status}
+        AND type = ${type}
+        AND ${PublicationQueries.whereisActive()}
+        ${PublicationQueries.andHasStatus(status)}
+      ORDER BY pub.${raw(sort.by)} ${raw(sort.order)}
+      LIMIT ${raw(pagination.limit)} OFFSET ${raw(pagination.offset)}`
       ),
       this.countAssetPublications(filters, type)
     ])

--- a/src/Asset/Asset.js
+++ b/src/Asset/Asset.js
@@ -38,7 +38,7 @@ export class Asset {
       WHERE tx_status = ${tx_status}
         AND type = ${type}
         AND ${PublicationQueries.whereisActive()}
-        ${PublicationQueries.andHasStatus(status)}
+        AND ${PublicationQueries.hasStatus(status)}
       ORDER BY pub.${raw(sort.by)} ${raw(sort.order)}
       LIMIT ${raw(pagination.limit)} OFFSET ${raw(pagination.offset)}`
       ),

--- a/src/Asset/Asset.router.js
+++ b/src/Asset/Asset.router.js
@@ -20,7 +20,7 @@ export class AssetRouter {
      * @param  {number} offset
      * @return {array<Asset>}
      */
-    this.app.get('/api/assets', server.handleRequest(this.getAssets))
+    this.app.get('/assets', server.handleRequest(this.getAssets))
   }
 
   async getAssets(req) {

--- a/src/Contribution/Contribution.router.js
+++ b/src/Contribution/Contribution.router.js
@@ -14,7 +14,7 @@ export class ContributionRouter {
      * @return {array<Contribution>}
      */
     this.app.get(
-      '/api/addresses/:address/contributions',
+      '/addresses/:address/contributions',
       server.handleRequest(this.getAddressContributions)
     )
   }

--- a/src/District/District.router.js
+++ b/src/District/District.router.js
@@ -12,7 +12,7 @@ export class DistrictRouter {
      * Returns all stored districts
      * @return {array<District>}
      */
-    this.app.get('/api/districts', server.handleRequest(this.getDistricts))
+    this.app.get('/districts', server.handleRequest(this.getDistricts))
   }
 
   async getDistricts() {

--- a/src/Estate/Estate.router.js
+++ b/src/Estate/Estate.router.js
@@ -20,7 +20,7 @@ export class EstateRouter {
      * @param  {number} offset
      * @return {array<Estate>}
      */
-    this.app.get('/api/estates', server.handleRequest(this.getEstates))
+    this.app.get('/estates', server.handleRequest(this.getEstates))
 
     /**
      * Returns the parcels an address owns
@@ -29,7 +29,7 @@ export class EstateRouter {
      * @return {array<Estate>}
      */
     this.app.get(
-      '/api/addresses/:address/estates',
+      '/addresses/:address/estates',
       server.handleRequest(this.getAddressEstates)
     )
   }

--- a/src/Map/Map.router.js
+++ b/src/Map/Map.router.js
@@ -28,9 +28,9 @@ export class MapRouter {
   }
 
   mount() {
-    this.app.get('/api/map.png', this.handleRequest(this.getMapPNG))
+    this.app.get('/map.png', this.handleRequest(this.getMapPNG))
     this.app.get(
-      '/api/parcels/:x/:y/map.png',
+      '/parcels/:x/:y/map.png',
       this.handleRequest(this.getParcelPNG)
     )
     // TODO: add an endpoint for Estates someday 🏌🏼‍

--- a/src/Mortgage/Mortgage.model.js
+++ b/src/Mortgage/Mortgage.model.js
@@ -1,6 +1,7 @@
 import { Model } from 'decentraland-commons'
 
 import { SQL, raw, getInStatus } from '../database'
+import { MORTGAGE_STATUS } from '../shared/mortgage'
 
 export class Mortgage extends Model {
   static tableName = 'mortgages'
@@ -23,17 +24,11 @@ export class Mortgage extends Model {
   ]
   static primaryKey = 'tx_hash'
 
-  static STATUS = Object.freeze({
-    open: 'open',
-    claimed: 'claimed',
-    cancelled: 'cancelled'
-  })
-
   static findByBorrower(borrower, status) {
     return this.db.query(
       SQL`SELECT * FROM ${raw(this.tableName)}
         WHERE borrower = ${borrower}
-          AND status IN (${raw(getInStatus(status, this.STATUS))})
+          AND status IN (${raw(getInStatus(status, MORTGAGE_STATUS))})
           ORDER BY created_at DESC`
     )
   }
@@ -42,7 +37,7 @@ export class Mortgage extends Model {
     return this.db.query(
       SQL`SELECT * FROM ${raw(this.tableName)}
         WHERE asset_id = ${assetId}
-          AND status IN(${raw(getInStatus(status, this.STATUS))})
+          AND status IN(${raw(getInStatus(status, MORTGAGE_STATUS))})
           ORDER BY created_at DESC`
     )
   }

--- a/src/Mortgage/Mortgage.router.js
+++ b/src/Mortgage/Mortgage.router.js
@@ -16,7 +16,7 @@ export class MortgageRouter {
      * @return {array<Parcel>}
      */
     this.app.get(
-      '/api/parcels/:address/mortgages',
+      '/parcels/:address/mortgages',
       server.handleRequest(this.getMortgagedParcelsByBorrower)
     )
 
@@ -27,7 +27,7 @@ export class MortgageRouter {
      * @return {array<Mortgage>}
      */
     this.app.get(
-      '/api/addresses/:address/mortgages',
+      '/addresses/:address/mortgages',
       server.handleRequest(this.getMortgagesByBorrower)
     )
 
@@ -39,7 +39,7 @@ export class MortgageRouter {
      * @return {array<Mortgage>}
      */
     this.app.get(
-      '/api/parcels/:x/:y/mortgages',
+      '/parcels/:x/:y/mortgages',
       server.handleRequest(this.getMortgagesInCoordinate)
     )
   }

--- a/src/Parcel/Parcel.router.js
+++ b/src/Parcel/Parcel.router.js
@@ -23,7 +23,7 @@ export class ParcelRouter {
      * @param  {number} offset
      * @return {array<Parcel>}
      */
-    this.app.get('/api/parcels', server.handleRequest(this.getParcels))
+    this.app.get('/parcels', server.handleRequest(this.getParcels))
 
     /**
      * Returns the parcels an address owns
@@ -32,7 +32,7 @@ export class ParcelRouter {
      * @return {array<Parcel>}
      */
     this.app.get(
-      '/api/addresses/:address/parcels',
+      '/addresses/:address/parcels',
       server.handleRequest(this.getAddressParcels)
     )
   }

--- a/src/Publication/Publication.model.js
+++ b/src/Publication/Publication.model.js
@@ -1,6 +1,7 @@
 import { Model } from 'decentraland-commons'
 import { BlockchainEvent } from '../BlockchainEvent'
 import { SQL } from '../database'
+import { PUBLICATION_STATUS, PUBLICATION_TYPES } from '../shared/publication'
 
 export class Publication extends Model {
   static tableName = 'publications'
@@ -22,23 +23,12 @@ export class Publication extends Model {
     'contract_id'
   ]
 
-  static STATUS = Object.freeze({
-    open: 'open',
-    sold: 'sold',
-    cancelled: 'cancelled'
-  })
-
-  static TYPES = Object.freeze({
-    parcel: 'parcel',
-    estate: 'estate'
-  })
-
   static isValidStatus(status) {
-    return Object.values(this.STATUS).includes(status)
+    return Object.values(PUBLICATION_STATUS).includes(status)
   }
 
   static isValidType(type) {
-    return Object.values(this.TYPES).includes(type)
+    return Object.values(PUBLICATION_TYPES).includes(type)
   }
 
   static findByOwner(owner) {
@@ -59,7 +49,7 @@ export class Publication extends Model {
 
   static async cancelOlder(asset_id, block_number) {
     const name = BlockchainEvent.EVENTS.publicationCreated
-    const status = this.STATUS.open
+    const status = PUBLICATION_STATUS.open
 
     const rows = await this.db.query(
       SQL`SELECT p.tx_hash
@@ -74,7 +64,7 @@ export class Publication extends Model {
     const txHashes = rows.map(row => row.tx_hash)
 
     if (txHashes.length) {
-      await this.updateManyStatus(txHashes, this.STATUS.cancelled)
+      await this.updateManyStatus(txHashes, PUBLICATION_STATUS.cancelled)
     }
   }
 

--- a/src/Publication/Publication.queries.js
+++ b/src/Publication/Publication.queries.js
@@ -3,6 +3,8 @@ import { SQL, raw } from '../database'
 
 export const PublicationQueries = Object.freeze({
   whereisActive: () => SQL`expires_at >= EXTRACT(epoch from now()) * 1000`,
+  andHasStatus: status =>
+    status != null ? SQL`AND status = ${status}` : SQL``,
 
   findByStatusSql: (status = null) => {
     if (!Publication.isValidStatus(status)) {

--- a/src/Publication/Publication.queries.js
+++ b/src/Publication/Publication.queries.js
@@ -3,8 +3,7 @@ import { SQL, raw } from '../database'
 
 export const PublicationQueries = Object.freeze({
   whereisActive: () => SQL`expires_at >= EXTRACT(epoch from now()) * 1000`,
-  andHasStatus: status =>
-    status != null ? SQL`AND status = ${status}` : SQL``,
+  hasStatus: status => (status != null ? SQL`status = ${status}` : SQL`1 = 1`),
 
   findByStatusSql: (status = null) => {
     if (!Publication.isValidStatus(status)) {

--- a/src/Publication/Publication.router.js
+++ b/src/Publication/Publication.router.js
@@ -18,7 +18,7 @@ export class PublicationRouter {
      * @return {array<Publication>}
      */
     this.app.get(
-      '/api/parcels/:x/:y/publications',
+      '/parcels/:x/:y/publications',
       server.handleRequest(this.getParcelPublications)
     )
 
@@ -28,7 +28,7 @@ export class PublicationRouter {
      * @return {array}
      */
     this.app.get(
-      '/api/publications/:txHash',
+      '/publications/:txHash',
       server.handleRequest(this.getPublication)
     )
   }

--- a/src/Publication/PublicationRequestFilters.js
+++ b/src/Publication/PublicationRequestFilters.js
@@ -3,16 +3,27 @@ import { server } from 'decentraland-commons'
 import { Publication } from './Publication.model'
 import { PUBLICATION_STATUS, PUBLICATION_TYPES } from '../../shared/publication'
 
-const ALLOWED_VALUES = Object.freeze({
+export const ALLOWED_SORT_VALUES = Object.freeze({
   price: ['ASC'],
   created_at: ['DESC'],
   block_time_updated_at: ['DESC'],
   expires_at: ['ASC']
 })
+export const DEFAULT_STATUS = PUBLICATION_STATUS.open
+export const DEFAULT_TYPE = PUBLICATION_TYPES.parcel
+export const DEFAULT_SORT_VALUE = 'created_at'
+export const DEFAULT_SORT = {
+  by: DEFAULT_SORT_VALUE,
+  order: ALLOWED_SORT_VALUES[DEFAULT_SORT_VALUE][0]
+}
+export const DEFAULT_PAGINATION = {
+  offset: 0,
+  limit: 20
+}
 
 export class PublicationRequestFilters {
   static getAllowedValues() {
-    return ALLOWED_VALUES
+    return ALLOWED_SORT_VALUES
   }
 
   constructor(req) {
@@ -21,10 +32,18 @@ export class PublicationRequestFilters {
 
   sanitize(req) {
     return {
-      status: this.getStatus(),
-      type: this.getType(),
-      sort: this.getSort(),
-      pagination: this.getPagination()
+      status: this.getOrDefault(this.getStatus, null),
+      type: this.getOrDefault(this.getType, DEFAULT_TYPE),
+      sort: this.getOrDefault(this.getSort, DEFAULT_SORT),
+      pagination: this.getOrDefault(this.getPagination, DEFAULT_PAGINATION)
+    }
+  }
+
+  getOrDefault(getter, defaultValue) {
+    try {
+      return getter.call(this)
+    } catch (error) {
+      return defaultValue
     }
   }
 
@@ -42,13 +61,13 @@ export class PublicationRequestFilters {
     let by = this.getReqParam('sort_by')
     let order = this.getReqParam('sort_order')
 
-    by = by in ALLOWED_VALUES ? by : 'created_at'
+    by = by in ALLOWED_SORT_VALUES ? by : DEFAULT_SORT.by
 
     return {
       by,
-      order: ALLOWED_VALUES[by].includes(order.toUpperCase())
+      order: ALLOWED_SORT_VALUES[by].includes(order.toUpperCase())
         ? order
-        : ALLOWED_VALUES[by][0]
+        : ALLOWED_SORT_VALUES[by][0]
     }
   }
 

--- a/src/Translation/Translation.router.js
+++ b/src/Translation/Translation.router.js
@@ -13,7 +13,7 @@ export class TranslationRouter {
      * @return {array<Translation>}
      */
     this.app.get(
-      '/api/translations/:locale',
+      '/translations/:locale',
       server.handleRequest(this.getTranslations)
     )
   }

--- a/src/server.js
+++ b/src/server.js
@@ -1,8 +1,6 @@
 import http from 'http'
 import express from 'express'
 import bodyParser from 'body-parser'
-
-import { eth, contracts } from 'decentraland-eth'
 import { env } from 'decentraland-commons'
 
 import { db } from './database'

--- a/src/server.js
+++ b/src/server.js
@@ -60,22 +60,6 @@ async function startServer() {
   console.log('Connecting database')
   await db.connect()
 
-  console.log('Connecting to Ethereum node')
-  await eth
-    .connect({
-      contracts: [
-        new contracts.LANDRegistry(env.get('LAND_REGISTRY_CONTRACT_ADDRESS'))
-      ],
-      provider: env.get('RPC_URL') // default to localhost
-    })
-    .catch(error =>
-      console.error(
-        '\nCould not connect to the Ethereum node. Some endpoints may not work correctly.',
-        '\nMake sure you have a node running on port 8545.',
-        `\nError: "${error.message}"\n`
-      )
-    )
-
   return httpServer.listen(SERVER_PORT, () =>
     console.log('Server running on port', SERVER_PORT)
   )

--- a/webapp/src/lib/api.js
+++ b/webapp/src/lib/api.js
@@ -138,7 +138,7 @@ export class API {
   }
 
   getUrl(path) {
-    return `${URL}/api${path}`
+    return `${URL}${path}`
   }
 }
 


### PR DESCRIPTION
In this PR I added a `docs/http-api.md` file with some documentation for our HTTP API (Mortgages docs are still missing) 

I made a few fixes and changes along the way:

- Removed the duplicated static constants `Publication.STATUS`, `Publication.TYPES`, `Mortgage.STATUS` and `Mortgage.TYPES`

- Added default values to the `PublicationRequestFilter`'s parameters and allowed requests

- Added support for requests without a `status` param