### PR TITLE
fix: get asset type

### DIFF
--- a/webapp/src/components/PublishEstatePage/PublishEstatePage.container.js
+++ b/webapp/src/components/PublishEstatePage/PublishEstatePage.container.js
@@ -42,7 +42,7 @@ const mapDispatch = (dispatch, ownProps) => {
   return {
     onPublish: publication =>
       dispatch(
-        publishRequest({ ...publication, assetType: ASSET_TYPES.estate })
+        publishRequest({ ...publication, asset_type: ASSET_TYPES.estate })
       ),
     onCancel: () => dispatch(push(locations.estateDetail(id)))
   }

--- a/webapp/src/components/PublishParcelPage/PublishParcelPage.container.js
+++ b/webapp/src/components/PublishParcelPage/PublishParcelPage.container.js
@@ -44,7 +44,7 @@ const mapDispatch = (dispatch, ownProps) => {
   return {
     onPublish: publication =>
       dispatch(
-        publishRequest({ ...publication, assetType: ASSET_TYPES.parcel })
+        publishRequest({ ...publication, asset_type: ASSET_TYPES.parcel })
       ),
     onCancel: () => dispatch(push(locations.parcelDetail(x, y)))
   }

--- a/webapp/src/modules/analytics/track.js
+++ b/webapp/src/modules/analytics/track.js
@@ -29,7 +29,7 @@ const addAssetType = (actionName, assetType) =>
 
 add(
   BUY_SUCCESS,
-  action => addAssetType('Buy', action.assetType),
+  action => addAssetType('Buy', action.publication.asset_type),
   action => ({
     assetId: action.publication.asset_id,
     price: action.publication.price,
@@ -39,7 +39,7 @@ add(
 
 add(
   PUBLISH_SUCCESS,
-  action => addAssetType('Publish', action.assetType),
+  action => addAssetType('Publish', action.publication.assetType),
   action => ({
     assetId: action.publication.asset_id,
     price: action.publication.price
@@ -48,7 +48,7 @@ add(
 
 add(
   CANCEL_SALE_SUCCESS,
-  action => addAssetType('Cancel Sale', action.assetType),
+  action => addAssetType('Cancel Sale', action.publication.asset_type),
   action => ({
     assetId: action.publication.asset_id,
     price: action.publication.price

--- a/webapp/src/modules/analytics/track.js
+++ b/webapp/src/modules/analytics/track.js
@@ -39,7 +39,7 @@ add(
 
 add(
   PUBLISH_SUCCESS,
-  action => addAssetType('Publish', action.publication.assetType),
+  action => addAssetType('Publish', action.publication.asset_type),
   action => ({
     assetId: action.publication.asset_id,
     price: action.publication.price

--- a/webapp/src/modules/publication/sagas.js
+++ b/webapp/src/modules/publication/sagas.js
@@ -79,10 +79,10 @@ function* handleAssetPublicationsRequest(action) {
 
 function* handlePublishRequest(action) {
   try {
-    const { asset_id, assetType, price, expires_at } = action.publication
+    const { asset_id, asset_type, price, expires_at } = action.publication
     const priceInWei = eth.utils.toWei(price)
-    const nftAddress = getNFTAddressByType(assetType)
-    const asset = yield call(() => buildAsset(asset_id, assetType))
+    const nftAddress = getNFTAddressByType(asset_type)
+    const asset = yield call(() => buildAsset(asset_id, asset_type))
     const marketplaceContract = eth.getContract('Marketplace')
 
     const txHash = yield call(() =>


### PR DESCRIPTION
Now when we send a tx related to a publication, it fails because `assetType` is `undefined`