### PR TITLE
feat: prevent showing market tos in auction

### DIFF
--- a/webapp/src/components/Page/Page.container.js
+++ b/webapp/src/components/Page/Page.container.js
@@ -2,12 +2,13 @@ import { connect } from 'react-redux'
 
 import { fetchDistrictsRequest } from 'modules/districts/actions'
 import { openModal } from 'modules/ui/actions'
-import { isRootPage } from 'modules/location/selectors'
+import { isRootPage, isAuctionPage } from 'modules/location/selectors'
 
 import Page from './Page'
 
 const mapState = state => ({
-  isRootPage: isRootPage(state)
+  isRootPage: isRootPage(state),
+  isAuctionPage: isAuctionPage(state)
 })
 
 const mapDispatch = dispatch => ({

--- a/webapp/src/components/Page/Page.js
+++ b/webapp/src/components/Page/Page.js
@@ -11,6 +11,7 @@ export default class Page extends React.PureComponent {
   static propTypes = {
     children: PropTypes.node.isRequired,
     isRootPage: PropTypes.bool.isRequired,
+    isAuctionPage: PropTypes.bool.isRequired,
     onFetchDistricts: PropTypes.func.isRequired,
     onFirstVisit: PropTypes.func.isRequired
   }
@@ -18,29 +19,30 @@ export default class Page extends React.PureComponent {
   static defaultProps = {
     children: null,
     isRootPage: false,
+    isAuctionPage: false,
     onFetchDistricts: () => {},
     onFirstVisit: () => {}
   }
 
   componentWillMount() {
-    const { onFetchDistricts, isRootPage } = this.props
+    const { onFetchDistricts, isRootPage, isAuctionPage } = this.props
 
     onFetchDistricts()
-    this.showTermsModal(isRootPage)
+    this.showTermsModal(isRootPage, isAuctionPage)
   }
 
   componentWillReceiveProps(nextProps) {
-    this.showTermsModal(nextProps.isRootPage)
+    this.showTermsModal(nextProps.isRootPage, nextProps.isAuctionPage)
   }
 
-  showTermsModal(isRootPage) {
-    if (this.shouldTriggerTermsModal(isRootPage)) {
+  showTermsModal(isRootPage, isAuctionPage) {
+    if (this.shouldTriggerTermsModal(isRootPage, isAuctionPage)) {
       this.props.onFirstVisit()
     }
   }
 
-  shouldTriggerTermsModal(isRootPage) {
-    return !isRootPage && !hasAgreedToTerms()
+  shouldTriggerTermsModal(isRootPage, isAuctionPage) {
+    return !isRootPage && !isAuctionPage && !hasAgreedToTerms()
   }
 
   render() {

--- a/webapp/src/modules/location/selectors.js
+++ b/webapp/src/modules/location/selectors.js
@@ -2,6 +2,7 @@ import { locations } from 'locations'
 import { getPathname, getPathAction } from '@dapps/modules/location/selectors'
 
 export const isRootPage = state => getPathname(state) === locations.root()
+export const isAuctionPage = state => getPathname(state) === locations.auction()
 export const isModalPage = state => {
   const lastPartOfUrl = getPathAction(state)
   switch (lastPartOfUrl) {


### PR DESCRIPTION
This prevents showing the marketplace tos modal on the `/auction`, this is to prevent users from seeing 2 modals if it's the first time they arrive to the marketplace, and they land on the auction page.

They will still see it if they navigate to the rest of the marketplace. 

We could include the market tos into the auction modal checkbox as well if needed.