### PR TITLE
fix: unconnected estates

### DIFF
--- a/shared/estate.js
+++ b/shared/estate.js
@@ -1,5 +1,3 @@
-import { getCoordsMatcher } from './parcel'
-
 export function isEstate(asset) {
   return !!asset.data.parcels
 }
@@ -45,31 +43,27 @@ export function getInitialEstate(x, y) {
   }
 }
 
-export function areConnected(
-  parcels,
-  remaining = [...parcels],
-  alreadyTraveled = []
-) {
-  if (alreadyTraveled.length === parcels.length) {
-    return true
-  }
-
-  if (remaining.length === 0) {
+export function areConnected(parcels) {
+  if (parcels.length === 0) {
     return false
   }
+  const visited = visitParcel(parcels[0], parcels)
+  return visited.length === parcels.length
+}
 
-  let actual = remaining.pop()
-
-  const neighbours = getNeighbours(actual.x, actual.y, parcels).filter(
-    coords => {
-      return (
-        parcels.some(getCoordsMatcher(coords)) &&
-        !alreadyTraveled.some(getCoordsMatcher(coords))
-      )
-    }
+export function visitParcel(parcel, allParcels = [parcel], visited = []) {
+  var isVisited = visited.some(
+    visitedParcel =>
+      visitedParcel.x === parcel.x && visitedParcel.y === parcel.y
   )
-
-  return areConnected(parcels, remaining, [...alreadyTraveled, ...neighbours])
+  if (!isVisited) {
+    visited.push(parcel)
+    var neighbours = getNeighbours(parcel.x, parcel.y, allParcels)
+    neighbours.forEach(neighbours =>
+      visitParcel(neighbours, allParcels, visited)
+    )
+  }
+  return visited
 }
 
 export function getIsNeighbourMatcher(x, y) {

--- a/webapp/src/components/EstateDetailPage/EstateDetail.js
+++ b/webapp/src/components/EstateDetailPage/EstateDetail.js
@@ -74,14 +74,16 @@ export default class EstateDetail extends React.PureComponent {
                   >
                     <h3 className="parcels-included">
                       {t('estate_detail.parcels')}
-                      <Button
-                        size="tiny"
-                        className="link"
-                        onClick={onEditParcels}
-                      >
-                        <Icon name="pencil" />
-                        {t('estate_detail.edit_parcels')}{' '}
-                      </Button>
+                      {isOwner && (
+                        <Button
+                          size="tiny"
+                          className="link"
+                          onClick={onEditParcels}
+                        >
+                          <Icon name="pencil" />
+                          {t('estate_detail.edit_parcels')}{' '}
+                        </Button>
+                      )}
                     </h3>
                   </Grid.Column>
                   {isOwner && (

--- a/webapp/src/components/EstateDetailPage/EstateDetail.js
+++ b/webapp/src/components/EstateDetailPage/EstateDetail.js
@@ -86,12 +86,6 @@ export default class EstateDetail extends React.PureComponent {
                       )}
                     </h3>
                   </Grid.Column>
-                  {isOwner && (
-                    <Grid.Column
-                      width={8}
-                      className={'selected-parcels-headline'}
-                    />
-                  )}
                   <Grid.Column width={16} className={'selected-parcels'}>
                     {parcels.map(({ x, y }) => {
                       const parcel = allParcels[buildCoordinate(x, y)]

--- a/webapp/src/components/EstateDetailPage/EstateSelect/EstateSelect.js
+++ b/webapp/src/components/EstateDetailPage/EstateSelect/EstateSelect.js
@@ -37,7 +37,7 @@ export default class EstateSelect extends React.PureComponent {
       return
     }
 
-    const { estate, isCreation, onChange } = this.props
+    const { estate, onChange } = this.props
     const parcels = estate.data.parcels
 
     if (isEstate(asset) && asset.asset_id !== estate.asset_id) {
@@ -53,12 +53,7 @@ export default class EstateSelect extends React.PureComponent {
       const newParcels = parcels.filter(
         coords => !isEqualCoords(coords, { x, y })
       )
-
-      if (
-        !areConnected(newParcels, [...parcels]) ||
-        !areConnected(newParcels) ||
-        (!isCreation && newParcels.length < 2)
-      ) {
+      if (!areConnected(newParcels)) {
         return
       }
       return onChange(newParcels)


### PR DESCRIPTION
Fixes #386 

The current implementation of `areConnected` used to determine if all the parcels in an Estate are connected is broken:

![estate-unconnected](https://user-images.githubusercontent.com/2781777/44741231-dba9ea00-aad2-11e8-81a3-53df11edcab8.gif)

I replaced that implementation with an equivalent that uses graph theory to determine if all the parcels are connected: do depth first search to travel the graph and collect all the visited nodes, if all the parcels in the estate are visited it means they are all connected.

This is the result:

![estate-connected](https://user-images.githubusercontent.com/2781777/44741364-32afbf00-aad3-11e8-94fd-0cd9a8e7b153.gif)
