### PR TITLE
feat: limit maximum parcels per transaction

### DIFF
--- a/shared/estate.js
+++ b/shared/estate.js
@@ -1,3 +1,5 @@
+export const MAX_PARCELS_PER_TX = 12
+
 export function isEstate(asset) {
   return !!asset.data.parcels
 }

--- a/src/Translation/locales/en.json
+++ b/src/Translation/locales/en.json
@@ -59,6 +59,9 @@
     "dissolve_desc": "You are going to dissolve the estate {name}",
     "edit_parcels": "Edit Parcels",
     "empty_estate": "The estate {name} has been dissolved",
+    "maximum_parcels_message":
+      "You can't send more than {max} parcels in a single transaction. You can submit this transaction and then add or remove more parcels in a subsequent transaction by editing the estate.",
+    "maximum_parcels_title": "Maximum parcels per transaction",
     "parcels": "Parcels included",
     "pending_tx": "This estate"
   },

--- a/src/Translation/locales/en.json
+++ b/src/Translation/locales/en.json
@@ -68,7 +68,7 @@
   "estate_dissolve": {
     "too_big": "This estate is too big",
     "too_big_desc":
-      "When an estate has over {max} parcels a transaction to dissolve may run out of gas. You should remove parcels by editing the estate and dissolve it when it has {max} parcels or less."
+      "When an estate has over {max} parcels a transaction to dissolve it may run out of gas. You should remove parcels by editing the estate and dissolve it when it has {max} parcels or less."
   },
   "estate_edit": {
     "description": "Description",

--- a/src/Translation/locales/en.json
+++ b/src/Translation/locales/en.json
@@ -60,10 +60,15 @@
     "edit_parcels": "Edit Parcels",
     "empty_estate": "The estate {name} has been dissolved",
     "maximum_parcels_message":
-      "You can't send more than {max} parcels in a single transaction. You can submit this transaction and then add or remove more parcels in a subsequent transaction by editing the estate.",
-    "maximum_parcels_title": "Maximum parcels per transaction",
+      "If you add or removes more than {max} parcels in a single transaction it may run out of gas. You can submit this transaction and then add or remove more parcels in a subsequent transaction by editing the estate.",
+    "maximum_parcels_title": "You reached the maximum parcels per transaction",
     "parcels": "Parcels included",
     "pending_tx": "This estate"
+  },
+  "estate_dissolve": {
+    "too_big": "This estate is too big",
+    "too_big_desc":
+      "When an estate has over {max} parcels a transaction to dissolve may run out of gas. You should remove parcels by editing the estate and dissolve it when it has {max} parcels or less."
   },
   "estate_edit": {
     "description": "Description",

--- a/src/Translation/locales/es.json
+++ b/src/Translation/locales/es.json
@@ -59,8 +59,16 @@
     "dissolve_desc": "Vas a disolver la propiedad {name}",
     "edit_parcels": "Editar paquetes",
     "empty_estate": "La propiedad {name} ha sido disuelta",
+    "maximum_parcels_message":
+      "Si agrega o elimina más de {max} parcelas en una sola transacción, puede quedarse sin gas. Puedes enviar esta transacción y luego agregar o quitar más parcelas en otra transacción editando la propiedad",
+    "maximum_parcels_title": "Alcanzaste el máximo de parcelas por transacción",
     "parcels": "Parcelas incluidas",
     "pending_tx": "Esta propiedad"
+  },
+  "estate_dissolve": {
+    "too_big": "Esta propiedad es demasiado grande",
+    "too_big_desc":
+      "Cuando una propiedad tiene más de {max} parcelas, una transacción para disolverlo puede quedarse sin gas. Debes remover parcelas primero editando la propiedad y disolverla cuando tenga {max} parcelas o menos."
   },
   "estate_edit": {
     "description": "Descripción",

--- a/src/Translation/locales/fr.json
+++ b/src/Translation/locales/fr.json
@@ -59,7 +59,13 @@
     "dissolve": "Dissoudre le domaine",
     "dissolve_desc": "Vous allez dissoudre le domaine {name}",
     "edit_parcels": "Modifier les colis",
+<<<<<<< HEAD
     "empty_estate": "Le domaine {name} a été dissous",
+=======
+    "maximum_parcels_message":
+      "Vous ne pouvez pas envoyer plus de colis {max} en une seule transaction. ",
+    "maximum_parcels_title": "Maximum de colis par transaction",
+>>>>>>> feat: limit maximum parcels per transaction
     "parcels": "Colis inclus",
     "pending_tx": "Ce domaine"
   },

--- a/src/Translation/locales/fr.json
+++ b/src/Translation/locales/fr.json
@@ -59,15 +59,18 @@
     "dissolve": "Dissoudre le domaine",
     "dissolve_desc": "Vous allez dissoudre le domaine {name}",
     "edit_parcels": "Modifier les colis",
-<<<<<<< HEAD
     "empty_estate": "Le domaine {name} a été dissous",
-=======
     "maximum_parcels_message":
-      "Vous ne pouvez pas envoyer plus de colis {max} en une seule transaction. ",
-    "maximum_parcels_title": "Maximum de colis par transaction",
->>>>>>> feat: limit maximum parcels per transaction
+      "Si vous ajoutez ou supprimez plus de paquets {max} en une seule transaction, vous risquez de manquer d'essence. ",
+    "maximum_parcels_title":
+      "Vous avez atteint le maximum de colis par transaction",
     "parcels": "Colis inclus",
     "pending_tx": "Ce domaine"
+  },
+  "estate_dissolve": {
+    "too_big": "Ce domaine est trop grand",
+    "too_big_desc":
+      "Lorsqu'une succession a plus de {max} colis, une transaction à dissoudre peut manquer d'essence. "
   },
   "estate_edit": {
     "description": "La description",

--- a/src/Translation/locales/ja.json
+++ b/src/Translation/locales/ja.json
@@ -58,7 +58,13 @@
     "dissolve": "ディゾルブエステート",
     "dissolve_desc": "あなたは不動産{name}を解散するつもりです",
     "edit_parcels": "パーセルの編集",
+<<<<<<< HEAD
     "empty_estate": "不動産{name}が解散しました",
+=======
+    "maximum_parcels_message":
+      "単一のトランザクションでは、{max}個以上の小包を送ることはできません。",
+    "maximum_parcels_title": "トランザクションあたりの最大パーセル",
+>>>>>>> feat: limit maximum parcels per transaction
     "parcels": "パーセルを含む",
     "pending_tx": "この不動産"
   },

--- a/src/Translation/locales/ja.json
+++ b/src/Translation/locales/ja.json
@@ -58,15 +58,18 @@
     "dissolve": "ディゾルブエステート",
     "dissolve_desc": "あなたは不動産{name}を解散するつもりです",
     "edit_parcels": "パーセルの編集",
-<<<<<<< HEAD
     "empty_estate": "不動産{name}が解散しました",
-=======
     "maximum_parcels_message":
-      "単一のトランザクションでは、{max}個以上の小包を送ることはできません。",
-    "maximum_parcels_title": "トランザクションあたりの最大パーセル",
->>>>>>> feat: limit maximum parcels per transaction
+      "1回のトランザクションで{max}パーセルを追加または削除すると、ガスがなくなる可能性があります。",
+    "maximum_parcels_title":
+      "あなたはトランザクションごとに最大の小包に達しました",
     "parcels": "パーセルを含む",
     "pending_tx": "この不動産"
+  },
+  "estate_dissolve": {
+    "too_big": "この不動産は大きすぎます",
+    "too_big_desc":
+      "不動産が{max}小包を超過すると、解散する取引にガスがなくなる可能性があります。"
   },
   "estate_edit": {
     "description": "説明",

--- a/src/Translation/locales/ko.json
+++ b/src/Translation/locales/ko.json
@@ -59,15 +59,17 @@
     "dissolve": "부동산 디졸브",
     "dissolve_desc": "당신은 부동산 {name}을 해산하려고합니다.",
     "edit_parcels": "소포 편집",
-<<<<<<< HEAD
     "empty_estate": "부동산 {name}가 해체되었습니다.",
-=======
     "maximum_parcels_message":
-      "단일 트랜잭션에서 {max} 소포를 초과하여 보낼 수 없습니다. ",
-    "maximum_parcels_title": "거래 당 최대 소포",
->>>>>>> feat: limit maximum parcels per transaction
+      "단일 트랜잭션에서 {max} 개 이상의 소포를 추가하거나 제거하면 가스가 고갈 될 수 있습니다. ",
+    "maximum_parcels_title": "거래 당 최대 소포에 도달했습니다.",
     "parcels": "소포 포함",
     "pending_tx": "이 재산"
+  },
+  "estate_dissolve": {
+    "too_big": "이 부동산은 너무 큽니다.",
+    "too_big_desc":
+      "토지가 {max} 소포를 초과하면 해산 될 거래에 가스가 부족할 수 있습니다. "
   },
   "estate_edit": {
     "description": "기술",

--- a/src/Translation/locales/ko.json
+++ b/src/Translation/locales/ko.json
@@ -59,7 +59,13 @@
     "dissolve": "부동산 디졸브",
     "dissolve_desc": "당신은 부동산 {name}을 해산하려고합니다.",
     "edit_parcels": "소포 편집",
+<<<<<<< HEAD
     "empty_estate": "부동산 {name}가 해체되었습니다.",
+=======
+    "maximum_parcels_message":
+      "단일 트랜잭션에서 {max} 소포를 초과하여 보낼 수 없습니다. ",
+    "maximum_parcels_title": "거래 당 최대 소포",
+>>>>>>> feat: limit maximum parcels per transaction
     "parcels": "소포 포함",
     "pending_tx": "이 재산"
   },

--- a/src/Translation/locales/zh.json
+++ b/src/Translation/locales/zh.json
@@ -57,7 +57,12 @@
     "dissolve": "解散遗产",
     "dissolve_desc": "你将解散庄园{name}",
     "edit_parcels": "编辑地块",
+<<<<<<< HEAD
     "empty_estate": "庄园{name}已经解散",
+=======
+    "maximum_parcels_message": "您不能在单个交易中发送超过{max}的包裹。",
+    "maximum_parcels_title": "每笔交易的最大包裹数",
+>>>>>>> feat: limit maximum parcels per transaction
     "parcels": "包括地块",
     "pending_tx": "地产"
   },

--- a/src/Translation/locales/zh.json
+++ b/src/Translation/locales/zh.json
@@ -57,14 +57,16 @@
     "dissolve": "解散遗产",
     "dissolve_desc": "你将解散庄园{name}",
     "edit_parcels": "编辑地块",
-<<<<<<< HEAD
     "empty_estate": "庄园{name}已经解散",
-=======
-    "maximum_parcels_message": "您不能在单个交易中发送超过{max}的包裹。",
-    "maximum_parcels_title": "每笔交易的最大包裹数",
->>>>>>> feat: limit maximum parcels per transaction
+    "maximum_parcels_message":
+      "如果您在单个交易中添加或删除超过{max}的包裹，则可能会耗尽燃气。",
+    "maximum_parcels_title": "您达到了每笔交易的最大包裹数",
     "parcels": "包括地块",
     "pending_tx": "地产"
+  },
+  "estate_dissolve": {
+    "too_big": "这个庄园太大了",
+    "too_big_desc": "如果遗产超过{max}包裹，则解散的交易可能会耗尽燃气。"
   },
   "estate_edit": {
     "description": "描述",

--- a/webapp/src/components/DeleteEstatePage/DeleteEstatePage.js
+++ b/webapp/src/components/DeleteEstatePage/DeleteEstatePage.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-
+import { Container, Message } from 'semantic-ui-react'
 import EstateModal from 'components/EstateDetailPage/EditEstateMetadata/EstateModal'
 import Estate from 'components/Estate'
 import { isNewAsset } from 'shared/asset'
+import { MAX_PARCELS_PER_TX } from 'shared/estate'
 import { t } from 'modules/translation/utils'
 
 export default class DeleteEstatePage extends React.PureComponent {
@@ -13,27 +14,43 @@ export default class DeleteEstatePage extends React.PureComponent {
     onCancel: PropTypes.func.isRequired,
     onConfirm: PropTypes.func.isRequired
   }
+
+  isTooBig(estate) {
+    return estate.data.parcels.length > MAX_PARCELS_PER_TX
+  }
   render() {
     const { assetId, isTxIdle, onCancel, onConfirm } = this.props
     return (
-      <Estate assetId={assetId} ownerOnly>
-        {estate => (
-          <React.Fragment>
-            <EstateModal
-              estate={estate}
-              parcels={estate.data.parcels}
-              title={t('estate_detail.dissolve')}
-              subtitle={t('estate_detail.dissolve_desc', {
-                name: estate.data.name
-              })}
-              isTxIdle={isTxIdle}
-              onCancel={onCancel}
-              onConfirm={onConfirm}
-              isDisabled={isNewAsset(estate)}
-            />
-          </React.Fragment>
-        )}
-      </Estate>
+      <Container className="DeleteEstatePage">
+        <Estate assetId={assetId} ownerOnly>
+          {estate => (
+            <React.Fragment>
+              {this.isTooBig(estate) ? (
+                <Message
+                  warning
+                  icon="warning sign"
+                  header={t('estate_dissolve.too_big')}
+                  content={t('estate_dissolve.too_big_desc', {
+                    max: MAX_PARCELS_PER_TX
+                  })}
+                />
+              ) : null}
+              <EstateModal
+                estate={estate}
+                parcels={estate.data.parcels}
+                title={t('estate_detail.dissolve')}
+                subtitle={t('estate_detail.dissolve_desc', {
+                  name: estate.data.name
+                })}
+                isTxIdle={isTxIdle}
+                onCancel={onCancel}
+                onConfirm={onConfirm}
+                isDisabled={isNewAsset(estate) || this.isTooBig(estate)}
+              />
+            </React.Fragment>
+          )}
+        </Estate>
+      </Container>
     )
   }
 }

--- a/webapp/src/components/EstateDetailPage/EstateSelect/EstateSelect.js
+++ b/webapp/src/components/EstateDetailPage/EstateSelect/EstateSelect.js
@@ -16,11 +16,14 @@ import { t } from 'modules/translation/utils'
 import { parcelType, estateType } from 'components/types'
 import { getCoordsMatcher, isEqualCoords, buildCoordinate } from 'shared/parcel'
 import { isOwner } from 'shared/asset'
-import { hasNeighbour, areConnected, isEstate } from 'shared/estate'
+import {
+  hasNeighbour,
+  areConnected,
+  isEstate,
+  MAX_PARCELS_PER_TX
+} from 'shared/estate'
 import { getParcelsNotIncluded } from 'shared/utils'
 import './EstateSelect.css'
-
-const MAX_PARCELS_PER_TX = 12
 
 export default class EstateSelect extends React.PureComponent {
   static propTypes = {
@@ -93,7 +96,7 @@ export default class EstateSelect extends React.PureComponent {
       return false
     }
 
-    const pristineParcels = estatePristine.data.parcels
+    const pristineParcels = estatePristine ? estatePristine.data.parcels : []
 
     if (pristineParcels.length != parcels.length) {
       return true
@@ -112,14 +115,14 @@ export default class EstateSelect extends React.PureComponent {
   getParcelsToAdd() {
     const { estate, estatePristine } = this.props
     const newParcels = estate.data.parcels
-    const pristineParcels = estatePristine.data.parcels
+    const pristineParcels = estatePristine ? estatePristine.data.parcels : []
     return getParcelsNotIncluded(newParcels, pristineParcels)
   }
 
   getParcelsToRemove() {
     const { estate, estatePristine } = this.props
     const newParcels = estate.data.parcels
-    const pristineParcels = estatePristine.data.parcels
+    const pristineParcels = estatePristine ? estatePristine.data.parcels : []
     return getParcelsNotIncluded(pristineParcels, newParcels)
   }
 

--- a/webapp/src/components/EstateDetailPage/EstateSelect/EstateSelect.js
+++ b/webapp/src/components/EstateDetailPage/EstateSelect/EstateSelect.js
@@ -60,12 +60,11 @@ export default class EstateSelect extends React.PureComponent {
       return
     }
 
-    if (this.hasReachedTransactionLimit()) {
-      return
-    }
-
     const isSelected = parcels.some(getCoordsMatcher({ x, y }))
     if (isSelected) {
+      if (this.hasReachedRemoveLimit()) {
+        return
+      }
       const newParcels = parcels.filter(
         coords => !isEqualCoords(coords, { x, y })
       )
@@ -73,6 +72,10 @@ export default class EstateSelect extends React.PureComponent {
         return
       }
       return onChange(newParcels)
+    }
+
+    if (this.hasReachedAddLimit()) {
+      return
     }
 
     onChange([...parcels, { x, y }])
@@ -126,13 +129,14 @@ export default class EstateSelect extends React.PureComponent {
     return getParcelsNotIncluded(pristineParcels, newParcels)
   }
 
-  hasReachedTransactionLimit() {
+  hasReachedAddLimit() {
     const parcelsToAdd = this.getParcelsToAdd()
+    return parcelsToAdd.length >= MAX_PARCELS_PER_TX
+  }
+
+  hasReachedRemoveLimit() {
     const parcelsToRemove = this.getParcelsToRemove()
-    return (
-      parcelsToAdd.length >= MAX_PARCELS_PER_TX ||
-      parcelsToRemove.length >= MAX_PARCELS_PER_TX
-    )
+    return parcelsToRemove.length >= MAX_PARCELS_PER_TX
   }
 
   renderTxLabel = () => {
@@ -191,7 +195,7 @@ export default class EstateSelect extends React.PureComponent {
         </div>
         <Container>
           <Grid className="estate-selection">
-            {this.hasReachedTransactionLimit() ? (
+            {this.hasReachedAddLimit() || this.hasReachedRemoveLimit() ? (
               <Grid.Row>
                 <Grid.Column width={16}>
                   <Message

--- a/webapp/src/components/EstateDetailPage/EstateSelect/EstateSelect.js
+++ b/webapp/src/components/EstateDetailPage/EstateSelect/EstateSelect.js
@@ -113,16 +113,14 @@ export default class EstateSelect extends React.PureComponent {
     const { estate, estatePristine } = this.props
     const newParcels = estate.data.parcels
     const pristineParcels = estatePristine.data.parcels
-    const parcelsToAdd = getParcelsNotIncluded(newParcels, pristineParcels)
-    return parcelsToAdd
+    return getParcelsNotIncluded(newParcels, pristineParcels)
   }
 
   getParcelsToRemove() {
     const { estate, estatePristine } = this.props
     const newParcels = estate.data.parcels
     const pristineParcels = estatePristine.data.parcels
-    const parcelsToRemove = getParcelsNotIncluded(pristineParcels, newParcels)
-    return parcelsToRemove
+    return getParcelsNotIncluded(pristineParcels, newParcels)
   }
 
   hasReachedTransactionLimit() {


### PR DESCRIPTION
Closes #385 

This shows a warning if a single transaction reaches the limit of parcels, which is 12, ie: adding 12 parcels or removing 12 parcels. This doesn't mean 12 "modifications", because you can still add 10 parcels and remove 10 parcels in the same edition (since those are done in two different transactions).

This is an screenshot of how it looks like:

 
<img width="1241" alt="screen shot 2018-08-29 at 2 45 57 pm" src="https://user-images.githubusercontent.com/2781777/44805527-dca64e80-ab9a-11e8-80d2-959d6616cfb4.png">

This limit also applies when the user tries to dissolve an estate that is too big:

<img width="1437" alt="screen shot 2018-08-29 at 2 43 48 pm" src="https://user-images.githubusercontent.com/2781777/44805554-f21b7880-ab9a-11e8-9b4b-e4a13a029369.png">
