### PR TITLE
fix: prevent showing the TxStatusAsset component when creating a new Estate

### DIFF
--- a/webapp/src/components/TxStatus/TxStatusAsset/utils.js
+++ b/webapp/src/components/TxStatus/TxStatusAsset/utils.js
@@ -8,5 +8,5 @@ export function isAssetPendingTransaction(asset, tx) {
     ? buildCoordinate(tx.payload.x, tx.payload.y)
     : tx.payload.id
 
-  return isPending(tx.status) && payloadAssetId === asset.id
+  return isPending(tx.status) && asset && payloadAssetId === asset.id
 }


### PR DESCRIPTION
Fixes #514 

When there's any pending transaction that is neither from a parcel nor an estate (ie authorizing the marketplace) the `payloadAssetId` in [this line](https://github.com/decentraland/marketplace/blob/master/webapp/src/components/TxStatus/TxStatusAsset/utils.js#L7) is `undefined`, and so is the `asset.id` from an Estate the the user is creating (since it hasn't been created yet it doesn't have an id). So [this condition](https://github.com/decentraland/marketplace/blob/master/webapp/src/components/TxStatus/TxStatusAsset/utils.js#L11) end up being `undefined === undefined` triggering the warning message.

This PR fixes that.