### PR TITLE
chore: bumped decentraland-dapps

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -74,7 +74,7 @@
     },
     "@types/flat": {
       "version": "0.0.28",
-      "resolved": "http://registry.npmjs.org/@types/flat/-/flat-0.0.28.tgz",
+      "resolved": "https://registry.npmjs.org/@types/flat/-/flat-0.0.28.tgz",
       "integrity": "sha1-XHiBSdhabPj/X18ACs3ZEs3qQnQ="
     },
     "@types/history": {
@@ -2951,9 +2951,9 @@
       }
     },
     "decentraland-dapps": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-3.8.1.tgz",
-      "integrity": "sha512-WErVGGtFPN2dfB1PzJM94hoYTEPUzEkWxLAefiOQhwkLFJvBfiBpJgAxjIY2+FTgwAAxNSN6kuGMHcFypXE/5Q==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-3.8.2.tgz",
+      "integrity": "sha512-Par8I8mehkHVB3u/xWY2Ve72DNdT5voH9VDcPc+Q4iChNZC5pwsoipTukJu+gD/Vnk6BfvFH/XZmR/TaQRTSBA==",
       "requires": {
         "@types/axios": "0.14.0",
         "@types/flat": "0.0.28",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -29,7 +29,7 @@
     "css-loader": "0.28.7",
     "date-fns": "^1.29.0",
     "decentraland-commons": "^4.0.1",
-    "decentraland-dapps": "^3.8.1",
+    "decentraland-dapps": "^3.8.2",
     "decentraland-eth": "^7.4.0",
     "decentraland-ui": "^1.10.0",
     "dotenv": "4.0.0",


### PR DESCRIPTION
Bump `decentraland-dapps` to `v3.8.2`. This version makes the `Fix Reverted Transaction` action to trigger a `STORE_SAVE` event, saving the state to localStorage. Otherwise fixed transactions are lost when the user refreshes the page (and they are fixed again, so the user doesn't notice, but this screwed up our analytics metrics since we had more Fixed Transaction events than Failed Transaction ones).

