### PR TITLE
feat: add estate highlights

### DIFF
--- a/webapp/src/components/EstateDetailPage/EstateDetail.css
+++ b/webapp/src/components/EstateDetailPage/EstateDetail.css
@@ -121,7 +121,7 @@
   margin-top: 20px;
 }
 
-.EstateDetail .row .column.highlights{
+.EstateDetail .row .column.highlights {
   margin-top: 20px
 }
 

--- a/webapp/src/components/EstateDetailPage/EstateDetail.css
+++ b/webapp/src/components/EstateDetailPage/EstateDetail.css
@@ -121,6 +121,10 @@
   margin-top: 20px;
 }
 
+.EstateDetail .row .column.highlights{
+  margin-top: 20px
+}
+
 @media (max-width: 768px) {
   .EstateDetail {
     overflow-x: hidden;

--- a/webapp/src/components/EstateDetailPage/EstateDetail.js
+++ b/webapp/src/components/EstateDetailPage/EstateDetail.js
@@ -15,6 +15,7 @@ import LandAmount from 'components/LandAmount'
 import { locations } from 'locations'
 import { calculateMapProps } from 'shared/estate'
 import ParcelAttributes from 'components/ParcelAttributes'
+import ParcelTags from 'components/ParcelTags'
 import './EstateDetail.css'
 
 const WITH_ACTION_BUTTONS_WIDTH = 8
@@ -137,6 +138,12 @@ export default class EstateDetail extends React.PureComponent {
             </Grid.Column>
           </Grid.Row>
           <Grid.Row>
+            <Grid.Column className={'highlights'}>
+              <h3>{t('parcel_detail.tags.title')}</h3>
+              <ParcelTags estate={estate} showDetails={true} />
+            </Grid.Column>
+          </Grid.Row>
+          <Grid.Row>
             {allParcels && (
               <React.Fragment>
                 <Grid.Column
@@ -166,7 +173,11 @@ export default class EstateDetail extends React.PureComponent {
                   {parcels.map(({ x, y }) => {
                     const parcel = allParcels[buildCoordinate(x, y)]
                     return parcel ? (
-                      <ParcelAttributes key={parcel.id} parcel={parcel} />
+                      <ParcelAttributes
+                        key={parcel.id}
+                        parcel={parcel}
+                        withTags={false}
+                      />
                     ) : null
                   })}
                 </Grid.Column>

--- a/webapp/src/components/EstateDetailPage/EstateDetail.js
+++ b/webapp/src/components/EstateDetailPage/EstateDetail.js
@@ -2,9 +2,11 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 import { Icon, Header, Grid, Button } from 'semantic-ui-react'
+import { utils } from 'decentraland-commons'
+import { t } from '@dapps/modules/translation/utils'
+
 import AddressBlock from 'components/AddressBlock'
 import { estateType, parcelType, publicationType } from 'components/types'
-import { t } from '@dapps/modules/translation/utils'
 import { buildCoordinate } from 'shared/parcel'
 import EstateActions from './EstateActions'
 import { getOpenPublication } from 'shared/asset'
@@ -137,12 +139,15 @@ export default class EstateDetail extends React.PureComponent {
               />
             </Grid.Column>
           </Grid.Row>
-          <Grid.Row>
-            <Grid.Column className={'highlights'}>
-              <h3>{t('parcel_detail.tags.title')}</h3>
-              <ParcelTags estate={estate} showDetails={true} />
-            </Grid.Column>
-          </Grid.Row>
+          {estate.parcels.filter(parcel => !utils.isEmptyObject(parcel.tags))
+            .length > 0 && (
+            <Grid.Row>
+              <Grid.Column className={'highlights'}>
+                <h3>{t('parcel_detail.tags.title')}</h3>
+                <ParcelTags estate={estate} showDetails={true} />
+              </Grid.Column>
+            </Grid.Row>
+          )}
           <Grid.Row>
             {allParcels && (
               <React.Fragment>

--- a/webapp/src/components/ParcelAttributes/ParcelAttributes.js
+++ b/webapp/src/components/ParcelAttributes/ParcelAttributes.js
@@ -10,15 +10,17 @@ import { locations } from 'locations'
 export default class ParcelAttributes extends React.PureComponent {
   static propTypes = {
     parcel: parcelType,
-    withLink: PropTypes.bool
+    withLink: PropTypes.bool,
+    withTags: PropTypes.bool
   }
 
   static defaultProps = {
-    withLink: true
+    withLink: true,
+    withTags: true
   }
 
   render() {
-    const { parcel, withLink } = this.props
+    const { parcel, withLink, withTags } = this.props
     const Wrapper = withLink ? Link : React.Fragment
     const wrapperProps = withLink
       ? { to: locations.parcelDetail(parcel.x, parcel.y) }
@@ -30,7 +32,7 @@ export default class ParcelAttributes extends React.PureComponent {
             <Icon name="marker" />
             <span className="coord">{parcel.id}</span>
           </div>
-          <ParcelTags parcel={parcel} size="small" />
+          {withTags && <ParcelTags parcel={parcel} size="small" />}
         </div>
       </Wrapper>
     )


### PR DESCRIPTION
Close #583 

- Remove tags from `Parcels included` section 
- Show highlights

![screen shot 2018-10-18 at 1 36 24 pm](https://user-images.githubusercontent.com/7549152/47169951-3b569180-d2db-11e8-9491-46fc3db7bcd7.png)


I kept the tags from parcel when you edit the Estate's parcels just a way to show the user the attributes of the parcels to be included