### PR TITLE
chore: tech debt

### DIFF
--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -110,7 +110,7 @@ Returns a list of Estates, paginated, sorted, and filtered according to the quer
 
 | name       | type | default              | description                                                                          |
 | ---------- | ---- | -------------------- | ------------------------------------------------------------------------------------ |
-| status     | enum | `open`               | Filter parcels by publications status: `open`, `cancelled` or `sold`                 |
+| status     | enum | `open`               | Filter estates by publications status: `open`, `cancelled` or `sold`                 |
 | sort_by    | enum | `created_at`         | Property to order by: `price`, `created_at`, `block_time_updated_at` or `expires_at` |
 | sort_order | enum | depends on `sort_by` | The order to sort by: `asc` or `desc`                                                |
 | limit      | int  | `20`                 | The number of results to be retuned                                                  |

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -270,10 +270,9 @@ Same as `/parcels/:x/:y/map.png`, but instead of using `x` and `y` coordinates t
 
 ### URI Params
 
-| name | type   | description               |
-| ---- | ------ | ------------------------- |
-| id   | string | The id of the estate      |
-
+| name | type   | description          |
+| ---- | ------ | -------------------- |
+| id   | string | The id of the estate |
 
 ### Query Params
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -141,6 +141,43 @@ Returns all the Estates that belong to a given address
 ## Map
 
 ```
+GET /map
+```
+
+### Description
+
+Returns all the parcels and estates in a given area
+
+### Query Params
+
+| name | type | min  | max | description                     |
+| ---- | ---- | ---- | --- | ------------------------------- |
+| nw   | int  | -150 | 150 | The northwest coord of the area |
+| se   | int  | -150 | 150 | The southeast coord of the area |
+
+### Request Example:
+
+```
+GET /map?nw=-10,10&se=10,-10
+```
+
+### Result:
+
+```js
+{
+  "data": {
+    "assets": {
+      "parcels": [/* parcels */],
+      "estates": [/* estates */]
+    },
+    "total": 441
+  }
+}
+```
+
+---
+
+```
 GET /map.png
 ```
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -390,6 +390,16 @@ GET /addresses/:address/parcels
 
 Returns all the parcels that belong to a given address
 
+---
+
+```
+GET /parcels/:x/:y
+```
+
+### Description
+
+Returns a single parcel by its coords
+
 ## Publications
 
 ```

--- a/src/Map/Map.router.js
+++ b/src/Map/Map.router.js
@@ -85,8 +85,14 @@ export class MapRouter {
   }
 
   async getMap(req) {
-    const nw = server.extractFromReq(req, 'nw')
-    const se = server.extractFromReq(req, 'se')
+    let nw
+    let se
+    try {
+      nw = server.extractFromReq(req, 'nw')
+      se = server.extractFromReq(req, 'se')
+    } catch (_) {
+      throw new Error('Both "nw" and "se" are required query params')
+    }
 
     const parcelsRange = await Parcel.inRange(nw, se)
     const parcels = utils.mapOmit(parcelsRange, blacklist.parcel)

--- a/src/Map/Map.router.js
+++ b/src/Map/Map.router.js
@@ -9,8 +9,7 @@ import {
 import { toEstateObject, calculateZoomAndCenter } from '../shared/estate'
 import { Viewport, Bounds } from '../shared/map'
 import { Map as MapRenderer } from '../shared/map/render'
-import { toPublicationObject, PUBLICATION_TYPES } from '../shared/publication'
-import { AssetRouter } from '../Asset'
+import { toPublicationObject } from '../shared/publication'
 import { Parcel, coordinates } from '../Parcel'
 import { Estate, EstateService } from '../Estate'
 import { blacklist } from '../lib'
@@ -86,23 +85,16 @@ export class MapRouter {
   }
 
   async getMap(req) {
-    try {
-      const nw = server.extractFromReq(req, 'nw')
-      const se = server.extractFromReq(req, 'se')
+    const nw = server.extractFromReq(req, 'nw')
+    const se = server.extractFromReq(req, 'se')
 
-      const parcelsRange = await Parcel.inRange(nw, se)
-      const parcels = utils.mapOmit(parcelsRange, blacklist.parcel)
-      const estates = await EstateService.getByParcels(parcels)
+    const parcelsRange = await Parcel.inRange(nw, se)
+    const parcels = utils.mapOmit(parcelsRange, blacklist.parcel)
+    const estates = await EstateService.getByParcels(parcels)
 
-      const assets = { parcels, estates }
-      const total = parcels.length + estates.length
-      return { assets, total }
-    } catch (error) {
-      // Force parcel type
-      req.params.type = PUBLICATION_TYPES.parcel
-      const { assets, total } = await new AssetRouter().getAssets(req)
-      return { assets, total }
-    }
+    const assets = { parcels, estates }
+    const total = parcels.length + estates.length
+    return { assets, total }
   }
 
   async sendPNG(

--- a/src/Map/Map.router.js
+++ b/src/Map/Map.router.js
@@ -219,7 +219,7 @@ export class MapRouter {
       value = unsafeParseInt(param)
     } catch (e) {
       throw new Error(
-        `Invalid param "${name}" should be a number but got "${param}".`
+        `Invalid param "${name}" should be a integer but got "${param}".`
       )
     }
     return value > max ? max : value < min ? min : value

--- a/src/Parcel/Parcel.router.js
+++ b/src/Parcel/Parcel.router.js
@@ -5,6 +5,7 @@ import { ASSET_TYPE } from '../shared/asset'
 import { Bounds } from '../shared/map'
 import { AssetRouter } from '../Asset'
 import { blacklist } from '../lib'
+import { unsafeParseInt } from '../lib/unsafeParseInt'
 
 export class ParcelRouter {
   constructor(app) {
@@ -71,17 +72,18 @@ export class ParcelRouter {
   }
 
   async getParcel(req) {
-    let parcel
+    let parcel, x, y
 
-    const x = parseInt(server.extractFromReq(req, 'x'), 10)
-    const y = parseInt(server.extractFromReq(req, 'y'), 10)
-
-    if (isNaN(x)) {
-      throw new Error('Invalid coordinate "x" must be a number')
+    try {
+      x = unsafeParseInt(server.extractFromReq(req, 'x'))
+    } catch (e) {
+      throw new Error('Invalid coordinate "x" must be an integer')
     }
 
-    if (isNaN(y)) {
-      throw new Error('Invalid coordinate "y" must be a number')
+    try {
+      y = unsafeParseInt(server.extractFromReq(req, 'y'))
+    } catch (e) {
+      throw new Error('Invalid coordinate "y" must be an integer')
     }
 
     if (!Bounds.inBounds(x, y)) {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,2 +1,3 @@
 export * from './asyncBatch'
 export * from './blacklist'
+export * from './unsafeParseInt'

--- a/src/lib/unsafeParseInt.js
+++ b/src/lib/unsafeParseInt.js
@@ -1,0 +1,6 @@
+export function unsafeParseInt(str) {
+  if (!Number.isInteger(Number(str))) {
+    throw new Error(`Invalid integer: ${str}`)
+  }
+  return parseInt(str, 10)
+}

--- a/webapp/src/components/ParcelTags/ParcelTags.css
+++ b/webapp/src/components/ParcelTags/ParcelTags.css
@@ -75,3 +75,9 @@
 .ParcelTags .tag-details {
   margin-left: 16px;
 }
+
+@media (max-width: 768px) {
+  .ParcelTags .tag.medium {
+    margin-bottom: 16px;
+  }
+}

--- a/webapp/src/lib/api.js
+++ b/webapp/src/lib/api.js
@@ -28,8 +28,8 @@ export class API {
     return this.request('get', '/map', { nw, se })
   }
 
-  fetchParcelsInRange(nw, se) {
-    return this.request('get', '/parcels', { nw, se })
+  fetchParcel(x, y) {
+    return this.request('get', `/parcels/${x}/${y}`)
   }
 
   fetchParcels(options = FILTER_DEFAULTS) {

--- a/webapp/src/modules/parcels/sagas.js
+++ b/webapp/src/modules/parcels/sagas.js
@@ -16,7 +16,6 @@ import { getData as getParcels } from './selectors'
 import { locations } from 'locations'
 import { api } from 'lib/api'
 import { buildCoordinate } from 'shared/parcel'
-import { Bounds } from 'shared/map'
 
 export function* parcelsSaga() {
   yield takeEvery(FETCH_PARCEL_REQUEST, handleParcelRequest)
@@ -27,16 +26,7 @@ export function* parcelsSaga() {
 function* handleParcelRequest(action) {
   const { x, y } = action
   try {
-    const parcelId = buildCoordinate(x, y)
-    const nw = parcelId
-    const se = parcelId
-
-    if (!Bounds.inBounds(x, y)) {
-      throw new Error(`Coords (${x}, ${y}) are outside of the valid bounds`)
-    }
-
-    const { parcels } = yield call(() => api.fetchParcelsInRange(nw, se))
-    const parcel = parcels.find(p => p.id === parcelId)
+    const parcel = yield call(() => api.fetchParcel(x, y))
 
     yield put(fetchParcelSuccess(x, y, parcel))
   } catch (error) {


### PR DESCRIPTION
This PR improves de HTTP API documentation (more importantly it adds the missing `/map` endpoint), refactors a little bit the way we use the API so it makes more sense (like I stopped fetching single parcels like `/parcels?nw=x,y&se=x,y` and doing `/parcels/:x/:y` instead) and fixes a mobile issue with the highlights:

before:

<img width="399" alt="screen shot 2018-07-11 at 11 05 26 am" src="https://user-images.githubusercontent.com/2781777/42590382-08e5a0ba-851a-11e8-892f-40206bd993ef.png">

after:

<img width="393" alt="screen shot 2018-07-11 at 2 52 41 pm" src="https://user-images.githubusercontent.com/2781777/42590433-2e632574-851a-11e8-9a1e-9f8fa719416b.png">

**IMPORTANT**

**I did not remove any functionality** from the API, so folks using our API like `/parcels?nw=x,y&se=x,y` can still do so, but I just didn't add that to the docs to discourage misuse and added the preferred `/parcels/:x/:y` for that purpose
