### PR TITLE
fix: white line on footer

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -2,6 +2,10 @@
   box-sizing: border-box;
 }
 
+html {
+  background: var(--dark-background);
+}
+
 html,
 body {
   height: 100%;


### PR DESCRIPTION
Fixes #520 

Removes the whilte line that appears in the `/marketplace` page between the table and the footer

<img width="1440" alt="screen shot 2018-10-06 at 3 44 14 pm" src="https://user-images.githubusercontent.com/2781777/46574757-e16ed700-c97e-11e8-812f-c7a51934cfa9.png">
