### PR TITLE
feat: migrate ls v2

### DIFF
--- a/webapp/src/modules/estates/actions.js
+++ b/webapp/src/modules/estates/actions.js
@@ -1,4 +1,7 @@
-import { buildTransactionAction } from 'modules/transaction/utils'
+import {
+  buildTransactionAction,
+  buildTransactionWithReceiptAction
+} from 'modules/transaction/utils'
 
 export const ADD_PARCELS = 'add'
 export const REMOVE_PARCELS = 'remove'
@@ -19,7 +22,7 @@ export function createEstateRequest(estate) {
 export function createEstateSuccess(txHash, estate) {
   return {
     type: CREATE_ESTATE_SUCCESS,
-    ...buildTransactionAction(txHash, {
+    ...buildTransactionWithReceiptAction(txHash, {
       estate,
       tx_hash: txHash
     }),

--- a/webapp/src/modules/estates/utils.js
+++ b/webapp/src/modules/estates/utils.js
@@ -25,8 +25,8 @@ export function validateCoords(x, y) {
   }
 }
 
-export function getEstateIdFromTxReceipt({ receipt }) {
-  const createEstateLog = receipt.logs.find(log => log.name === 'CreateEstate')
+export function getEstateIdFromTxReceipt({ logs }) {
+  const createEstateLog = logs.find(log => log.name === 'CreateEstate')
   const estateIdArg = createEstateLog.events.find(
     args => args.name === '_estateId'
   )

--- a/webapp/src/modules/transaction/sagas.js
+++ b/webapp/src/modules/transaction/sagas.js
@@ -37,7 +37,9 @@ function* handleTransactionRequest(action = {}) {
       fetchTransactionSuccess({
         ...transaction,
         status: TRANSACTION_STATUS.confirmed,
-        receipt
+        receipt: {
+          logs: transaction.withReceipt ? receipt.receipt.logs : []
+        }
       })
     )
   } catch (error) {

--- a/webapp/src/modules/transaction/utils.js
+++ b/webapp/src/modules/transaction/utils.js
@@ -28,10 +28,10 @@ export function buildTransactionWithReceiptAction(
   payload = {},
   events = []
 ) {
-  return {
-    ...buildTransactionAction(hash, payload, events),
-    withReceipt: true
-  }
+  const txAction = buildTransactionAction(hash, payload, events)
+  txAction[TRANSACTION_ACTION_FLAG].withReceipt = true
+
+  return txAction
 }
 
 export function isTransactionRejectedError(message) {

--- a/webapp/src/modules/transaction/utils.js
+++ b/webapp/src/modules/transaction/utils.js
@@ -23,6 +23,17 @@ export function buildTransactionAction(hash, payload = {}, events = []) {
   }
 }
 
+export function buildTransactionWithReceiptAction(
+  hash,
+  payload = {},
+  events = []
+) {
+  return {
+    ...buildTransactionAction(hash, payload, events),
+    withReceipt: true
+  }
+}
+
 export function isTransactionRejectedError(message) {
   // "Recommended" way to check for rejections
   // https://github.com/MetaMask/faq/issues/6#issuecomment-264900031


### PR DESCRIPTION
Remove `receipt` from old `transactions` and save `receipt` on demand. In this PR for `createEstate` action