### PR TITLE
fix: publications with a wrong tx status were shown as not open

### DIFF
--- a/shared/asset.js
+++ b/shared/asset.js
@@ -46,12 +46,7 @@ export function isExpired(expires_at) {
 }
 
 export function hasStatus(obj, status) {
-  return (
-    obj &&
-    obj.status === status &&
-    obj.tx_status === 'confirmed' &&
-    !isExpired(obj.expires_at)
-  )
+  return obj && obj.status === status && !isExpired(obj.expires_at)
 }
 
 export function isRoad(district_id) {

--- a/shared/mortgage.js
+++ b/shared/mortgage.js
@@ -68,9 +68,10 @@ export function getActiveMortgages(
 
 /**
  * filter actibe mortgages by borrower
- * @param {object} - obj with status & tx_status fields
- * @param  {array} - parcels
- * @returns {object} - mortgage
+ * @param {array} - mortgages
+ * @param  {object} - parcels
+ * @param  {object} - publications
+ * @returns {array} - mortgages (active)
  */
 export function getActiveMortgageByBorrower(
   mortgages = [],

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -3,10 +3,5 @@ export function isExpired(expires_at) {
 }
 
 export function hasStatus(obj, status) {
-  return (
-    obj &&
-    obj.status === status &&
-    obj.tx_status === 'confirmed' &&
-    !isExpired(obj.expires_at)
-  )
+  return obj && obj.status === status && !isExpired(obj.expires_at)
 }

--- a/webapp/src/components/Asset/Asset.container.js
+++ b/webapp/src/components/Asset/Asset.container.js
@@ -9,7 +9,7 @@ import {
 } from 'modules/address/selectors'
 import { isFetchingParcel } from 'modules/parcels/selectors'
 import { isFetchingEstate } from 'modules/estates/selectors'
-import { getPublications } from 'modules/publication/selectors'
+import { getData as getPublications } from 'modules/publication/selectors'
 
 import Asset from './Asset'
 

--- a/webapp/src/components/EstateCard/EstateCard.container.js
+++ b/webapp/src/components/EstateCard/EstateCard.container.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import { getPublications } from 'modules/publication/selectors'
+import { getData as getPublications } from 'modules/publication/selectors'
 import EstateCard from './EstateCard'
 
 const mapState = state => ({

--- a/webapp/src/components/EstateDetailPage/EstateDetailPage.container.js
+++ b/webapp/src/components/EstateDetailPage/EstateDetailPage.container.js
@@ -6,7 +6,7 @@ import { navigateTo } from 'modules/location/actions'
 import { getMatchParams } from 'modules/location/selectors'
 import EstateDetailPage from 'components/EstateDetailPage/EstateDetailPage'
 import { getData as getParcels } from 'modules/parcels/selectors'
-import { getPublications } from 'modules/publication/selectors'
+import { getData as getPublications } from 'modules/publication/selectors'
 
 const mapState = (state, ownProps) => {
   const { id, x, y } = getMatchParams(ownProps)

--- a/webapp/src/components/ParcelCard/ParcelCard.container.js
+++ b/webapp/src/components/ParcelCard/ParcelCard.container.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import { getPublications } from 'modules/publication/selectors'
+import { getData as getPublications } from 'modules/publication/selectors'
 import ParcelCard from './ParcelCard'
 
 const mapState = state => ({

--- a/webapp/src/components/ParcelDetailPage/ParcelDetailPage.container.js
+++ b/webapp/src/components/ParcelDetailPage/ParcelDetailPage.container.js
@@ -5,7 +5,7 @@ import { locations } from 'locations'
 import { getMatchParams } from 'modules/location/selectors'
 import { navigateTo } from 'modules/location/actions'
 import { getParcelMortgageFactory } from 'modules/mortgage/selectors'
-import { getPublications } from 'modules/publication/selectors'
+import { getData as getPublications } from 'modules/publication/selectors'
 import { getDistricts } from 'modules/districts/selectors'
 import { getEstates } from 'modules/estates/selectors'
 

--- a/webapp/src/components/ParcelPreview/ParcelCanvas/ParcelCanvas.container.js
+++ b/webapp/src/components/ParcelPreview/ParcelCanvas/ParcelCanvas.container.js
@@ -3,7 +3,7 @@ import { getWallet } from 'modules/wallet/selectors'
 import { getData as getParcels } from 'modules/parcels/selectors'
 import { getEstates } from 'modules/estates/selectors'
 import { getDistricts } from 'modules/districts/selectors'
-import { getPublications } from 'modules/publication/selectors'
+import { getData as getPublications } from 'modules/publication/selectors'
 import { fetchMapRequest } from 'modules/map/actions'
 
 import ParcelCanvas from './ParcelCanvas'

--- a/webapp/src/components/TransferParcelPage/TransferParcelPage.container.js
+++ b/webapp/src/components/TransferParcelPage/TransferParcelPage.container.js
@@ -1,7 +1,7 @@
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import { push } from 'react-router-redux'
-import { getPublications } from 'modules/publication/selectors'
+import { getData as getPublications } from 'modules/publication/selectors'
 import { isTransferIdle } from 'modules/parcels/selectors'
 import { getMatchParamsCoordinates } from 'modules/location/selectors'
 import { transferParcelRequest } from 'modules/parcels/actions'

--- a/webapp/src/modules/address/selectors.js
+++ b/webapp/src/modules/address/selectors.js
@@ -4,7 +4,7 @@ import {
   getData as getParcels,
   getMortgagedParcels
 } from 'modules/parcels/selectors'
-import { getPublications } from 'modules/publication/selectors'
+import { getData as getPublications } from 'modules/publication/selectors'
 import { getDistricts } from 'modules/districts/selectors'
 import { getEstates } from 'modules/estates/selectors'
 import { getData as getAuthorizations } from 'modules/authorization/selectors'

--- a/webapp/src/modules/estates/selectors.js
+++ b/webapp/src/modules/estates/selectors.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect'
 import { isLoadingType } from '@dapps/modules/loading/selectors'
 import { getData as getParcels } from 'modules/parcels/selectors'
-import { getPublications } from 'modules/publication/selectors'
+import { getData as getPublications } from 'modules/publication/selectors'
 import { buildCoordinate } from 'shared/parcel'
 import {
   CREATE_ESTATE_REQUEST,

--- a/webapp/src/modules/mortgage/selectors.js
+++ b/webapp/src/modules/mortgage/selectors.js
@@ -8,7 +8,7 @@ import {
 import { isLoadingType } from '@dapps/modules/loading/selectors'
 import { getAddress } from 'modules/wallet/selectors'
 import { getData as getParcels } from 'modules/parcels/selectors'
-import { getPublications } from 'modules/publication/selectors'
+import { getData as getPublications } from 'modules/publication/selectors'
 import { getActiveMortgageByBorrower } from 'shared/mortgage'
 import { buildCoordinate } from 'shared/parcel'
 

--- a/webapp/src/modules/parcels/selectors.js
+++ b/webapp/src/modules/parcels/selectors.js
@@ -6,7 +6,7 @@ import {
   TRANSFER_PARCEL_REQUEST
 } from './actions'
 import { isLoadingType } from '@dapps/modules/loading/selectors'
-import { getPublications as getAllPublications } from 'modules/publication/selectors'
+import { getData as getAllPublications } from 'modules/publication/selectors'
 import { getMortgagesArray } from 'modules/mortgage/selectors'
 import { buildCoordinate } from 'shared/parcel'
 import { getActiveMortgages } from 'shared/mortgage'

--- a/webapp/src/modules/publication/selectors.js
+++ b/webapp/src/modules/publication/selectors.js
@@ -1,15 +1,7 @@
-import { createSelector } from 'reselect'
-import {
-  PUBLISH_REQUEST,
-  PUBLISH_SUCCESS,
-  BUY_REQUEST,
-  CANCEL_SALE_REQUEST
-} from './actions'
+import { PUBLISH_REQUEST, BUY_REQUEST, CANCEL_SALE_REQUEST } from './actions'
 import { isLoadingType } from '@dapps/modules/loading/selectors'
 import { getData as getParcels } from 'modules/parcels/selectors'
 import { getData as getEstates } from 'modules/estates/selectors'
-import { getAddress } from 'modules/wallet/selectors'
-import { getTransactionsByType } from '@dapps/modules/transaction/selectors'
 import { PUBLICATION_STATUS, findAssetPublications } from 'shared/publication'
 import { buildCoordinate } from 'shared/parcel'
 
@@ -26,29 +18,6 @@ export const isBuyIdle = state => isLoadingType(getLoading(state), BUY_REQUEST)
 
 export const isCancelIdle = state =>
   isLoadingType(getLoading(state), CANCEL_SALE_REQUEST)
-
-export const getPublications = createSelector(
-  state => getData(state),
-  state => getTransactionsByType(state, getAddress(state), PUBLISH_SUCCESS),
-  (publications = {}, publishTransactions) => {
-    const txPublications = {}
-
-    for (const transaction of publishTransactions) {
-      const publication = transaction.payload
-
-      txPublications[publication.tx_hash] = {
-        ...publications[publication.tx_hash],
-        ...publication,
-        tx_status: transaction.status
-      }
-    }
-
-    return {
-      ...publications,
-      ...txPublications
-    }
-  }
-)
 
 export const getPublicationByCoordinate = (state, x, y) => {
   const parcels = getParcels(state)

--- a/webapp/src/modules/ui/marketplace/selectors.js
+++ b/webapp/src/modules/ui/marketplace/selectors.js
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect'
 import { getData as getAllParcels } from 'modules/parcels/selectors'
 import { getEstates as getAllEstates } from 'modules/estates/selectors'
-import { getPublications } from 'modules/publication/selectors'
+import { getData as getPublications } from 'modules/publication/selectors'
 import { ASSET_TYPES } from 'shared/asset'
 
 export const getState = state => state.ui.marketplace


### PR DESCRIPTION
Fixes #541

When a publication had a transaction status different than `confirmed` the `isOpen` helper would return `false` causing several parts of the UI to be rendered wrong (like empty For Sale tab in profile, or publications without price).