### PR TITLE
fix: remove "Waiting for confirmations" to prevent flickering

### DIFF
--- a/src/Translation/locales/en.json
+++ b/src/Translation/locales/en.json
@@ -410,8 +410,7 @@
   },
   "transaction_confirmations": {
     "count":
-      "{confirmations_count} {confirmations_count, plural, one {confirmation} other {confirmations}}",
-    "waiting": "Waiting for confirmations"
+      "{confirmations_count} {confirmations_count, plural, one {confirmation} other {confirmations}}"
   },
   "transaction_status": {
     "activity_page": "activity page",

--- a/src/Translation/locales/es.json
+++ b/src/Translation/locales/es.json
@@ -411,8 +411,7 @@
   },
   "transaction_confirmations": {
     "count":
-      "{confirmations_count} {confirmations_count, plural, one {confirmación} other {confirmaciones}}",
-    "waiting": "Esperando confirmaciones"
+      "{confirmations_count} {confirmations_count, plural, one {confirmación} other {confirmaciones}}"
   },
   "transaction_status": {
     "activity_page": "página de actividad",

--- a/src/Translation/locales/fr.json
+++ b/src/Translation/locales/fr.json
@@ -418,8 +418,7 @@
   },
   "transaction_confirmations": {
     "count":
-      "{confirmations_count} {confirmations_count, plural, one {confirmation} other {confirmations}}",
-    "waiting": "En attente de confirmation"
+      "{confirmations_count} {confirmations_count, plural, one {confirmation} other {confirmations}}"
   },
   "transaction_status": {
     "activity_page": "page d'activité",

--- a/src/Translation/locales/ja.json
+++ b/src/Translation/locales/ja.json
@@ -406,8 +406,7 @@
     "transfer_mana": "{mana}MANAを{address_link}へ転送しました。"
   },
   "transaction_confirmations": {
-    "count": "{confirmations_count}件の確認",
-    "waiting": "承認待ち"
+    "count": "{confirmations_count}件の確認"
   },
   "transaction_status": {
     "activity_page": "活動ページ",

--- a/src/Translation/locales/ko.json
+++ b/src/Translation/locales/ko.json
@@ -385,8 +385,7 @@
       "{parcel_link}을(를) \"{name}\" 이름 및 설명 \"{description}\" (으)로 수정했습니다.",
     "edit_estate_metadata":
       "이름이 \"{name}\"이고 설명이 \"{description}\"인 부동산 {estate_id}을 편집했습니다.",
-    "edit_estate_parcels_added":
-      "부동산 {name}에 {amount} 소포를 추가했습니다",
+    "edit_estate_parcels_added": "부동산 {name}에 {amount} 소포를 추가했습니다",
     "edit_estate_parcels_removed":
       "부동산 {name}에서 {amount} 소포를 제거했습니다",
     "manage":
@@ -404,8 +403,7 @@
     "transfer_mana": "{mana} MANA를 {address_link}으로 이전했습니다"
   },
   "transaction_confirmations": {
-    "count": "{confirmations_count} 가지 확인",
-    "waiting": "확인을 기다리는 중"
+    "count": "{confirmations_count} 가지 확인"
   },
   "transaction_status": {
     "activity_page": "활동 페이지",

--- a/src/Translation/locales/zh.json
+++ b/src/Translation/locales/zh.json
@@ -371,8 +371,7 @@
     "transfer_mana": "{mana} MANA 已转帐至 {address_link}"
   },
   "transaction_confirmations": {
-    "count": "{confirmations_count}个确认",
-    "waiting": "等待确认"
+    "count": "{confirmations_count}个确认"
   },
   "transaction_status": {
     "activity_page": "活动页面",

--- a/webapp/src/components/ActivityPage/Transaction/Status/Status.js
+++ b/webapp/src/components/ActivityPage/Transaction/Status/Status.js
@@ -81,11 +81,7 @@ export default class Status extends React.PureComponent {
   renderConfirmations(hash, status) {
     const { confirmations } = this.state
     if (confirmations == null) {
-      return (
-        <span className="no-link">
-          {t('transaction_confirmations.waiting')}&nbsp;
-        </span>
-      )
+      return null
     }
     if (confirmations < MINIMUM_CONFIRMATIONS) {
       return (
@@ -152,7 +148,7 @@ export default class Status extends React.PureComponent {
   renderConfirmationIcon() {
     const { confirmations } = this.state
     if (confirmations == null) {
-      return <Loader active size="mini" />
+      return null
     }
     if (confirmations >= MINIMUM_CONFIRMATIONS) {
       return <Icon name="check" />


### PR DESCRIPTION
Fixes #561 (sort of)

Since we don't store the number of confirmations in the app state, we always have to fetch them to know if a transaction's status is `Accepted` or `N confirmations`. 

I removed the `Waiting for confirmations...` placeholder that shows while we fetch the confirmations. This causes the status to just "appear" when we know the amount of confirmations, but I think it's better than showing the placeholder for a fraction of a second.

Any better ideas?