### PR TITLE
fix: prevent estates from being zoomed in

### DIFF
--- a/shared/estate.js
+++ b/shared/estate.js
@@ -1,6 +1,7 @@
 import { getParcelMatcher } from './parcel'
 
 export const MAX_PARCELS_PER_TX = 12
+export const ZOOM_MULTIPLIER = 7.5
 
 export function isNewEstate(estate) {
   return !estate || !estate.id
@@ -37,7 +38,7 @@ export function calculateMapProps(parcels, size = 20) {
   const x = xs[parseInt(xs.length / 2, 10)]
   const y = ys[parseInt(ys.length / 2, 10)]
   const center = { x, y }
-  const huge = 1 / (xs.length + ys.length) * 7.5 // only used for big ass estates
+  const huge = 1 / (xs.length + ys.length) * ZOOM_MULTIPLIER // only used for big ass estates
   const normal = (xs.length + ys.length) / (xs.length * ys.length) // used for regular estates
   const zoom = Math.min(1, huge, normal) // prevent zoomin in
   const pan = {

--- a/shared/estate.js
+++ b/shared/estate.js
@@ -37,7 +37,9 @@ export function calculateMapProps(parcels, size = 20) {
   const x = xs[parseInt(xs.length / 2, 10)]
   const y = ys[parseInt(ys.length / 2, 10)]
   const center = { x, y }
-  const zoom = 1 / (xs.length + ys.length) * 7.5
+  const huge = 1 / (xs.length + ys.length) * 7.5 // only used for big ass estates
+  const normal = (xs.length + ys.length) / (xs.length * ys.length) // used for regular estates
+  const zoom = Math.min(1, huge, normal) // prevent zoomin in
   const pan = {
     x: xs.length % 2 === 0 ? size / 2 * zoom : 0,
     y: ys.length % 2 === 0 ? -size / 2 * zoom : 0

--- a/webapp/src/components/ActivityPage/Transaction/Transaction.js
+++ b/webapp/src/components/ActivityPage/Transaction/Transaction.js
@@ -48,6 +48,10 @@ import { hasEtherscanLink, getHash } from '../utils'
 import './Transaction.css'
 import Status from './Status'
 
+const PREVIEW_SIZE = 48
+const NUM_PARCELS = 5
+const PARCEL_SIZE = PREVIEW_SIZE / NUM_PARCELS
+
 export default class Transaction extends React.PureComponent {
   static propTypes = {
     tx: transactionType,
@@ -351,9 +355,11 @@ export default class Transaction extends React.PureComponent {
   }
 
   renderEstatePreview(tx) {
-    const size = 9.6
     const { estate } = tx.payload
-    const { center, zoom, pan } = calculateMapProps(estate.data.parcels, size)
+    const { center, zoom, pan } = calculateMapProps(
+      estate.data.parcels,
+      PARCEL_SIZE
+    )
     const { x, y } = center
 
     return (
@@ -368,9 +374,9 @@ export default class Transaction extends React.PureComponent {
           x={x}
           y={y}
           zoom={zoom}
-          width={48}
-          height={48}
-          size={size}
+          width={PREVIEW_SIZE}
+          height={PREVIEW_SIZE}
+          size={PARCEL_SIZE}
           panX={pan.x}
           panY={pan.y}
           selected={estate.data.parcels}
@@ -386,9 +392,9 @@ export default class Transaction extends React.PureComponent {
         <ParcelPreview
           x={x}
           y={y}
-          width={48}
-          height={48}
-          size={9.6}
+          width={PREVIEW_SIZE}
+          height={PREVIEW_SIZE}
+          size={PARCEL_SIZE}
           selected={{ x, y }}
         />
       </Link>

--- a/webapp/src/components/ActivityPage/Transaction/Transaction.js
+++ b/webapp/src/components/ActivityPage/Transaction/Transaction.js
@@ -351,7 +351,7 @@ export default class Transaction extends React.PureComponent {
   }
 
   renderEstatePreview(tx) {
-    const size = 5
+    const size = 9.6
     const { estate } = tx.payload
     const { center, zoom, pan } = calculateMapProps(estate.data.parcels, size)
     const { x, y } = center


### PR DESCRIPTION
Fixes #516 

The current implementation of `calculateMapProps` returns `>1` zoom levels for small estates. This causes them to be too zoomed in, and it looks bad when shown next to regular parcels.

Like this:

<img width="745" alt="screen shot 2018-10-06 at 4 17 17 pm" src="https://user-images.githubusercontent.com/2781777/46575052-5b558f00-c984-11e8-9d44-0d881850162d.png">

This PR makes the zoom level to never go above 1, so they look like this:

<img width="757" alt="screen shot 2018-10-06 at 4 16 50 pm" src="https://user-images.githubusercontent.com/2781777/46575056-76c09a00-c984-11e8-9421-e143f7d65c3a.png">

It also changes the formula for zoom level to be `(x + y) / (x * y)` which works nicer for regular sized estates, this is a 2x1 estate followed by a 5x3 estate followed by a single parcel:

<img width="293" alt="screen shot 2018-10-06 at 4 26 59 pm" src="https://user-images.githubusercontent.com/2781777/46575078-dcad2180-c984-11e8-9230-31118e39e71d.png">

It keeps the old zoom formula for disproportioned estates (with way more parcels in one axis than the other) because it works better for those scenarios (like [this one](https://market.decentraland.org/estates/38/detail))