### PR TITLE
chore: track fixed and replaced transactions

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -2951,9 +2951,9 @@
       }
     },
     "decentraland-dapps": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-3.8.0.tgz",
-      "integrity": "sha512-Fumr0lCllVdVt0nalN9V7tf17oNJy77sQU42HTpp+nvszWWTm9Na0Rm4k6sRhI7SDOEvAfrQVHLWL/4bbtb9lg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-3.8.1.tgz",
+      "integrity": "sha512-WErVGGtFPN2dfB1PzJM94hoYTEPUzEkWxLAefiOQhwkLFJvBfiBpJgAxjIY2+FTgwAAxNSN6kuGMHcFypXE/5Q==",
       "requires": {
         "@types/axios": "0.14.0",
         "@types/flat": "0.0.28",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -29,7 +29,7 @@
     "css-loader": "0.28.7",
     "date-fns": "^1.29.0",
     "decentraland-commons": "^4.0.1",
-    "decentraland-dapps": "^3.8.0",
+    "decentraland-dapps": "^3.8.1",
     "decentraland-eth": "^7.4.0",
     "decentraland-ui": "^1.10.0",
     "dotenv": "4.0.0",

--- a/webapp/src/modules/analytics/track.js
+++ b/webapp/src/modules/analytics/track.js
@@ -1,6 +1,10 @@
 import { txUtils } from 'decentraland-eth'
 
-import { FETCH_TRANSACTION_FAILURE } from '@dapps/modules/transaction/actions'
+import {
+  FETCH_TRANSACTION_FAILURE,
+  FIX_REVERTED_TRANSACTION,
+  REPLACE_TRANSACTION_SUCCESS
+} from '@dapps/modules/transaction/actions'
 import { add } from '@dapps/modules/analytics/utils'
 import {
   BUY_SUCCESS,
@@ -103,6 +107,14 @@ export function track() {
       action.payload.status === txUtils.TRANSACTION_TYPES.reverted
         ? 'Transaction Failed'
         : 'Transaction Dropped',
+    action => action.payload
+  )
+
+  add(FIX_REVERTED_TRANSACTION, 'Transaction Fixed', action => action.payload)
+
+  add(
+    REPLACE_TRANSACTION_SUCCESS,
+    'Transaction Replaced',
     action => action.payload
   )
 


### PR DESCRIPTION
Currently we are tracking reverted and dropped transactions. Some of the dropped transactions end up being replaced, and some of the reverted transactions are false positives that end up being accepted ("fixed transactions"). We are not keeping track of these scenarios so our analytics show that we have more failures than we actually do.

This PR adds those events to our analytics.