### PR TITLE
refactor: marketplace

### DIFF
--- a/webapp/src/components/ActivityPage/ActivityPage.js
+++ b/webapp/src/components/ActivityPage/ActivityPage.js
@@ -65,7 +65,7 @@ export default class ActivityPage extends React.PureComponent {
               id="activity.start"
               values={{
                 marketplace: (
-                  <Link to={locations.marketplacePageDefault()}>
+                  <Link to={locations.marketplace()}>
                     {t('global.marketplace')}
                   </Link>
                 )

--- a/webapp/src/components/Estate/Estate.container.js
+++ b/webapp/src/components/Estate/Estate.container.js
@@ -21,7 +21,7 @@ const mapState = (state, { id, x, y }) => {
 
 const mapDispatch = (dispatch, { id }) => ({
   onLoaded: () => id && dispatch(fetchEstateRequest(id)),
-  onAccessDenied: () => dispatch(push(locations.marketplacePageDefault()))
+  onAccessDenied: () => dispatch(push(locations.marketplace()))
 })
 
 export default connect(mapState, mapDispatch)(Estate)

--- a/webapp/src/components/HomePage/HomePage.js
+++ b/webapp/src/components/HomePage/HomePage.js
@@ -39,7 +39,7 @@ export default class HomePage extends React.PureComponent {
           <div className="gap" />
           <div className="publications-header">
             <h3>{t('homepage.newest_lands')}</h3>
-            <Link to={locations.marketplacePageDefault()}>
+            <Link to={locations.marketplace()}>
               <span role="button" onClick={this.handleNext}>
                 {t('homepage.view_more')}&nbsp;<Icon name="chevron right" />
               </span>

--- a/webapp/src/components/MarketplacePage/MarketplacePage.container.js
+++ b/webapp/src/components/MarketplacePage/MarketplacePage.container.js
@@ -1,40 +1,33 @@
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import { isLoading } from 'modules/publication/selectors'
-import {
-  getParcels,
-  getEstates,
-  getTotals
-} from 'modules/ui/marketplace/selectors'
+import { getAssets, getTotals } from 'modules/ui/marketplace/selectors'
 import { fetchPublicationsRequest } from 'modules/publication/actions'
 import { navigateTo } from 'modules/location/actions'
 import { Pagination } from 'lib/Pagination'
-import { MARKETPLACE_PAGE_TABS } from 'locations'
 import { getOptionsFromRouter } from './utils'
 import MarketplacePage from './MarketplacePage'
+import { ASSET_TYPES } from '../../shared/asset'
 
-const mapState = (state, { location, match }) => {
-  let { tab } = match.params
-  const { limit, offset, sortBy, sortOrder, status } = getOptionsFromRouter(
-    location
-  )
-  const parcels = getParcels(state)
-  const estates = getEstates(state)
+const mapState = (state, { location }) => {
+  let {
+    limit,
+    offset,
+    sortBy,
+    sortOrder,
+    assetType,
+    status
+  } = getOptionsFromRouter(location)
+  const assets = getAssets(state)
   const totals = getTotals(state)
 
-  let isEmpty, pagination
-  if (tab === MARKETPLACE_PAGE_TABS.parcels) {
-    isEmpty = parcels.length === 0
-    pagination = new Pagination(totals.parcel)
-  } else if (tab === MARKETPLACE_PAGE_TABS.estates) {
-    isEmpty = estates.length === 0
-    pagination = new Pagination(totals.estate)
-  }
+  const isEmpty = assets.length === 0
+  const pagination = new Pagination(assets)
   const page = pagination.getCurrentPage(offset)
   const pages = pagination.getPageCount()
 
-  if (!Object.values(MARKETPLACE_PAGE_TABS).includes(tab)) {
-    tab = MARKETPLACE_PAGE_TABS.parcels
+  if (!Object.values(ASSET_TYPES).includes(assetType)) {
+    assetType = ASSET_TYPES.parcel
   }
 
   return {
@@ -45,25 +38,23 @@ const mapState = (state, { location, match }) => {
     status,
     page,
     pages,
-    parcels,
-    estates,
-    tab,
+    assets,
+    assetType,
     isEmpty,
     totals,
     isLoading: isLoading(state)
   }
 }
 
-const mapDispatch = (dispatch, { location, match }) => {
-  let { tab } = match.params
+const mapDispatch = (dispatch, { location }) => {
   return {
-    onFetchPublications: assetType =>
-      dispatch(
-        fetchPublicationsRequest({
-          ...getOptionsFromRouter(location),
-          tab: assetType || tab
-        })
-      ),
+    onFetchPublications: assetType => {
+      let options = getOptionsFromRouter(location)
+      if (assetType) {
+        options.assetType = assetType // override router option
+      }
+      dispatch(fetchPublicationsRequest(options))
+    },
     onNavigate: url => dispatch(navigateTo(url))
   }
 }

--- a/webapp/src/components/MarketplacePage/MarketplacePage.css
+++ b/webapp/src/components/MarketplacePage/MarketplacePage.css
@@ -31,13 +31,13 @@
   opacity: 0.8 !important;
 }
 
-.MarketplacePage .ui.label {
-  background-color: var(--dark-gray) !important;
-  color: white !important;
+.MarketplacePage .ui.menu .item > .label {
+  background-color: var(--dark-gray);
+  color: white;
 }
 
-.MarketplacePage .ui.label.active {
-  background-color: var(--primary) !important;
+.MarketplacePage .ui.menu .item > .label.active {
+  background-color: var(--primary);
 }
 
 .MarketplacePage .menu.right > .item {

--- a/webapp/src/components/MarketplacePage/MarketplacePage.js
+++ b/webapp/src/components/MarketplacePage/MarketplacePage.js
@@ -10,9 +10,8 @@ import {
   Loader,
   Label
 } from 'semantic-ui-react'
-
-import ParcelCard from 'components/ParcelCard'
-import EstateCard from 'components/EstateCard'
+import AssetCard from 'components/AssetCard'
+import { getTypeByMarketplaceTab } from 'modules/publication/utils'
 import { parcelType, estateType } from 'components/types'
 import { t } from '@dapps/modules/translation/utils'
 import {
@@ -24,8 +23,6 @@ import {
 import { MARKETPLACE_PAGE_TABS } from 'locations'
 
 import './MarketplacePage.css'
-import { isParcel } from '../../shared/parcel'
-import { getTypeByMarketplaceTab } from 'modules/publication/utils'
 
 export default class MarketplacePage extends React.PureComponent {
   static propTypes = {
@@ -125,22 +122,9 @@ export default class MarketplacePage extends React.PureComponent {
     const { assets } = this.props
     return (
       <Card.Group stackable={true}>
-        {assets.map(
-          (asset, index) =>
-            isParcel(asset) ? (
-              <ParcelCard
-                key={asset.id}
-                parcel={asset}
-                debounce={index * 100}
-              />
-            ) : (
-              <EstateCard
-                key={asset.id}
-                estate={asset}
-                debounce={index * 100}
-              />
-            )
-        )}
+        {assets.map((asset, index) => (
+          <AssetCard key={asset.id} asset={asset} debounce={index * 100} />
+        ))}
       </Card.Group>
     )
   }

--- a/webapp/src/components/MarketplacePage/utils.js
+++ b/webapp/src/components/MarketplacePage/utils.js
@@ -67,14 +67,16 @@ export function getOptionsFromRouter(location) {
     'offset',
     'sortBy',
     'sortOrder',
+    'assetType',
     'status'
   ])
 }
 
-export function buildUrl({ tab, page, sortBy, sortOrder }) {
-  return Location.buildUrl(locations.marketplace(tab), {
+export function buildUrl({ page, sortBy, sortOrder, assetType }) {
+  return Location.buildUrl(locations.marketplace(), {
     page,
     sort_by: sortBy,
-    sort_order: sortOrder
+    sort_order: sortOrder,
+    asset_type: assetType
   })
 }

--- a/webapp/src/components/Navbar/Navbar.js
+++ b/webapp/src/components/Navbar/Navbar.js
@@ -43,7 +43,7 @@ export default class Navbar extends React.PureComponent {
     const { wallet, center } = this.props
     return {
       [NAVBAR_PAGES.atlas]: locations.parcelMapDetail(center.x, center.y),
-      [NAVBAR_PAGES.marketplace]: locations.marketplacePageDefault(),
+      [NAVBAR_PAGES.marketplace]: locations.marketplace(),
       [NAVBAR_PAGES.profile]: locations.profilePageDefault(wallet.address),
       [NAVBAR_PAGES.activity]: locations.activity(),
       [NAVBAR_PAGES.signIn]: locations.signIn()

--- a/webapp/src/components/ProfilePage/ProfilePage.container.js
+++ b/webapp/src/components/ProfilePage/ProfilePage.container.js
@@ -87,7 +87,7 @@ const mapState = (state, { location, match }) => {
 const mapDispatch = (dispatch, { match }) => ({
   onFetchAddress: () => dispatch(fetchAddress(match.params.address)),
   onNavigate: url => dispatch(navigateTo(url)),
-  onAccessDenied: () => dispatch(navigateTo(locations.marketplacePageDefault()))
+  onAccessDenied: () => dispatch(navigateTo(locations.marketplace()))
 })
 
 export default withRouter(connect(mapState, mapDispatch)(ProfilePage))

--- a/webapp/src/lib/Location.js
+++ b/webapp/src/lib/Location.js
@@ -1,6 +1,7 @@
 import queryString from 'query-string'
 import { PUBLICATION_STATUS } from 'shared/publication'
 import { PAGE_SIZE } from './Pagination'
+import { ASSET_TYPES } from '../shared/asset'
 
 export class Location {
   static buildUrl(origin, queryParams) {
@@ -18,6 +19,10 @@ export class Location {
     return this.getOptionFromRouter('page')
   }
 
+  getAssetTypeFromRouter() {
+    return this.getOptionFromRouter('assetType')
+  }
+
   getOptionsFromRouter(optionNames) {
     return optionNames.reduce((result, option) => {
       result[option] = this.getOptionFromRouter(option)
@@ -26,7 +31,7 @@ export class Location {
   }
 
   getOptionFromRouter(optionName) {
-    const { sort_by, sort_order, page } = this.query
+    const { sort_by, sort_order, page, asset_type } = this.query
     let value = null
 
     switch (optionName) {
@@ -47,6 +52,9 @@ export class Location {
         break
       case 'status':
         value = PUBLICATION_STATUS.open
+        break
+      case 'assetType':
+        value = asset_type || ASSET_TYPES.parcel
         break
       default:
         value = null

--- a/webapp/src/lib/api.js
+++ b/webapp/src/lib/api.js
@@ -9,6 +9,7 @@ const FILTER_DEFAULTS = {
   offset: 0,
   sortBy: 'created_at',
   sortOrder: 'asc',
+  assetType: null,
   status: PUBLICATION_STATUS.open
 }
 
@@ -32,10 +33,15 @@ export class API {
     return this.request('get', `/parcels/${x}/${y}`)
   }
 
-  fetchMarketplace(assetType, options = FILTER_DEFAULTS) {
-    const { limit, offset, sortBy, sortOrder, status } = getFilterOptions(
-      options
-    )
+  fetchMarketplace(options = FILTER_DEFAULTS) {
+    const {
+      limit,
+      offset,
+      sortBy,
+      sortOrder,
+      assetType,
+      status
+    } = getFilterOptions(options)
 
     return this.request('get', `/marketplace`, {
       limit,

--- a/webapp/src/locations.js
+++ b/webapp/src/locations.js
@@ -65,10 +65,7 @@ export const locations = {
   payMortgageParcel: (x = params.x, y = params.y) => `/mortgages/${x}/${y}/pay`,
 
   // General routes
-
-  marketplacePageDefault: (tab = MARKETPLACE_PAGE_TABS.parcels) =>
-    locations.marketplace(MARKETPLACE_PAGE_TABS.parcels),
-  marketplace: (tab = ':tab') => `/marketplace/${tab}`,
+  marketplace: () => `/marketplace`,
 
   buyMana: () => '/buy-mana',
   transferMana: () => '/transfer-mana',

--- a/webapp/src/modules/publication/actions.js
+++ b/webapp/src/modules/publication/actions.js
@@ -11,7 +11,7 @@ export function fetchPublicationsRequest({
   sortBy,
   sortOrder,
   status,
-  tab
+  assetType
 } = {}) {
   return {
     type: FETCH_PUBLICATIONS_REQUEST,
@@ -20,7 +20,7 @@ export function fetchPublicationsRequest({
     sortBy,
     sortOrder,
     status,
-    tab
+    assetType
   }
 }
 
@@ -28,14 +28,16 @@ export function fetchPublicationsSuccess({
   assets,
   total,
   publications,
-  assetType
+  assetType,
+  isGrid
 }) {
   return {
     type: FETCH_PUBLICATIONS_SUCCESS,
     assets,
     assetType,
     publications,
-    total
+    total,
+    isGrid
   }
 }
 

--- a/webapp/src/modules/publication/utils.js
+++ b/webapp/src/modules/publication/utils.js
@@ -18,10 +18,12 @@ export function getNFTAddressByType(type) {
 }
 
 export function getTypeByMarketplaceTab(tab) {
-  if (tab === MARKETPLACE_PAGE_TABS.parcels) {
-    return ASSET_TYPES.parcel
-  } else if (tab === MARKETPLACE_PAGE_TABS.estates) {
-    return ASSET_TYPES.estate
+  switch (tab) {
+    case MARKETPLACE_PAGE_TABS.parcels:
+      return ASSET_TYPES.parcel
+    case MARKETPLACE_PAGE_TABS.estates:
+      return ASSET_TYPES.estate
+    default:
+      return ASSET_TYPES.parcel
   }
-  return null
 }

--- a/webapp/src/modules/ui/marketplace/reducer.js
+++ b/webapp/src/modules/ui/marketplace/reducer.js
@@ -22,7 +22,7 @@ export function marketplaceReducer(state = INITIAL_STATE, action) {
           [assetType]: total
         }
       }
-      let newGrid = action.isGrid
+      const newGrid = action.isGrid
         ? assets.map(asset => ({
             id: asset.id,
             type: asset.publication.asset_type

--- a/webapp/src/modules/ui/marketplace/reducer.js
+++ b/webapp/src/modules/ui/marketplace/reducer.js
@@ -1,6 +1,5 @@
 import { FETCH_PUBLICATIONS_SUCCESS } from 'modules/publication/actions'
 import { ASSET_TYPES } from 'shared/asset'
-import { isParcel } from 'shared/parcel'
 
 const initTotals = {}
 for (let type in ASSET_TYPES) {
@@ -23,15 +22,15 @@ export function marketplaceReducer(state = INITIAL_STATE, action) {
           [assetType]: total
         }
       }
+      let newGrid = action.isGrid
+        ? assets.map(asset => ({
+            id: asset.id,
+            type: asset.publication.asset_type
+          }))
+        : state.grid
       return {
         ...state,
-        grid: assets.map(asset => {
-          let type = assetType
-          if (!type) {
-            type = isParcel(asset) ? ASSET_TYPES.parcel : ASSET_TYPES.estate
-          }
-          return { id: asset.id, type }
-        }),
+        grid: newGrid,
         totals: newTotals
       }
     }

--- a/webapp/src/modules/ui/marketplace/selectors.js
+++ b/webapp/src/modules/ui/marketplace/selectors.js
@@ -6,44 +6,6 @@ import { ASSET_TYPES } from 'shared/asset'
 
 export const getState = state => state.ui.marketplace
 export const getGrid = state => getState(state).grid
-export const getParcels = createSelector(
-  state => getGrid(state),
-  state => getPublications(state),
-  state => getAllParcels(state),
-  (grid, publications, parcels) =>
-    grid.reduce((acc, { type, id }) => {
-      if (type === ASSET_TYPES.parcel && parcels[id]) {
-        acc.push({
-          ...parcels[id],
-          publication:
-            parcels[id].publication_tx_hash in publications
-              ? publications[parcels[id].publication_tx_hash]
-              : null
-        })
-      }
-      return acc
-    }, [])
-)
-
-export const getEstates = createSelector(
-  state => getGrid(state),
-  state => getPublications(state),
-  state => getAllEstates(state),
-  (grid, publications, estates) =>
-    grid.reduce((acc, { type, id }) => {
-      if (type === ASSET_TYPES.estate && estates[id]) {
-        acc.push({
-          ...estates[id],
-          publication:
-            estates[id].publication_tx_hash in publications
-              ? publications[estates[id].publication_tx_hash]
-              : null
-        })
-      }
-      return acc
-    }, [])
-)
-
 export const getAssets = createSelector(
   state => getGrid(state),
   state => getPublications(state),
@@ -58,13 +20,16 @@ export const getAssets = createSelector(
         asset = estates[id]
       }
 
-      acc.push({
-        ...asset,
-        publication:
-          asset.publication_tx_hash in publications
-            ? publications[asset.publication_tx_hash]
-            : null
-      })
+      if (asset) {
+        acc.push({
+          ...asset,
+          publication:
+            asset.publication_tx_hash in publications
+              ? publications[asset.publication_tx_hash]
+              : null
+        })
+      }
+
       return acc
     }, [])
 )


### PR DESCRIPTION
This PR refactors the `tab` into a query param `asset_type`. 

This keeps it consistent with the server API, and it lets us use the logic already implemented in the `Location` class to build paths and extract values from the router.

Also it allow us to have a single route for the marketplace (no need for `marketplaceDefaultPage` location)

This PR also refactores the MarketplacePage to work with `assets` instead of `parcels` and `estates`, which reduces repeated logic. 

This PR also fixes a race condition that happened when the MarketplacePage was mounted and the publications for each asset type were fetched: now it relies on the router instead of the order that the actions are dispatched.