### PR TITLE
fix: show adjacent estates separated

### DIFF
--- a/shared/parcel.js
+++ b/shared/parcel.js
@@ -80,15 +80,13 @@ export function areConnected(parcels, parcelId, sideId) {
     return false
   }
 
-  const sameDistrict = parcel.district_id === sideParcel.district_id
-  if (parcel.district_id && sameDistrict) {
+  const isSameDistrict = parcel.district_id === sideParcel.district_id
+  if (parcel.district_id && isSameDistrict) {
     return true
   }
-  const sameEstate = parcel.estate_id === sideParcel.estate_id
-  if (parcel.estate_id && sameEstate) {
-    return true
-  }
-  return false
+
+  const isSameEstate = parcel.estate_id === sideParcel.estate_id
+  return parcel.estate_id && isSameEstate
 }
 
 export function isSameValue(parcelA, parcelB, prop) {

--- a/shared/parcel.js
+++ b/shared/parcel.js
@@ -84,8 +84,11 @@ export function areConnected(parcels, parcelId, sideId) {
   if (parcel.district_id && sameDistrict) {
     return true
   }
-  const sameOwner = parcel.owner === sideParcel.owner
-  return parcel.estate_id && parcel.owner && sameOwner
+  const sameEstate = parcel.estate_id === sideParcel.estate_id
+  if (parcel.estate_id && sameEstate) {
+    return true
+  }
+  return false
 }
 
 export function isSameValue(parcelA, parcelB, prop) {


### PR DESCRIPTION
Closes #388

Adjacent estates from different owners were shown as one single estate:

![different-estates](https://user-images.githubusercontent.com/2781777/44747389-70b4df00-aae3-11e8-807c-3271515c6dcd.gif)

This PR fixes that:

<img width="173" alt="screen shot 2018-08-28 at 4 57 57 pm" src="https://user-images.githubusercontent.com/2781777/44747461-a1951400-aae3-11e8-9cfb-fa2356631517.png">


