### PR TITLE
chore: bump decentraland-dapps to v3.4.2

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -2951,9 +2951,9 @@
       }
     },
     "decentraland-dapps": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-3.4.0.tgz",
-      "integrity": "sha512-oKi9mC0qZuKGEJcF7onb6wvt4VfNXsQE5OD0XNbcS0O1Qty0yp87lKQCrQV/K3g5Hswo/kbs9lLest1E7T7GBw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-3.4.2.tgz",
+      "integrity": "sha512-w770MnOVwEaVZrWAWR8sAsrL9Ak+LO1SvNh5hLMgMygfjioKdUO84val4FBWesJOEweNDLr7F7N1DiGTeRhklQ==",
       "requires": {
         "@types/axios": "0.14.0",
         "@types/flat": "0.0.28",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -29,7 +29,7 @@
     "css-loader": "0.28.7",
     "date-fns": "^1.29.0",
     "decentraland-commons": "^4.0.1",
-    "decentraland-dapps": "^3.4.1",
+    "decentraland-dapps": "^3.4.2",
     "decentraland-eth": "^7.0.0",
     "decentraland-ui": "^1.10.0",
     "dotenv": "4.0.0",


### PR DESCRIPTION
Bumped `decentraland-dapps`. This fixes the bug that caused dropped transactions to be repeated in the app state.