### PR TITLE
fix: estates within districts

### DIFF
--- a/shared/asset.js
+++ b/shared/asset.js
@@ -1,40 +1,7 @@
 import { contracts } from 'decentraland-eth'
 import { isOpen } from './publication'
 import { isParcel } from './parcel'
-import { isEstate, calculateMapProps } from './estate'
-
-export const ROADS_ID = 'f77140f9-c7b4-4787-89c9-9fa0e219b079'
-export const PLAZA_ID = '55327350-d9f0-4cae-b0f3-8745a0431099'
-
-export const TYPES = Object.freeze({
-  myParcels: 'MY_PARCEL_TYPE',
-  myParcelsOnSale: 'MY_PARCEL_ON_SALE_TYPE',
-  myEstates: 'MY_ESTATE_TYPE',
-  district: 'DISTRICT_TYPE',
-  contribution: 'CONTRIBUTION_TYPE',
-  roads: 'ROADS_TYPE',
-  plaza: 'PLAZA_TYPE',
-  taken: 'TAKEN_TYPE',
-  onSale: 'ON_SALE_TYPE',
-  unowned: 'UNOWNED_TYPE',
-  background: 'BACKGROUND_TYPE',
-  loading: 'LOADING_TYPE'
-})
-
-export const COLORS = Object.freeze({
-  myParcels: '#ff9990',
-  myParcelsOnSale: '#ff4053',
-  district: '#7773ff',
-  contribution: '#4a27d4',
-  roads: '#8188a3',
-  plaza: '#80c290',
-  taken: '#505772',
-  onSale: '#00dbef',
-  unowned: '#1b1e2d',
-  background: '#0d0e18',
-  loadingEven: '#131523',
-  loadingOdd: '#181a29'
-})
+import { calculateMapProps } from './estate'
 
 export const ASSET_TYPES = Object.freeze({
   estate: 'estate',
@@ -52,22 +19,6 @@ export function hasStatus(obj, status) {
   return obj && obj.status === status && !isExpired(obj.expires_at)
 }
 
-export function isRoad(district_id) {
-  return district_id === ROADS_ID
-}
-
-export function isPlaza(district_id) {
-  return district_id === PLAZA_ID
-}
-
-export function isDistrict(asset) {
-  return !!asset.district_id
-}
-
-export function getDistrict(asset, districts = {}) {
-  return asset && districts[asset.district_id]
-}
-
 export function getOpenPublication(asset, publications) {
   if (asset && publications && asset.publication_tx_hash in publications) {
     const publication = publications[asset.publication_tx_hash]
@@ -82,56 +33,6 @@ export function isOnSale(asset, publications) {
   return getOpenPublication(asset, publications) != null
 }
 
-export function getColor(x, y, asset, publications, wallet) {
-  const type = getType(asset, publications, wallet)
-  return getColorByType(type, x, y)
-}
-
-export function getColorByType(type, x, y) {
-  switch (type) {
-    case TYPES.loading: {
-      const isEven = (x + y) % 2 === 0
-      return isEven ? COLORS.loadingEven : COLORS.loadingOdd
-    }
-    case TYPES.myParcels:
-      return COLORS.myParcels
-    case TYPES.myParcelsOnSale:
-      return COLORS.myParcelsOnSale
-    case TYPES.myEstates:
-      return COLORS.myParcels
-    case TYPES.myEstatesOnSale:
-      return COLORS.myParcelsOnSale
-    case TYPES.district:
-      return COLORS.district
-    case TYPES.contribution:
-      return COLORS.contribution
-    case TYPES.roads:
-      return COLORS.roads
-    case TYPES.plaza:
-      return COLORS.plaza
-    case TYPES.taken:
-      return COLORS.taken
-    case TYPES.onSale:
-      return COLORS.onSale
-    case TYPES.unowned:
-      return COLORS.unowned
-    case TYPES.background:
-    default:
-      return COLORS.background
-  }
-}
-
-export function getMapAsset(parcelId, parcels, estates) {
-  const parcel = parcels[parcelId]
-  if (!parcel) {
-    return {}
-  }
-
-  return {
-    asset: parcel.estate_id ? estates[parcel.estate_id] : parcel
-  }
-}
-
 export function isOwner(wallet, assetId) {
   if (!wallet) {
     return false
@@ -141,51 +42,6 @@ export function isOwner(wallet, assetId) {
     return true
   }
   return !!(wallet.estatesById && wallet.estatesById[assetId])
-}
-
-export function getType(asset, publications, wallet) {
-  if (!asset) {
-    return TYPES.loading
-  }
-  const isAssetOwner = wallet && isOwner(wallet, asset.id)
-  if (isEstate(asset)) {
-    if (isOnSale(asset, publications) && isAssetOwner) {
-      return TYPES.myParcelsOnSale
-    }
-    if (isOnSale(asset, publications)) {
-      return TYPES.onSale
-    }
-    return isAssetOwner ? TYPES.myEstates : TYPES.taken
-  }
-
-  if (isDistrict(asset)) {
-    if (isRoad(asset.district_id)) {
-      return TYPES.roads
-    }
-    if (isPlaza(asset.district_id)) {
-      return TYPES.plaza
-    }
-    if (wallet && wallet.contributionsById[asset.district_id]) {
-      return TYPES.contribution
-    }
-    return TYPES.district
-  }
-
-  if (isAssetOwner) {
-    return isOnSale(asset, publications)
-      ? TYPES.myParcelsOnSale
-      : TYPES.myParcels
-  }
-
-  if (!asset.owner && !asset.district_id) {
-    return TYPES.unowned
-  }
-
-  if (isOnSale(asset, publications)) {
-    return TYPES.onSale
-  }
-
-  return TYPES.taken
 }
 
 export function isValidName(name = '') {

--- a/shared/district.js
+++ b/shared/district.js
@@ -1,0 +1,18 @@
+export const ROADS_ID = 'f77140f9-c7b4-4787-89c9-9fa0e219b079'
+export const PLAZA_ID = '55327350-d9f0-4cae-b0f3-8745a0431099'
+
+export function isRoad(district_id) {
+  return district_id === ROADS_ID
+}
+
+export function isPlaza(district_id) {
+  return district_id === PLAZA_ID
+}
+
+export function isDistrict(parcel) {
+  return !!parcel.district_id
+}
+
+export function getDistrict(parcel, districts = {}) {
+  return parcel && districts[parcel.district_id]
+}

--- a/shared/map/Tile.js
+++ b/shared/map/Tile.js
@@ -1,0 +1,128 @@
+import { isOnSale, isOwner } from '../asset'
+import { isDistrict, isPlaza, isRoad } from '../district'
+
+export const TYPES = Object.freeze({
+  myParcels: 'MY_PARCEL_TYPE',
+  myParcelsOnSale: 'MY_PARCEL_ON_SALE_TYPE',
+  myEstates: 'MY_ESTATE_TYPE',
+  myEstatesOnSale: 'MY_ESTATE_ON_SALE_TYPE',
+  district: 'DISTRICT_TYPE',
+  contribution: 'CONTRIBUTION_TYPE',
+  roads: 'ROADS_TYPE',
+  plaza: 'PLAZA_TYPE',
+  taken: 'TAKEN_TYPE',
+  onSale: 'ON_SALE_TYPE',
+  unowned: 'UNOWNED_TYPE',
+  background: 'BACKGROUND_TYPE',
+  loading: 'LOADING_TYPE'
+})
+
+export const COLORS = Object.freeze({
+  myParcels: '#ff9990',
+  myParcelsOnSale: '#ff4053',
+  myEstates: 'ff9990',
+  myEstatesOnSale: 'ff4053',
+  district: '#7773ff',
+  contribution: '#4a27d4',
+  roads: '#8188a3',
+  plaza: '#80c290',
+  taken: '#505772',
+  onSale: '#00dbef',
+  unowned: '#1b1e2d',
+  background: '#0d0e18',
+  loadingEven: '#131523',
+  loadingOdd: '#181a29'
+})
+
+export function getColor(x, y, parcel, estates, publications, wallet) {
+  const type = getType(parcel, estates, publications, wallet)
+  return getColorByType(type, x, y)
+}
+
+export function getColorByType(type, x, y) {
+  switch (type) {
+    case TYPES.loading: {
+      const isEven = (x + y) % 2 === 0
+      return isEven ? COLORS.loadingEven : COLORS.loadingOdd
+    }
+    case TYPES.myParcels:
+      return COLORS.myParcels
+    case TYPES.myParcelsOnSale:
+      return COLORS.myParcelsOnSale
+    case TYPES.myEstates:
+      return COLORS.myParcels
+    case TYPES.myEstatesOnSale:
+      return COLORS.myParcelsOnSale
+    case TYPES.district:
+      return COLORS.district
+    case TYPES.contribution:
+      return COLORS.contribution
+    case TYPES.roads:
+      return COLORS.roads
+    case TYPES.plaza:
+      return COLORS.plaza
+    case TYPES.taken:
+      return COLORS.taken
+    case TYPES.onSale:
+      return COLORS.onSale
+    case TYPES.unowned:
+      return COLORS.unowned
+    case TYPES.background:
+    default:
+      return COLORS.background
+  }
+}
+
+export function getMapAsset(parcelId, parcels, estates) {
+  const parcel = parcels[parcelId]
+  if (!parcel) {
+    return null
+  }
+
+  return parcel.estate_id ? estates[parcel.estate_id] : parcel
+}
+
+export function getType(parcel, estates, publications, wallet) {
+  if (!parcel) {
+    return TYPES.loading
+  }
+
+  if (isDistrict(parcel)) {
+    if (isRoad(parcel.district_id)) {
+      return TYPES.roads
+    }
+    if (isPlaza(parcel.district_id)) {
+      return TYPES.plaza
+    }
+    if (wallet && wallet.contributionsById[parcel.district_id]) {
+      return TYPES.contribution
+    }
+    return TYPES.district
+  }
+
+  const isEstate = !!parcel.estate_id
+  const isAssetOwner =
+    wallet && isOwner(wallet, isEstate ? parcel.estate_id : parcel.id)
+  if (parcel.estate_id == '60') {
+    debugger
+  }
+  const isAssetOnSale = isOnSale(
+    isEstate ? estates[parcel.estate_id] : parcel,
+    publications
+  )
+  if (isAssetOnSale) {
+    return isAssetOwner
+      ? isEstate
+        ? TYPES.myEstatesOnSale
+        : TYPES.myParcelsOnSale
+      : TYPES.onSale
+  } else {
+    return isAssetOwner
+      ? isEstate
+        ? TYPES.myEstates
+        : TYPES.myParcels
+      : parcel.owner
+        ? TYPES.taken
+        : TYPES.unowned
+  }
+}

--- a/shared/map/index.js
+++ b/shared/map/index.js
@@ -1,3 +1,3 @@
 export * from './Bounds'
-export * from './Tile'
+export * from './tile'
 export * from './Viewport'

--- a/shared/map/index.js
+++ b/shared/map/index.js
@@ -1,2 +1,3 @@
 export * from './Bounds'
+export * from './Tile'
 export * from './Viewport'

--- a/shared/map/render/Map.js
+++ b/shared/map/render/Map.js
@@ -1,5 +1,5 @@
 import { Selection, Parcel } from '.'
-import { COLORS, getColor, getMapAsset } from '../../asset'
+import { COLORS, getColor } from '../'
 import { buildCoordinate } from '../../coordinates'
 
 export class Map {
@@ -35,8 +35,7 @@ export class Map {
         const ry = cy - offsetY
         const id = buildCoordinate(px, py)
         const parcel = parcels[id]
-        const { asset } = getMapAsset(id, parcels, estates)
-        const color = getColor(px, py, asset, publications, wallet)
+        const color = getColor(px, py, parcel, estates, publications, wallet)
 
         const connectedLeft = parcel ? parcel.connectedLeft : false
         const connectedTop = parcel ? parcel.connectedTop : false

--- a/shared/map/render/Map.js
+++ b/shared/map/render/Map.js
@@ -1,5 +1,6 @@
-import { Selection, Parcel } from '.'
-import { COLORS, getColor } from '../'
+import { Parcel } from './Parcel'
+import { Selection } from './Selection'
+import { COLORS, getColor } from '../tile'
 import { buildCoordinate } from '../../coordinates'
 
 export class Map {

--- a/shared/map/render/Parcel.js
+++ b/shared/map/render/Parcel.js
@@ -1,4 +1,4 @@
-import { COLORS } from '../../asset'
+import { COLORS } from '../'
 
 export class Parcel {
   static draw({

--- a/shared/map/tile.js
+++ b/shared/map/tile.js
@@ -103,9 +103,6 @@ export function getType(parcel, estates, publications, wallet) {
   const isEstate = !!parcel.estate_id
   const isAssetOwner =
     wallet && isOwner(wallet, isEstate ? parcel.estate_id : parcel.id)
-  if (parcel.estate_id == '60') {
-    debugger
-  }
   const isAssetOnSale = isOnSale(
     isEstate ? estates[parcel.estate_id] : parcel,
     publications

--- a/webapp/src/components/AssetDetailPage/AssetDetailPage.container.js
+++ b/webapp/src/components/AssetDetailPage/AssetDetailPage.container.js
@@ -14,7 +14,8 @@ const mapState = (state, { match }) => {
 }
 
 const mapDispatch = dispatch => ({
-  onAssetClick: asset => dispatch(navigateTo(locations.assetDetail(asset)))
+  onAssetClick: ({ asset }) =>
+    dispatch(navigateTo(locations.assetDetail(asset)))
 })
 
 export default withRouter(connect(mapState, mapDispatch)(AssetDetailPage))

--- a/webapp/src/components/AssetLoader/AssetLoader.container.js
+++ b/webapp/src/components/AssetLoader/AssetLoader.container.js
@@ -7,7 +7,12 @@ import {
   getData as getParcels,
   isFetchingParcel
 } from 'modules/parcels/selectors'
-import { getEstates, isFetchingEstate } from 'modules/estates/selectors'
+import {
+  getEstates,
+  isFetchingEstate,
+  isHiddenEstate,
+  areParcelsLoaded
+} from 'modules/estates/selectors'
 import { fetchEstateRequest } from 'modules/estates/actions'
 import { ASSET_TYPES } from 'shared/asset'
 import { splitCoordinate } from 'shared/coordinates'
@@ -16,17 +21,24 @@ import AssetLoader from './AssetLoader'
 const mapState = (state, { id, assetType }) => {
   let assets
   let isLoading
+  let isLoaded
+  let isHidden
   switch (assetType) {
     case ASSET_TYPES.parcel:
       assets = getParcels(state)
-      isLoading = isFetchingParcel(state)
+      isLoaded = id in assets
+      isLoading = !isLoaded && isFetchingParcel(state)
       break
     case ASSET_TYPES.estate:
       assets = getEstates(state)
-      isLoading = isFetchingEstate(state)
+      isLoaded = id in assets
+      isLoading =
+        (!isLoaded && isFetchingEstate(state)) ||
+        (isLoaded && !areParcelsLoaded(state, { id }))
+      isHidden = !isLoading && isHiddenEstate(state, { id })
       break
   }
-  const asset = assets[id]
+  const asset = isHidden ? null : assets[id]
 
   return {
     isLoading,

--- a/webapp/src/components/AtlasPage/Map/Map.container.js
+++ b/webapp/src/components/AtlasPage/Map/Map.container.js
@@ -36,7 +36,7 @@ const mapDispatch = (dispatch, { location }) => ({
   onLoading: () => dispatch(setLoading(true)),
   onChange: (x, y) =>
     dispatch(push(locations.parcelMapDetail(x, y, getMarker(location)))),
-  onSelect: asset => dispatch(push(locations.assetDetail(asset)))
+  onSelect: ({ asset }) => dispatch(push(locations.assetDetail(asset)))
 })
 
 export default withRouter(connect(mapState, mapDispatch)(MapComponent))

--- a/webapp/src/components/AuctionPage/AuctionPage.js
+++ b/webapp/src/components/AuctionPage/AuctionPage.js
@@ -60,7 +60,7 @@ export default class AuctionPage extends React.PureComponent {
     return authorization && !isAuthorized(authorization)
   }
 
-  selectUnownedParcel = (asset, { x, y }) => {
+  selectUnownedParcel = ({ asset, x, y }) => {
     const { selectedCoordsById } = this.state
 
     // TODO: Check ownership with contract

--- a/webapp/src/components/EditEstatePage/EstateSelect/EstateSelect.js
+++ b/webapp/src/components/EditEstatePage/EstateSelect/EstateSelect.js
@@ -47,7 +47,7 @@ export default class EstateSelect extends React.PureComponent {
     onDeleteEstate: PropTypes.func.isRequired
   }
 
-  parcelClickHandler = (asset, { x, y }) => {
+  parcelClickHandler = ({ asset, x, y }) => {
     const { wallet } = this.props
 
     if (!isOwner(wallet, buildCoordinate(x, y)) && !isOwner(wallet, asset.id)) {

--- a/webapp/src/components/NotFound/NotFound.css
+++ b/webapp/src/components/NotFound/NotFound.css
@@ -1,0 +1,14 @@
+.NotFound {
+  display: flex;
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  justify-content: center;
+  align-items: center;
+}
+
+.NotFound .message {
+  color: var(--gray);
+}

--- a/webapp/src/components/NotFound/NotFound.js
+++ b/webapp/src/components/NotFound/NotFound.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import { t } from '@dapps/modules/translation/utils'
+import './NotFound.css'
+
+export default class NotFound extends React.PureComponent {
+  render() {
+    return (
+      <div className="NotFound">
+        <div className="message">{t('marketplace.empty')}</div>
+      </div>
+    )
+  }
+}

--- a/webapp/src/components/NotFound/index.js
+++ b/webapp/src/components/NotFound/index.js
@@ -1,0 +1,2 @@
+import NotFound from './NotFound'
+export default NotFound

--- a/webapp/src/components/ParcelDetailPage/ParcelDetail/ParcelDetail.js
+++ b/webapp/src/components/ParcelDetailPage/ParcelDetail/ParcelDetail.js
@@ -15,7 +15,8 @@ import {
   walletType,
   estateType
 } from 'components/types'
-import { getDistrict, getOpenPublication } from 'shared/asset'
+import { getOpenPublication } from 'shared/asset'
+import { getDistrict } from 'shared/district'
 import { hasTags } from 'shared/parcel'
 import ParcelOwner from './ParcelOwner'
 import ParcelActions from './ParcelActions'

--- a/webapp/src/components/ParcelDetailPage/ParcelDetail/ParcelOwner/ParcelOwner.js
+++ b/webapp/src/components/ParcelDetailPage/ParcelDetail/ParcelOwner/ParcelOwner.js
@@ -7,7 +7,7 @@ import { locations } from 'locations'
 import AddressBlock from 'components/AddressBlock'
 import { parcelType, districtType, estateType } from 'components/types'
 import { t, T } from '@dapps/modules/translation/utils'
-import { getDistrict, isDistrict } from 'shared/asset'
+import { getDistrict, isDistrict } from 'shared/district'
 
 import './ParcelOwner.css'
 

--- a/webapp/src/components/ParcelPreview/ParcelCanvas/ParcelCanvas.js
+++ b/webapp/src/components/ParcelPreview/ParcelCanvas/ParcelCanvas.js
@@ -372,12 +372,7 @@ export default class ParcelPreview extends React.PureComponent {
           asset = parcel
           break
       }
-      onClick({
-        type,
-        asset,
-        x,
-        y
-      })
+      onClick({ type, asset, x, y })
     }
   }
 

--- a/webapp/src/components/ParcelPreview/ParcelCanvas/ParcelCanvas.js
+++ b/webapp/src/components/ParcelPreview/ParcelCanvas/ParcelCanvas.js
@@ -11,15 +11,18 @@ import {
   publicationType
 } from 'components/types'
 import { isMobileWidth } from 'lib/utils'
+import { getOpenPublication, ASSET_TYPES } from 'shared/asset'
+import { buildCoordinate } from 'shared/coordinates'
 import {
+  Bounds,
+  Viewport,
   getMapAsset,
   getType,
   getColorByType,
-  getOpenPublication
-} from 'shared/asset'
-import { buildCoordinate } from 'shared/coordinates'
+  TYPES
+} from 'shared/map'
 import { Map as MapRenderer } from 'shared/map/render'
-import { Bounds, Viewport } from 'shared/map'
+import { isParcel } from 'shared/parcel'
 import {
   getLabel,
   getTextColor,
@@ -351,14 +354,30 @@ export default class ParcelPreview extends React.PureComponent {
 
     const parcelId = buildCoordinate(x, y)
     const { onClick, parcels, estates } = this.props
-    const { asset } = getMapAsset(parcelId, parcels, estates)
+
+    let asset = getMapAsset(parcelId, parcels, estates)
 
     if (
       onClick &&
       Date.now() - this.mousedownTimestamp < 200 &&
       asset != null
     ) {
-      onClick(asset, parcels[parcelId])
+      const type = isParcel(asset) ? ASSET_TYPES.parcel : ASSET_TYPES.estate
+      const parcel = parcels[parcelId]
+      // if the parcel clicked is a district/plaza/road, send the parcel to the callback
+      switch (getType(parcel, estates)) {
+        case TYPES.district:
+        case TYPES.plaza:
+        case TYPES.roads:
+          asset = parcel
+          break
+      }
+      onClick({
+        type,
+        asset,
+        x,
+        y
+      })
     }
   }
 
@@ -444,10 +463,11 @@ export default class ParcelPreview extends React.PureComponent {
     }
 
     const { wallet, parcels, districts, publications, estates } = this.props
-    const { asset } = getMapAsset(parcelId, parcels, estates)
+    const asset = getMapAsset(parcelId, parcels, estates)
+    const parcel = parcels[parcelId]
     const publication = getOpenPublication(asset, publications)
 
-    const type = getType(asset, publications, wallet)
+    const type = getType(parcel, estates, publications, wallet)
     const color = getTextColor(type)
     const label = getLabel(type, asset, districts)
     const description = getDescription(type, asset)

--- a/webapp/src/components/ParcelPreview/ParcelCanvas/utils.js
+++ b/webapp/src/components/ParcelPreview/ParcelCanvas/utils.js
@@ -8,7 +8,7 @@ import * as wheel from 'mouse-wheel'
 import * as touchPinch from 'touch-pinch'
 import * as position from 'touch-position'
 import { t } from '@dapps/modules/translation/utils'
-import { TYPES } from 'shared/asset'
+import { TYPES } from 'shared/map'
 import { shortenAddress } from 'lib/utils'
 
 export function panzoom(target, cb) {

--- a/webapp/src/components/ParcelTags/ParcelTags.js
+++ b/webapp/src/components/ParcelTags/ParcelTags.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 import { parcelType, districtType, estateType } from 'components/types'
 import { t } from '@dapps/modules/translation/utils'
-import { getDistrict, isRoad, isPlaza } from 'shared/asset'
+import { getDistrict, isRoad, isPlaza } from 'shared/district'
 
 import './ParcelTags.css'
 

--- a/webapp/src/modules/estates/selectors.js
+++ b/webapp/src/modules/estates/selectors.js
@@ -71,3 +71,34 @@ export const getEstates = createSelector(
       return acc
     }, {})
 )
+
+export const getEstate = (state, { id }) => getEstates(state)[id]
+
+export const isHiddenEstate = createSelector(
+  (state, props) => getEstate(state, props),
+  state => getParcels(state),
+  (estate, parcels) => {
+    if (estate && estate.data.parcels.length > 0) {
+      return estate.data.parcels.some(({ x, y }) => {
+        const parcelId = buildCoordinate(x, y)
+        const parcel = parcels[parcelId]
+        return parcel != null && parcel.district_id != null // if the Estate contains any parcels with a district_id, it is a hidden Estate
+      })
+    }
+  }
+)
+
+export const areParcelsLoaded = createSelector(
+  (state, props) => getEstate(state, props),
+  state => getParcels(state),
+  (estate, parcels) => {
+    if (!estate) {
+      return false
+    }
+    return estate.data.parcels.every(({ x, y }) => {
+      const parcelId = buildCoordinate(x, y)
+      const parcel = parcels[parcelId]
+      return parcel != null
+    })
+  }
+)


### PR DESCRIPTION
This PR fixes the map rendered, the click handler and the popup for estates that are deployed within districts (this includes plazas and roads)

# How to test

Here are some queries to insert estates inside a plaza, a road and a district:

Insert an estate in Genesis Plaza (-4, 8)

```sql
INSERT INTO estates (id, owner, data, last_transferred_at, created_at, updated_at, tx_hash, token_id) VALUES ('9000', '0xfa5ad346a73fcd3defa42c694a710fe3c3dc6405', '{"ipns": "", "name": "TEST", "version": 0, "description": "", "parcels": ""}', 1541071498000, now(), now(), '0xdeadbeef', '9000');
UPDATE parcels SET estate_id = '9000' WHERE id IN ('-4,8', '-4,7');
UPDATE estates E SET data = jsonb_set(
  data,
  '{parcels}',
  (SELECT json_agg(json_build_object('x', P.x, 'y', P.y)) FROM parcels P WHERE P.estate_id = E.id)::jsonb
) WHERE E.id = '9000';
```

Insert an estate in a road (-10, 8)

```sql
INSERT INTO estates (id, owner, data, last_transferred_at, created_at, updated_at, tx_hash, token_id) VALUES ('9001', '0xfa5ad346a73fcd3defa42c694a710fe3c3dc6405', '{"ipns": "", "name": "TEST", "version": 0, "description": "", "parcels": ""}', 1541071498000, now(), now(), '0xfaceb00k', '9001');
UPDATE parcels SET estate_id = '9001' WHERE id IN ('-10,8', '-10,7');
UPDATE estates E SET data = jsonb_set(
  data,
  '{parcels}',
  (SELECT json_agg(json_build_object('x', P.x, 'y', P.y)) FROM parcels P WHERE P.estate_id = E.id)::jsonb
) WHERE E.id = '9001';
```

Insert an estate in Bittrex Tomorrow district (-57, 8)

```sql
INSERT INTO estates (id, owner, data, last_transferred_at, created_at, updated_at, tx_hash, token_id) VALUES ('9002', '0xfa5ad346a73fcd3defa42c694a710fe3c3dc6405', '{"ipns": "", "name": "TEST", "version": 0, "description": "", "parcels": ""}', 1541071498000, now(), now(), '0xcafebabe', '9002');
UPDATE parcels SET estate_id = '9002' WHERE id IN ('-57,8', '-57,7');
UPDATE estates E SET data = jsonb_set(
  data,
  '{parcels}',
  (SELECT json_agg(json_build_object('x', P.x, 'y', P.y)) FROM parcels P WHERE P.estate_id = E.id)::jsonb
) WHERE E.id = '9002';
```

The map should behave unaffected by these estates (rendering/clicking/hovering)