### PR TITLE
fix: estate publications on map

### DIFF
--- a/webapp/src/lib/webworker/WebWorkerOnMessage.js
+++ b/webapp/src/lib/webworker/WebWorkerOnMessage.js
@@ -5,7 +5,20 @@ export function WebWorkerOnMessage(event) {
   let result = {}
 
   switch (action.type) {
-    case 'FETCH_MAP_REQUEST':
+    case 'FETCH_MAP_REQUEST': {
+      const { assets, allParcels } = action
+      const parcelObject = toParcelObject(assets.parcels, allParcels)
+      const estateObject = toEstateObject(assets.estates)
+      const parcelPublications = getAssetPublications(assets.parcels)
+      const estatePublications = getAssetPublications(assets.estates)
+
+      result = {
+        parcels: parcelObject,
+        estates: estateObject,
+        publications: parcelPublications.concat(estatePublications)
+      }
+      break
+    }
     case 'FETCH_ADDRESS_PARCELS_REQUEST': {
       const { parcels, allParcels } = action
       const parcelObject = toParcelObject(parcels, allParcels)
@@ -17,7 +30,7 @@ export function WebWorkerOnMessage(event) {
       break
     }
     case 'FETCH_ADDRESS_ESTATES_REQUEST': {
-      const { estates, allEstates } = action
+      const { estates } = action
       const estateObject = toEstateObject(estates)
       const publications = getAssetPublications(estates)
       result = {

--- a/webapp/src/modules/address/sagas.js
+++ b/webapp/src/modules/address/sagas.js
@@ -24,7 +24,6 @@ import {
 } from './actions'
 import { fetchMortgagedParcelsRequest } from 'modules/mortgage/actions'
 import { getData as getParcels } from 'modules/parcels/selectors'
-import { getData as getEstates } from 'modules/estates/selectors'
 import { api } from 'lib/api'
 import { webworker } from 'lib/webworker'
 
@@ -68,13 +67,11 @@ function* handleAddressEstatesRequest(action) {
   const { address } = action
   try {
     const estates = yield call(() => api.fetchAddressEstates(address))
-    const allEstates = yield select(getEstates)
 
     const result = yield call(() =>
       webworker.postMessage({
         type: 'FETCH_ADDRESS_ESTATES_REQUEST',
-        estates,
-        allEstates
+        estates
       })
     )
     yield put(

--- a/webapp/src/modules/estates/reducer.js
+++ b/webapp/src/modules/estates/reducer.js
@@ -121,12 +121,10 @@ export function estatesReducer(state = INITIAL_STATE, action) {
     case FETCH_MAP_SUCCESS: {
       return {
         ...state,
-        data: action.assets.estates.reduce(
-          (acc, estate) => {
-            return { ...acc, [estate.id]: normalizeEstate(estate) }
-          },
-          { ...state.data }
-        )
+        data: {
+          ...state.data,
+          ...action.assets.estates
+        }
       }
     }
     case FETCH_ADDRESS_ESTATES_SUCCESS: {

--- a/webapp/src/modules/map/sagas.js
+++ b/webapp/src/modules/map/sagas.js
@@ -14,16 +14,17 @@ function* handleMapRequest(action) {
     const nw = buildCoordinate(action.nw.x, action.nw.y)
     const se = buildCoordinate(action.se.x, action.se.y)
     const { assets } = yield call(() => api.fetchMapInRange(nw, se))
-    const stateParcels = yield select(getParcels)
+    const allParcels = yield select(getParcels)
 
     const result = yield call(() =>
       webworker.postMessage({
         type: 'FETCH_MAP_REQUEST',
-        parcels: assets.parcels,
-        allParcels: stateParcels
+        assets,
+        allParcels
       })
     )
     assets.parcels = result.parcels
+    assets.estates = result.estates
 
     yield put(fetchMapSuccess(assets, result.publications))
   } catch (error) {


### PR DESCRIPTION
This PR fixes a bug in the branch `fix/list-estates` that causes the publications of Estates fetched by the `FETCH_MAP_REQUEST` to be left out of the app state. This resulted in Estate publications not showing up in the Atlas or in the EstateDetail page.