### PR TITLE
fix: mortgage saga

### DIFF
--- a/webapp/src/modules/mortgage/sagas.js
+++ b/webapp/src/modules/mortgage/sagas.js
@@ -1,4 +1,11 @@
-import { takeLatest, call, put, select, all, take } from 'redux-saga/effects'
+import {
+  takeLatest,
+  call,
+  put,
+  select,
+  all,
+  takeEvery
+} from 'redux-saga/effects'
 import { eth } from 'decentraland-eth'
 import { push } from 'react-router-redux'
 import { isFeatureEnabled } from 'lib/featureUtils'
@@ -47,7 +54,7 @@ export function* mortgageSaga() {
       handleFetchMortgageRequest
     )
     yield takeLatest(PAY_MORTGAGE_REQUEST, handlePayMortgageRequest)
-    yield take(
+    yield takeEvery(
       FETCH_ACTIVE_PARCEL_MORTGAGES_REQUEST,
       handleFetchActiveParcelMortgagesRequest
     )


### PR DESCRIPTION
When dispatching `FETH_PARCEL_SUCESS` take the latest but take every `FETCH_ACTIVE_MORTGAGE_PARCELS` actions in order to have the same number of request than success or failed