### PR TITLE
fix: bump decentraland-dapps, fixes failed transactions bug

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -74,18 +74,18 @@
     },
     "@types/flat": {
       "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@types/flat/-/flat-0.0.28.tgz",
+      "resolved": "http://registry.npmjs.org/@types/flat/-/flat-0.0.28.tgz",
       "integrity": "sha1-XHiBSdhabPj/X18ACs3ZEs3qQnQ="
     },
     "@types/history": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.0.tgz",
-      "integrity": "sha512-1A/RUAX4VtmGzNTGLSfmiPxQ3XwUSe/1YN4lW9GRa+j307oFK6MPjhlvw6jEHDodUBIvSvrA7/iHDchr5LS+0Q=="
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.1.tgz",
+      "integrity": "sha512-g7RRtPg2f2OJm3kvYVTAGEr3R+YN53XwZgpP8r4cl3ugJB+95hbPfOU5tjOoAOz4bTLQuiHVUJh8rl4hEDUUjQ=="
     },
     "@types/node": {
-      "version": "10.11.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.4.tgz",
-      "integrity": "sha512-ojnbBiKkZFYRfQpmtnnWTMw+rzGp/JiystjluW9jgN3VzRwilXddJ6aGQ9V/7iuDG06SBgn7ozW9k3zcAnYjYQ=="
+      "version": "10.11.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.7.tgz",
+      "integrity": "sha512-yOxFfkN9xUFLyvWaeYj90mlqTJ41CsQzWKS3gXdOMOyPVacUsymejKxJ4/pMW7exouubuEeZLJawGgcNGYlTeg=="
     },
     "@types/prop-types": {
       "version": "15.5.6",
@@ -132,11 +132,11 @@
       }
     },
     "@types/react-router": {
-      "version": "4.0.31",
-      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-4.0.31.tgz",
-      "integrity": "sha512-57Tqu1EDMgDzHhmIEjjQZHrc/N7/+GGv6CtH1wRTLmMIy3UMxX69vQoeEz0AmK0/zkf5ecfEW1ZX8DLVQ6Gl7Q==",
+      "version": "4.0.32",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-4.0.32.tgz",
+      "integrity": "sha512-VLQSifCIKCTpfMFrJN/nO5a45LduB6qSMkO9ASbcGdCHiDwJnrLNzk91Q895yG0qWY7RqT2jR16giBRpRG1HQw==",
       "requires": {
-        "@types/history": "4.7.0",
+        "@types/history": "4.7.1",
         "@types/react": "16.4.16"
       }
     },
@@ -145,9 +145,9 @@
       "resolved": "https://registry.npmjs.org/@types/react-router-redux/-/react-router-redux-5.0.16.tgz",
       "integrity": "sha512-EWJMP4/GtUG79uxYUOGvR50X5vtZVOptk14ebWN9WuBSqbWWzJDj5ClPPvUi80Qq/HruhC0O5Wl1OqpT9IQBeQ==",
       "requires": {
-        "@types/history": "4.7.0",
+        "@types/history": "4.7.1",
         "@types/react": "16.4.16",
-        "@types/react-router": "4.0.31",
+        "@types/react-router": "4.0.32",
         "redux": "3.7.2"
       }
     },
@@ -177,7 +177,7 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
       "integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
       "requires": {
-        "@types/node": "10.11.4"
+        "@types/node": "10.11.7"
       }
     },
     "abab": {
@@ -1535,7 +1535,7 @@
     },
     "babelify": {
       "version": "7.3.0",
-      "resolved": "http://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
       "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
       "requires": {
         "babel-core": "6.26.0",
@@ -2951,13 +2951,13 @@
       }
     },
     "decentraland-dapps": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-3.5.1.tgz",
-      "integrity": "sha512-+0a7TOkO0KkSX3n3T0JVAXti4080jpyaeHd2pTBh4wlG66RAfkX0Ev5ZNxlZdQWIhAIA6IeFjkfwFP40mKQ/Bw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-3.6.0.tgz",
+      "integrity": "sha512-4OhMYTMHTcmTDMN4t+TyQxB4Kf7hUPt47/cU/VHXEdYuHMimX3IOJ5vmq3ng6Nzq/gcHrDU8nWqdnP0hctXKQw==",
       "requires": {
         "@types/axios": "0.14.0",
         "@types/flat": "0.0.28",
-        "@types/node": "10.11.4",
+        "@types/node": "10.11.7",
         "@types/react": "16.4.16",
         "@types/react-intl": "2.3.11",
         "@types/react-redux": "6.0.9",
@@ -3999,7 +3999,7 @@
     },
     "eth-json-rpc-middleware": {
       "version": "1.6.0",
-      "resolved": "http://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-1.6.0.tgz",
       "integrity": "sha512-tDVCTlrUvdqHKqivYMjtFZsdD7TtpNLBCfKAcOpaVs7orBMS/A8HWro6dIzNtTZIR05FAbJ3bioFOnZpuCew9Q==",
       "requires": {
         "async": "2.6.1",
@@ -4126,7 +4126,7 @@
         },
         "web3-provider-engine": {
           "version": "13.8.0",
-          "resolved": "http://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-13.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-13.8.0.tgz",
           "integrity": "sha512-fZXhX5VWwWpoFfrfocslyg6P7cN3YWPG/ASaevNfeO80R+nzgoPUBXcWQekSGSsNDkeRTis4aMmpmofYf1TNtQ==",
           "requires": {
             "async": "2.6.1",
@@ -7713,7 +7713,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "1.0.2",
@@ -7750,7 +7750,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "1.0.2",
@@ -8201,7 +8201,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         }
       }
@@ -15697,7 +15697,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "resolve": {
@@ -17102,7 +17102,7 @@
     },
     "yargs": {
       "version": "4.8.1",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
       "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
       "requires": {
         "cliui": "3.2.0",
@@ -17143,7 +17143,7 @@
     },
     "yargs-parser": {
       "version": "2.4.1",
-      "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
       "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
       "requires": {
         "camelcase": "3.0.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -29,7 +29,7 @@
     "css-loader": "0.28.7",
     "date-fns": "^1.29.0",
     "decentraland-commons": "^4.0.1",
-    "decentraland-dapps": "^3.5.1",
+    "decentraland-dapps": "^3.6.0",
     "decentraland-eth": "^7.2.1",
     "decentraland-ui": "^1.10.0",
     "dotenv": "4.0.0",


### PR DESCRIPTION
This PR bumps `decentraland-dapps` to version `3.6.0`, which watches reverted transactions for up to an hour and if the transaction is found to be confirmed, it updates its status.

This is because sometimes transactions are found to be reverted at first when they get mined (because they have a `blockNumber` in their tx status but no receipt). This happens more often in mainnet.

# How to test

Checkout this branch, cd into webapp and npm install, then run this code at the console to turn your confirmed transactions into reverted ones:

```js
const storage = JSON.parse(localStorage['decentraland-marketplace'])
storage.transaction.data.forEach(tx => {
  if (tx.status === 'confirmed') {
    tx.status = "reverted"
    tx.timestamp = Date.now() - 1000
  }
})
localStorage['decentraland-marketplace'] = JSON.stringify(storage)
```

Then go to activity page and refresh the page. You should see all the transactions fixed as Accepted again, and if you open the console you will see a bunch of `Watch Reverted Transaction` actions followed by a bunch of `Update Transaction Status` actions that fix all the wrong statuses. 