### PR TITLE
fix: handle empty estate

### DIFF
--- a/src/Estate/Estate.router.js
+++ b/src/Estate/Estate.router.js
@@ -72,6 +72,9 @@ export class EstateRouter {
     const assetId = server.extractFromReq(req, 'assetId').toLowerCase()
 
     const result = await Estate.findByAssetId(assetId)
+    if (result.length === 0) {
+      throw new Error('Not found')
+    }
     return utils.mapOmit(result, blacklist.estate)[0]
   }
 }

--- a/src/Translation/locales/en.json
+++ b/src/Translation/locales/en.json
@@ -55,10 +55,10 @@
       "You have set a wrong derivation path for your wallet. Your derivation path must follow pattern 44'/60|61'/x'/n"
   },
   "estate_detail": {
-    "delete": "Delete Estate",
-    "delete_desc": "You are going to delete the estate {name}",
+    "dissolve": "Dissolve Estate",
+    "dissolve_desc": "You are going to dissolve the estate {name}",
     "edit_parcels": "Edit Parcels",
-    "empty_estate": "The estate {name} has been deleted",
+    "empty_estate": "The estate {name} has been dissolved",
     "parcels": "Parcels included",
     "pending_tx": "This estate"
   },
@@ -369,9 +369,9 @@
     "create_estate": "You created the estate {name}",
     "create_mortgage":
       "You requested a Mortgage to buy the parcel {parcel_link}",
-    "delete_estate": "You deleted the estate {name}",
     "disapproved":
       "You unauthorized the {marketplace_contract_link} to operate MANA on your behalf",
+    "dissolve_estate": "You dissolved the estate {name}",
     "edit":
       "You edited {parcel_link} with the name \"{name}\" and description \"{description}\"",
     "edit_estate_metadata":

--- a/src/Translation/locales/en.json
+++ b/src/Translation/locales/en.json
@@ -58,6 +58,7 @@
     "delete": "Delete Estate",
     "delete_desc": "You are going to delete the estate {name}",
     "edit_parcels": "Edit Parcels",
+    "empty_estate": "The estate {name} has been deleted",
     "parcels": "Parcels included",
     "pending_tx": "This estate"
   },

--- a/src/Translation/locales/es.json
+++ b/src/Translation/locales/es.json
@@ -55,10 +55,10 @@
       "El derivation path es incorrecto. Debe seguir el siguiente patrón 44'/60|61'/x'/n"
   },
   "estate_detail": {
-    "delete": "Eliminar Estado",
-    "delete_desc": "Vas a eliminar la propiedad {name}",
+    "dissolve": "Disolver Propiedad",
+    "dissolve_desc": "Vas a disolver la propiedad {name}",
     "edit_parcels": "Editar paquetes",
-    "empty_estate": "La propiedad {name} ha sido eliminada",
+    "empty_estate": "La propiedad {name} ha sido disuelta",
     "parcels": "Parcelas incluidas",
     "pending_tx": "Esta propiedad"
   },
@@ -374,9 +374,9 @@
     "create_estate": "Usted creó la propiedad {name}",
     "create_mortgage":
       "Solicitó una hipoteca para comprar el paquete {parcel_link}",
-    "delete_estate": "Borraste la propiedad {name}",
     "disapproved":
       "Has desautorizado al {marketplace_contract_link} para operar MANA por tu cuenta.",
+    "dissolve_estate": "Usted disolvió la propiedad {name}",
     "edit":
       "Has editado {parcel_link} con el nombre \"{name}\" y la descripción \"{description}\"",
     "edit_estate_metadata":

--- a/src/Translation/locales/es.json
+++ b/src/Translation/locales/es.json
@@ -58,6 +58,7 @@
     "delete": "Eliminar Estado",
     "delete_desc": "Vas a eliminar la propiedad {name}",
     "edit_parcels": "Editar paquetes",
+    "empty_estate": "La propiedad {name} ha sido eliminada",
     "parcels": "Parcelas incluidas",
     "pending_tx": "Esta propiedad"
   },

--- a/src/Translation/locales/fr.json
+++ b/src/Translation/locales/fr.json
@@ -59,6 +59,7 @@
     "delete": "Supprimer la succession",
     "delete_desc": "Vous allez supprimer le domaine {name}",
     "edit_parcels": "Modifier les colis",
+    "empty_estate": "Le domaine {name} a été supprimé",
     "parcels": "Colis inclus",
     "pending_tx": "Ce domaine"
   },

--- a/src/Translation/locales/fr.json
+++ b/src/Translation/locales/fr.json
@@ -56,10 +56,10 @@
       "Vous avez défini un mauvais chemin de dérivation pour votre portefeuille. Votre chemin de dérivation doit suivre le modèle 44 '/ 60 | 61' / x '/ n"
   },
   "estate_detail": {
-    "delete": "Supprimer la succession",
-    "delete_desc": "Vous allez supprimer le domaine {name}",
+    "dissolve": "Dissoudre le domaine",
+    "dissolve_desc": "Vous allez dissoudre le domaine {name}",
     "edit_parcels": "Modifier les colis",
-    "empty_estate": "Le domaine {name} a été supprimé",
+    "empty_estate": "Le domaine {name} a été dissous",
     "parcels": "Colis inclus",
     "pending_tx": "Ce domaine"
   },
@@ -380,9 +380,9 @@
     "create_estate": "Vous avez créé le domaine {name}",
     "create_mortgage":
       "Vous avez demandé une hypothèque pour acheter le colis {parcel_link}",
-    "delete_estate": "Vous avez supprimé le domaine {name}",
     "disapproved":
       "Vous avez autorisé le {marketplace_contract_link} à transférer des fonds en votre nom",
+    "dissolve_estate": "Vous avez dissous le domaine {name}",
     "edit":
       "Vous avez mis à jour {parcel_link} avec le nom \"{name}\" et la description \"{description}\"",
     "edit_estate_metadata":

--- a/src/Translation/locales/ja.json
+++ b/src/Translation/locales/ja.json
@@ -55,10 +55,10 @@
       "あなたのウォレットは、不適合な導出関数をしています。導出関数は44'/60|61'/x'/n型でなければいけません。"
   },
   "estate_detail": {
-    "delete": "不動産を削除",
-    "delete_desc": "あなたは不動産{name}を削除しようとしています。",
+    "dissolve": "ディゾルブエステート",
+    "dissolve_desc": "あなたは不動産{name}を解散するつもりです",
     "edit_parcels": "パーセルの編集",
-    "empty_estate": "不動産{name}が削除されました",
+    "empty_estate": "不動産{name}が解散しました",
     "parcels": "パーセルを含む",
     "pending_tx": "この不動産"
   },
@@ -370,9 +370,9 @@
     "create_estate": "あなたは不動産{name}を作成しました",
     "create_mortgage":
       "パーセル{parcel_link}を購入するのに担保を申請しました。",
-    "delete_estate": "あなたは不動産{name}を削除しました",
     "disapproved":
       "あなたは、マーケット上でMANAを使用することを{marketplace_contract_link}で承認していません。",
+    "dissolve_estate": "あなたは不動産{name}を解散しました",
     "edit":
       "{parcel_link}の名称を\"{name}\"に、説明文を\"{description}\"に変更しました。",
     "edit_estate_metadata":

--- a/src/Translation/locales/ja.json
+++ b/src/Translation/locales/ja.json
@@ -58,6 +58,7 @@
     "delete": "不動産を削除",
     "delete_desc": "あなたは不動産{name}を削除しようとしています。",
     "edit_parcels": "パーセルの編集",
+    "empty_estate": "不動産{name}が削除されました",
     "parcels": "パーセルを含む",
     "pending_tx": "この不動産"
   },

--- a/src/Translation/locales/ko.json
+++ b/src/Translation/locales/ko.json
@@ -56,10 +56,10 @@
       "지갑에 대해 잘못된 파생 경로를 설정했습니다. 파생 경로는 패턴 44 '/ 60 | 61'/ x '/ n을 따라야합니다."
   },
   "estate_detail": {
-    "delete": "재산 삭제",
-    "delete_desc": "당신은 부동산 {name}을 삭제하려고합니다.",
+    "dissolve": "부동산 디졸브",
+    "dissolve_desc": "당신은 부동산 {name}을 해산하려고합니다.",
     "edit_parcels": "소포 편집",
-    "empty_estate": "부동산 {name}이 삭제되었습니다.",
+    "empty_estate": "부동산 {name}가 해체되었습니다.",
     "parcels": "소포 포함",
     "pending_tx": "이 재산"
   },
@@ -363,9 +363,9 @@
     "claim_mortgage_resolution": "당신은 {parcel_link}을 주장했습니다.",
     "create_estate": "부동산 {name}을 만들었습니다.",
     "create_mortgage": "소포 {parcel_link}을 사기 위해 모기지를 요청했습니다.",
-    "delete_estate": "부동산 {name}을 삭제했습니다.",
     "disapproved":
       "귀하를 대신하여 {marketplace_contract_link}의 MANA 운영을 허가받지 않았습니다.",
+    "dissolve_estate": "너는 재산을 해산했다. {name}",
     "edit":
       "{parcel_link}을(를) \"{name}\" 이름 및 설명 \"{description}\" (으)로 수정했습니다.",
     "edit_estate_metadata":

--- a/src/Translation/locales/ko.json
+++ b/src/Translation/locales/ko.json
@@ -59,6 +59,7 @@
     "delete": "재산 삭제",
     "delete_desc": "당신은 부동산 {name}을 삭제하려고합니다.",
     "edit_parcels": "소포 편집",
+    "empty_estate": "부동산 {name}이 삭제되었습니다.",
     "parcels": "소포 포함",
     "pending_tx": "이 재산"
   },

--- a/src/Translation/locales/zh.json
+++ b/src/Translation/locales/zh.json
@@ -54,10 +54,10 @@
       "您为钱包设置了错误的派生路径。 您的派生路径必须遵循模式 44'/60|61'/x'/n"
   },
   "estate_detail": {
-    "delete": "删除地产",
-    "delete_desc": "您要删除地产{name}",
+    "dissolve": "解散遗产",
+    "dissolve_desc": "你将解散庄园{name}",
     "edit_parcels": "编辑地块",
-    "empty_estate": "庄园{name}已被删除",
+    "empty_estate": "庄园{name}已经解散",
     "parcels": "包括地块",
     "pending_tx": "地产"
   },
@@ -346,8 +346,8 @@
     "claim_mortgage_resolution": "您认领了 {parcel_link}",
     "create_estate": "您创建了地产 {name}",
     "create_mortgage": "您要求抵押以购买地块 {parcel_link}",
-    "delete_estate": "您删除了地产{name}",
     "disapproved": "您未授权{marketplace_contract_link}以您的名义操作 MANA",
+    "dissolve_estate": "你解散了庄园{name}",
     "edit": "您编辑了{parcel_link}地块的名称\"{name}\"和描述\"{description}\"",
     "edit_estate_metadata":
       "您编辑了地产{estate_id}，名称为“{name}”，描述为“{description}”",

--- a/src/Translation/locales/zh.json
+++ b/src/Translation/locales/zh.json
@@ -50,12 +50,14 @@
     "proposal": "提案"
   },
   "derivation_path": {
-    "invalid": "您为钱包设置了错误的派生路径。 您的派生路径必须遵循模式 44'/60|61'/x'/n"
+    "invalid":
+      "您为钱包设置了错误的派生路径。 您的派生路径必须遵循模式 44'/60|61'/x'/n"
   },
   "estate_detail": {
     "delete": "删除地产",
     "delete_desc": "您要删除地产{name}",
     "edit_parcels": "编辑地块",
+    "empty_estate": "庄园{name}已被删除",
     "parcels": "包括地块",
     "pending_tx": "地产"
   },
@@ -192,12 +194,15 @@
     "payable": "应付",
     "payable_placeholder": "应付天数",
     "pending_tx": "按揭",
-    "please_authorize_MANA": "请转到{settings_link}并授权Mortgage Helper合同代表您运营MANA",
-    "please_authorize_RCN": "请转到{settings_link}并授权抵押贷款经理合同代表您运营RCN",
+    "please_authorize_MANA":
+      "请转到{settings_link}并授权Mortgage Helper合同代表您运营MANA",
+    "please_authorize_RCN":
+      "请转到{settings_link}并授权抵押贷款经理合同代表您运营RCN",
     "punitory_rate": "惩罚性利率",
     "punitory_rate_placeholder": "惩罚性利率",
     "request": "申请抵押",
-    "request_land": "您将为 {parcel_name} 地块以 {parcel_price} 的价格申请抵押贷款",
+    "request_land":
+      "您将为 {parcel_name} 地块以 {parcel_price} 的价格申请抵押贷款",
     "requested": "已申请"
   },
   "parcel": {
@@ -279,7 +284,8 @@
     "expiration": "到期时间",
     "expiration_placeholder": "待售截止日期",
     "list_land": "地块上架出售",
-    "please_authorize": "您需要在设置页面{settings_link}授权委托虚拟市场以您的名义操作土地交易，然后才能将其上架出售。",
+    "please_authorize":
+      "您需要在设置页面{settings_link}授权委托虚拟市场以您的名义操作土地交易，然后才能将其上架出售。",
     "price": "价格",
     "price_placeholder": "此地块的 MANA 价格",
     "set_land_price": "为 {parcel_name} 设置价格和截止日期"
@@ -314,8 +320,10 @@
     "mortgage_manager_contract": "抵押管理合约",
     "pending_tx": "您有待处理的交易",
     "unauthorize_land_check": "取消勾选取消授权市场合约使用虚拟土地",
-    "you_approved_mortgage_mana": "您已授权{mortgage_contract_link}代表您操作 MANA",
-    "you_approved_mortgage_rcn": "您已授权{mortgage_contract_link}代表您运营 RCN",
+    "you_approved_mortgage_mana":
+      "您已授权{mortgage_contract_link}代表您操作 MANA",
+    "you_approved_mortgage_rcn":
+      "您已授权{mortgage_contract_link}代表您运营 RCN",
     "you_authorized": "您已授权{marketplace_contract_link}以您的名义操作土地"
   },
   "sign_in": {
@@ -323,7 +331,8 @@
     "get_started": "开始使用",
     "intro": "首先，您需要一个安全的地方来保存所有的LAND。",
     "options": {
-      "desktop": "您可以使用{metamask_link}扩展名或像{ledger_nano_link}这样的硬件钱包。",
+      "desktop":
+        "您可以使用{metamask_link}扩展名或像{ledger_nano_link}这样的硬件钱包。",
       "mobile": "您可以使用移动浏览器，如{toshi_link}或{imtoken_link}。"
     }
   },
@@ -340,7 +349,8 @@
     "delete_estate": "您删除了地产{name}",
     "disapproved": "您未授权{marketplace_contract_link}以您的名义操作 MANA",
     "edit": "您编辑了{parcel_link}地块的名称\"{name}\"和描述\"{description}\"",
-    "edit_estate_metadata": "您编辑了地产{estate_id}，名称为“{name}”，描述为“{description}”",
+    "edit_estate_metadata":
+      "您编辑了地产{estate_id}，名称为“{name}”，描述为“{description}”",
     "edit_estate_parcels_added": "您将 {amount} 地块添加到地产 {name}",
     "edit_estate_parcels_removed": "您从地产 {name} 中删除了 {amount} 地块",
     "manage": "您授权{address_link}更新{parcel_link}上的内容",
@@ -357,7 +367,8 @@
       "please_confirm": "请确认交易"
     },
     "parcel": {
-      "still_pending": "{parcel_name} 仍然有 {transactions_count} 个待处理的交易。"
+      "still_pending":
+        "{parcel_name} 仍然有 {transactions_count} 个待处理的交易。"
     },
     "see_activity": "要查看您的交易记录，请访问 {activity_link}。",
     "text": {

--- a/webapp/src/components/ActivityPage/Transaction/Transaction.js
+++ b/webapp/src/components/ActivityPage/Transaction/Transaction.js
@@ -285,7 +285,7 @@ export default class Transaction extends React.PureComponent {
       }
       case DELETE_ESTATE_SUCCESS: {
         const { estate } = payload
-        return t_html('transaction.delete_estate', {
+        return t_html('transaction.dissolve_estate', {
           name: estate.data.name
         })
       }

--- a/webapp/src/components/Asset/Asset.js
+++ b/webapp/src/components/Asset/Asset.js
@@ -48,8 +48,7 @@ export default class Asset extends React.PureComponent {
       ownerOnly,
       wallet,
       ownerNotAllowed,
-      withPublications,
-      onAccessDenied
+      withPublications
     } = nextProps
 
     const ownerIsNotAllowed =
@@ -65,8 +64,19 @@ export default class Asset extends React.PureComponent {
     }
 
     if (ownerIsNotAllowed || assetShouldBeOnSale) {
-      return onAccessDenied()
+      this.redirect()
+      return
     }
+
+    if (!value) {
+      this.redirect()
+    }
+  }
+
+  redirect() {
+    const { onAccessDenied } = this.props
+    this.isNavigatingAway = true
+    onAccessDenied()
   }
 
   checkOwnership(wallet, assetId) {

--- a/webapp/src/components/DeleteEstatePage/DeleteEstatePage.js
+++ b/webapp/src/components/DeleteEstatePage/DeleteEstatePage.js
@@ -22,8 +22,8 @@ export default class DeleteEstatePage extends React.PureComponent {
             <EstateModal
               estate={estate}
               parcels={estate.data.parcels}
-              title={t('estate_detail.delete')}
-              subtitle={t('estate_detail.delete_desc', {
+              title={t('estate_detail.dissolve')}
+              subtitle={t('estate_detail.dissolve_desc', {
                 name: estate.data.name
               })}
               isTxIdle={isTxIdle}

--- a/webapp/src/components/Estate/Estate.container.js
+++ b/webapp/src/components/Estate/Estate.container.js
@@ -23,7 +23,7 @@ const mapState = (state, { assetId, x, y }) => {
 
 const mapDispatch = (dispatch, { assetId }) => ({
   onLoaded: () => assetId && dispatch(fetchEstateRequest(assetId)),
-  onAccessDenied: () => dispatch(push(locations.estateDetail(assetId)))
+  onAccessDenied: () => dispatch(push(locations.marketplace))
 })
 
 export default connect(mapState, mapDispatch)(Estate)

--- a/webapp/src/components/EstateDetailPage/EstateDetail.css
+++ b/webapp/src/components/EstateDetailPage/EstateDetail.css
@@ -77,3 +77,13 @@
   margin-bottom: 0;
   margin-right: 25px;
 }
+
+.EstateDetail.empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.EstateDetail.empty .empty-estate-message {
+  color: var(--gray);
+}

--- a/webapp/src/components/EstateDetailPage/EstateDetail.js
+++ b/webapp/src/components/EstateDetailPage/EstateDetail.js
@@ -24,6 +24,19 @@ export default class EstateDetail extends React.PureComponent {
     onEditMetadata: PropTypes.func.isRequired
   }
 
+  renderEmptyEstate() {
+    const { estate } = this.props
+    return (
+      <div className="EstateDetail empty">
+        <span className="empty-estate-message">
+          {t('estate_detail.empty_estate', {
+            name: estate.data.name
+          })}
+        </span>
+      </div>
+    )
+  }
+
   render() {
     const {
       estate,
@@ -34,6 +47,10 @@ export default class EstateDetail extends React.PureComponent {
       onEditMetadata
     } = this.props
     const { parcels } = estate.data
+
+    if (estate.data.parcels.length === 0) {
+      return this.renderEmptyEstate()
+    }
 
     return (
       <div className="EstateDetail">

--- a/webapp/src/components/EstateDetailPage/EstateDetailPage.js
+++ b/webapp/src/components/EstateDetailPage/EstateDetailPage.js
@@ -41,8 +41,7 @@ export default class EstateDetailPage extends React.PureComponent {
     return (
       <Estate assetId={assetId} x={x} y={y}>
         {(estate, isOwner, wallet) =>
-          estate.data.parcels.length > 0 &&
-          (isNewAsset(estate) || isEditing) ? (
+          isNewAsset(estate) || isEditing ? (
             <EditEstate
               estate={estate}
               isCreation={isNewAsset(estate)}

--- a/webapp/src/components/EstateDetailPage/EstateDetailPage.js
+++ b/webapp/src/components/EstateDetailPage/EstateDetailPage.js
@@ -41,27 +41,26 @@ export default class EstateDetailPage extends React.PureComponent {
     return (
       <Estate assetId={assetId} x={x} y={y}>
         {(estate, isOwner, wallet) =>
-          estate.data.parcels.length ? (
-            isNewAsset(estate) || isEditing ? (
-              <EditEstate
-                estate={estate}
-                isCreation={isNewAsset(estate)}
-                isOwner={isOwner}
-                wallet={wallet}
-                onViewAssetClick={onViewAssetClick}
-                isSelecting={isNewAsset(estate) || isSelecting}
-              />
-            ) : (
-              <EstateDetail
-                allParcels={allParcels}
-                estate={estate}
-                isOwner={isOwner}
-                onViewAssetClick={onViewAssetClick}
-                onEditParcels={onEditParcels}
-                onEditMetadata={onEditMetadata}
-              />
-            )
-          ) : null
+          estate.data.parcels.length > 0 &&
+          (isNewAsset(estate) || isEditing) ? (
+            <EditEstate
+              estate={estate}
+              isCreation={isNewAsset(estate)}
+              isOwner={isOwner}
+              wallet={wallet}
+              onViewAssetClick={onViewAssetClick}
+              isSelecting={isNewAsset(estate) || isSelecting}
+            />
+          ) : (
+            <EstateDetail
+              allParcels={allParcels}
+              estate={estate}
+              isOwner={isOwner}
+              onViewAssetClick={onViewAssetClick}
+              onEditParcels={onEditParcels}
+              onEditMetadata={onEditMetadata}
+            />
+          )
         }
       </Estate>
     )

--- a/webapp/src/components/EstateDetailPage/EstateSelect/EstateSelect.js
+++ b/webapp/src/components/EstateDetailPage/EstateSelect/EstateSelect.js
@@ -178,7 +178,7 @@ export default class EstateSelect extends React.PureComponent {
                       onClick={onDeleteEstate}
                     >
                       <Icon name="trash" />
-                      {t('estate_detail.delete')}{' '}
+                      {t('estate_detail.dissolve')}{' '}
                     </Button>
                   </Grid.Column>
                 )}


### PR DESCRIPTION
Closes #384 

Currently empty (aka deleted) estates show a broken page (only navbar and footer, and footer is _en cualquiera_)

This PR adds a screen for empty estates:

<img width="1440" alt="screen shot 2018-08-28 at 4 15 48 pm" src="https://user-images.githubusercontent.com/2781777/44745374-f03faf80-aadd-11e8-85fe-f40c14cccbc6.png">
