### PR TITLE
chore: bump newrelic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -165,9 +165,9 @@
       }
     },
     "@newrelic/native-metrics": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-2.4.0.tgz",
-      "integrity": "sha512-6Pv2Z9vkinr0MTnH1BORBs/SFOdKei43tQo2z30h9NtTc1pmWb/n5VWjgp7ReZ7FwzTI2oIhjbgnk2gZzpl6bw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-3.1.0.tgz",
+      "integrity": "sha512-45OhFKiRT5L+hBzAkDkR5UTuHWIUNMjwlMlu65Y8HmyrTPtgUMKoqMmHERRX4aRqb/EEaW3oWYYLOpLnB6fiHg==",
       "optional": true,
       "requires": {
         "nan": "2.10.0"
@@ -208,6 +208,11 @@
       "requires": {
         "moment": "2.22.1"
       }
+    },
+    "@tyriar/fibonacci-heap": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.7.tgz",
+      "integrity": "sha512-DANf9u0VN5oWrRk31B+xCy9mMNx1H9YhWUaTzCzU0uBruj/zg8u9JSw5qpArntvfJxaW/gWGWbQtzpAkYO6VBg=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -252,9 +257,12 @@
       }
     },
     "agent-base": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-1.0.2.tgz",
-      "integrity": "sha1-aJDT+yFwBLYrcPiSjg+uX4lSpwY="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "requires": {
+        "es6-promisify": "5.0.0"
+      }
     },
     "ajv": {
       "version": "5.5.2",
@@ -2341,6 +2349,19 @@
         "is-symbol": "1.0.1"
       }
     },
+    "es6-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "4.2.4"
+      }
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -4014,23 +4035,12 @@
       }
     },
     "https-proxy-agent": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-0.3.6.tgz",
-      "integrity": "sha1-cT+jjl01P1DrFKNC/r4pAz7RYZs=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "requires": {
-        "agent-base": "1.0.2",
-        "debug": "2.6.9",
-        "extend": "3.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
+        "agent-base": "4.2.1",
+        "debug": "3.1.0"
       }
     },
     "iconv-lite": {
@@ -5285,15 +5295,16 @@
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "newrelic": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-3.3.1.tgz",
-      "integrity": "sha1-Uv3ddNEK99v+S7SnUKcjBmAuVc4=",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-4.8.0.tgz",
+      "integrity": "sha512-eteq0KPDBoG6lnNhRspf7I+dyWcXkcBZpFjekQ2CZM43XhOg9XM6/gaylzGqfuDqZ4Ld62OhddTrZhG73FLgUQ==",
       "requires": {
         "@newrelic/koa": "1.0.5",
-        "@newrelic/native-metrics": "2.4.0",
+        "@newrelic/native-metrics": "3.1.0",
+        "@tyriar/fibonacci-heap": "2.0.7",
         "async": "2.6.1",
         "concat-stream": "1.6.2",
-        "https-proxy-agent": "0.3.6",
+        "https-proxy-agent": "2.2.1",
         "json-stringify-safe": "5.0.1",
         "readable-stream": "2.3.6",
         "semver": "5.5.0"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "flat": "^4.0.0",
     "inquirer": "^5.2.0",
     "mocha": "^4.0.1",
-    "newrelic": "^3.3.0",
+    "newrelic": "^4.8.0",
     "node-pg-migrate": "^2.23.0",
     "prettier": "1.12.1",
     "sinon": "^5.0.3",


### PR DESCRIPTION
Bump `newrelic` to avoid a potential security vulnerability from one of its dependencies: `https-proxy-agent@0.3.6`