### PR TITLE
feat: defer update of the owner, update owners of selection, remove sold parcels from actual purchase

### DIFF
--- a/src/Translation/locales/en.json
+++ b/src/Translation/locales/en.json
@@ -124,7 +124,7 @@
     "welcome": "Welcome to the Decentraland LAND Auction!"
   },
   "auction_page": {
-    "available_parcels": "Available parcels",
+    "available_parcels": "parcels available",
     "bid": "Purchase",
     "description": "Find the LAND you want to buy",
     "empty_message":

--- a/src/Translation/locales/en.json
+++ b/src/Translation/locales/en.json
@@ -109,7 +109,7 @@
     "authorize_token": "Authorize {token} token",
     "confirmation": "Confirmation",
     "confirmation_description":
-      "You are about to purchase {parcels} LAND for {price} {token}",
+      "You are about to purchase {parcels} parcels of LAND for {price} {token}",
     "description":
       "There are just two things you need to do before you can start. First, you need to select the tokens you want to buy LAND with. Next, you have to authorize a new smart contract to access those tokens when you buy LAND.",
     "get_started": "Get started",

--- a/src/Translation/locales/es.json
+++ b/src/Translation/locales/es.json
@@ -110,7 +110,7 @@
     "authorize_token": "Autorizar el token {token}",
     "confirmation": "Confirmación",
     "confirmation_description":
-      "Está a punto de comprar {parcels} LAND por {price} {token}",
+      "Está a punto de comprar {parcels} parcelas de LAND por {price} {token}",
     "description":
       "Para participar en esta nueva subasta, deberá autorizar el nuevo contrato {contract_link}.",
     "get_started": "Empezar",

--- a/src/Translation/locales/es.json
+++ b/src/Translation/locales/es.json
@@ -125,7 +125,7 @@
     "welcome": "Bienvenido a la subasta Decentraland LAND!"
   },
   "auction_page": {
-    "available_parcels": "Parcelas disponibles",
+    "available_parcels": "parcelas disponibles",
     "bid": "Comprar",
     "description": "Encuentra LAND que quieres comprar.",
     "empty_message":

--- a/src/Translation/locales/fr.json
+++ b/src/Translation/locales/fr.json
@@ -127,7 +127,7 @@
     "welcome": "Bienvenue à la vente aux enchères Decentraland LAND!"
   },
   "auction_page": {
-    "available_parcels": "Colis disponibles",
+    "available_parcels": "colis disponibles",
     "bid": "Achat",
     "description": "Trouvez le LAND que vous voulez acheter",
     "empty_message":

--- a/webapp/src/components/AuctionPage/AuctionPage.container.js
+++ b/webapp/src/components/AuctionPage/AuctionPage.container.js
@@ -58,7 +58,10 @@ const mapState = state => {
     rate: getRate(state),
     selectedCoordinatesById: getSelectedCoordinatesById(state),
     wallet,
-    allParcels
+    allParcels,
+    // this is not used on the AuctionPage, but since we mutate allParcels,
+    // we pass this down to for a re-render down the tree
+    parcelOnChainOwners
   }
 }
 

--- a/webapp/src/components/AuctionPage/AuctionPage.container.js
+++ b/webapp/src/components/AuctionPage/AuctionPage.container.js
@@ -10,7 +10,8 @@ import {
   getCenter,
   getLoading,
   getSelectedToken,
-  getRate
+  getRate,
+  getSelectedCoordinatesById
 } from 'modules/auction/selectors'
 import { getModal } from 'modules/ui/selectors'
 import { openModal } from 'modules/ui/actions'
@@ -22,7 +23,8 @@ import {
   fetchAuctionParamsRequest,
   fetchAuctionRateRequest,
   setParcelOnChainOwner,
-  changeAuctionCenterParcel
+  changeAuctionCenterParcel,
+  setSelectedCoordinates
 } from 'modules/auction/actions'
 import AuctionPage from './AuctionPage'
 
@@ -54,6 +56,7 @@ const mapState = state => {
     modal: getModal(state),
     token: getSelectedToken(state),
     rate: getRate(state),
+    selectedCoordinatesById: getSelectedCoordinatesById(state),
     wallet,
     allParcels
   }
@@ -69,7 +72,9 @@ const mapDispatch = dispatch => ({
     dispatch(changeAuctionCenterParcel(parcel)),
   onSubmit: (parcels, beneficiary) =>
     dispatch(openModal('BidConfirmationModal', { parcels, beneficiary })),
-  onChangeToken: token => dispatch(fetchAuctionRateRequest(token))
+  onChangeToken: token => dispatch(fetchAuctionRateRequest(token)),
+  onChangeCoords: selectedCoordinatesById =>
+    dispatch(setSelectedCoordinates(selectedCoordinatesById))
 })
 
 export default connect(mapState, mapDispatch)(AuctionPage)

--- a/webapp/src/components/AuctionPage/AuctionPage.js
+++ b/webapp/src/components/AuctionPage/AuctionPage.js
@@ -70,6 +70,7 @@ export default class AuctionPage extends React.PureComponent {
 
     this.hasFetchedParams = false
     this.mounted = false
+    this.timoutId = null
 
     this.state = {
       showTokenTooltip: !hasSeenAuctionHelper(
@@ -95,6 +96,10 @@ export default class AuctionPage extends React.PureComponent {
 
   componentWillUnmount() {
     this.mounted = false
+    if (this.timoutId != null) {
+      clearTimeout(this.timeoutId)
+      this.timeoutId = null
+    }
   }
 
   componentWillReceiveProps(nextProps) {
@@ -199,7 +204,7 @@ export default class AuctionPage extends React.PureComponent {
 
   updateSelectionOwners = async () => {
     await Promise.all(this.getSelectedParcels().map(this.updateOwner))
-    setTimeout(() => {
+    this.timoutId = setTimeout(() => {
       if (!this.mounted) return
       this.updateSelectionOwners()
     }, REFRESH_OWNERS_INTERVAL)

--- a/webapp/src/components/AuctionPage/AuctionPage.js
+++ b/webapp/src/components/AuctionPage/AuctionPage.js
@@ -21,7 +21,8 @@ import {
   authorizationType,
   auctionParamsType,
   walletType,
-  parcelType
+  parcelType,
+  coordsType
 } from 'components/types'
 import {
   hasSeenAuctionHelper,
@@ -57,8 +58,10 @@ export default class AuctionPage extends React.PureComponent {
     onSetParcelOnChainOwner: PropTypes.func.isRequired,
     onFetchAvailableParcel: PropTypes.func.isRequired,
     onChangeAuctionCenterParcel: PropTypes.func.isRequired,
+    onChangeCoords: PropTypes.func.isRequired,
     token: PropTypes.oneOf(TOKEN_SYMBOLS),
-    rate: PropTypes.number
+    rate: PropTypes.number,
+    selectedCoordinatesById: PropTypes.objectOf(coordsType).isRequired
   }
 
   constructor(props) {
@@ -68,7 +71,6 @@ export default class AuctionPage extends React.PureComponent {
     this.mounted = false
 
     this.state = {
-      selectedCoordinatesById: {},
       showTokenTooltip: !hasSeenAuctionHelper(
         AUCTION_HELPERS.SEEN_AUCTION_TOKEN_TOOLTIP
       )
@@ -130,19 +132,19 @@ export default class AuctionPage extends React.PureComponent {
     this.updateOwner(asset)
 
     const wasOverLimit = this.hasReachedLimit(
-      this.state.selectedCoordinatesById
+      this.props.selectedCoordinatesById
     )
     const newSelectedCoordsById = this.buildNewSelectedCoords(asset)
     const isOverLimit = this.hasReachedLimit(newSelectedCoordsById)
 
     if (!wasOverLimit || (wasOverLimit && !isOverLimit)) {
-      this.setState({ selectedCoordinatesById: newSelectedCoordsById })
+      this.props.onChangeCoords(newSelectedCoordsById)
     }
   }
 
   handleDeselectUnownedParcel = parcel => {
     const newSelectedCoordsById = this.buildNewSelectedCoords(parcel)
-    this.setState({ selectedCoordinatesById: newSelectedCoordsById })
+    this.props.onChangeCoords(newSelectedCoordsById)
   }
 
   handleFindAvailableParcel = () => {
@@ -201,7 +203,7 @@ export default class AuctionPage extends React.PureComponent {
   }
 
   buildNewSelectedCoords(parcel) {
-    const { selectedCoordinatesById } = this.state
+    const { selectedCoordinatesById } = this.props
     const { id, x, y } = parcel
     const isSelected = selectedCoordinatesById[id] !== undefined
 
@@ -211,7 +213,7 @@ export default class AuctionPage extends React.PureComponent {
   }
 
   buildNewSelectionCoordsWithoutParcel(parcel) {
-    const { selectedCoordinatesById } = this.state
+    const { selectedCoordinatesById } = this.props
     return utils.omit(selectedCoordinatesById, parcel.id)
   }
 
@@ -221,8 +223,7 @@ export default class AuctionPage extends React.PureComponent {
   }
 
   getSelectedParcels() {
-    const { allParcels } = this.props
-    const { selectedCoordinatesById } = this.state
+    const { allParcels, selectedCoordinatesById } = this.props
 
     if (!allParcels) return []
 
@@ -252,10 +253,14 @@ export default class AuctionPage extends React.PureComponent {
       center,
       allParcels,
       token,
-      rate
+      rate,
+      selectedCoordinatesById,
+      isConnecting,
+      isConnected,
+      isAvailableParcelLoading
     } = this.props
-    const { isConnecting, isConnected, isAvailableParcelLoading } = this.props
-    const { selectedCoordinatesById, showTokenTooltip } = this.state
+
+    const { showTokenTooltip } = this.state
     const {
       availableParcelCount,
       landsLimitPerBid,

--- a/webapp/src/components/AuctionPage/AuctionPage.js
+++ b/webapp/src/components/AuctionPage/AuctionPage.js
@@ -218,8 +218,13 @@ export default class AuctionPage extends React.PureComponent {
   }
 
   hasReachedLimit(selected) {
-    const { landsLimitPerBid } = this.props.params
-    return Object.keys(selected).length >= landsLimitPerBid
+    const { allParcels, params } = this.props
+    const { landsLimitPerBid } = params
+    return (
+      Object.keys(selected).filter(
+        parcelId => allParcels[parcelId].owner == null
+      ).length >= landsLimitPerBid
+    )
   }
 
   getSelectedParcels() {

--- a/webapp/src/components/AuctionPage/AuctionPage.js
+++ b/webapp/src/components/AuctionPage/AuctionPage.js
@@ -61,7 +61,8 @@ export default class AuctionPage extends React.PureComponent {
     onChangeCoords: PropTypes.func.isRequired,
     token: PropTypes.oneOf(TOKEN_SYMBOLS),
     rate: PropTypes.number,
-    selectedCoordinatesById: PropTypes.objectOf(coordsType).isRequired
+    selectedCoordinatesById: PropTypes.objectOf(coordsType).isRequired,
+    parcelOnChainOwners: PropTypes.objectOf(PropTypes.string).isRequired
   }
 
   constructor(props) {

--- a/webapp/src/components/AuctionPage/AuctionPage.js
+++ b/webapp/src/components/AuctionPage/AuctionPage.js
@@ -80,7 +80,9 @@ export default class AuctionPage extends React.PureComponent {
 
   componentWillMount() {
     const { onFetchAvailableParcel, isConnected } = this.props
-    onFetchAvailableParcel()
+    if (this.getSelectedParcels().length === 0) {
+      onFetchAvailableParcel()
+    }
 
     if (isConnected) {
       this.showAuctionModal(this.props)

--- a/webapp/src/components/AuctionPage/AuctionPage.js
+++ b/webapp/src/components/AuctionPage/AuctionPage.js
@@ -298,7 +298,7 @@ export default class AuctionPage extends React.PureComponent {
       )
     }
 
-    const selectedParcels = this.getSelectedParcels(true)
+    const selectedParcels = this.getSelectedParcels()
     const validSelectedParcels = selectedParcels.filter(
       parcel => parcel.owner == null
     )

--- a/webapp/src/components/Modal/BidConfirmationModal/BidConfirmationModal.container.js
+++ b/webapp/src/components/Modal/BidConfirmationModal/BidConfirmationModal.container.js
@@ -53,7 +53,7 @@ const mapState = state => {
   // compute price
   const { currentPrice } = getParams(state)
   const rate = getRate(state)
-  const price = Number((currentPrice * rate).toFixed(2))
+  const price = Number((currentPrice * rate * parcels.length).toFixed(2))
 
   return {
     token,

--- a/webapp/src/components/Modal/BidConfirmationModal/BidConfirmationModal.container.js
+++ b/webapp/src/components/Modal/BidConfirmationModal/BidConfirmationModal.container.js
@@ -8,7 +8,12 @@ import {
 
 import { bidOnParcelsRequest } from 'modules/auction/actions'
 import { closeModal } from 'modules/ui/actions'
-import { getSelectedToken, getParams, getRate } from 'modules/auction/selectors'
+import {
+  getSelectedToken,
+  getParams,
+  getRate,
+  getParcelsForConfirmation
+} from 'modules/auction/selectors'
 import {
   allowTokenRequest,
   ALLOW_TOKEN_SUCCESS
@@ -20,7 +25,8 @@ import { token as tokenHelper } from 'lib/token'
 import BidConfirmationModal from './BidConfirmationModal'
 
 const mapState = state => {
-  const { parcels, beneficiary } = getModal(state).data || {}
+  const { beneficiary } = getModal(state).data || {}
+  const parcels = getParcelsForConfirmation(state)
   const address = getAddress(state)
   const token = getSelectedToken(state)
 

--- a/webapp/src/components/Modal/BidConfirmationModal/BidConfirmationModal.js
+++ b/webapp/src/components/Modal/BidConfirmationModal/BidConfirmationModal.js
@@ -25,9 +25,8 @@ export default class BidConfirmationModal extends React.PureComponent {
   }
 
   handleSubmit = () => {
-    const { parcels, beneficiary, isAuthorized, onClose, onSubmit } = this.props
+    const { parcels, beneficiary, isAuthorized, onSubmit } = this.props
     if (isAuthorized) {
-      onClose()
       onSubmit(parcels, beneficiary)
     }
   }

--- a/webapp/src/components/SignInPage/WalletIcon.js
+++ b/webapp/src/components/SignInPage/WalletIcon.js
@@ -8,29 +8,6 @@ const WalletIcon = () => (
     version="1.1"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <desc>Created with Sketch.</desc>
-    <defs>
-      <linearGradient
-        x1="50%"
-        y1="100%"
-        x2="50%"
-        y2="-2.48949813e-15%"
-        id="linearGradient-112"
-      >
-        <stop stopColor="#1F2333" offset="0%" />
-        <stop stopColor="#0D0F17" offset="100%" />
-      </linearGradient>
-      <linearGradient
-        x1="50%"
-        y1="100%"
-        x2="50%"
-        y2="3.061617e-15%"
-        id="linearGradient-222"
-      >
-        <stop stopColor="#00D7EB" offset="0%" />
-        <stop stopColor="#007B87" offset="100%" />
-      </linearGradient>
-    </defs>
     <g
       id="Marketplace12"
       stroke="none"
@@ -44,17 +21,11 @@ const WalletIcon = () => (
       >
         <g id="Group-5" transform="translate(360.000000, 184.000000)">
           <g id="Group-4" transform="translate(270.000000, 192.000000)">
-            <circle
-              id="Oval-2"
-              fill="url(#linearGradient-112)"
-              cx="90"
-              cy="90"
-              r="90"
-            />
+            <circle id="Oval-2" fill="#272329" cx="90" cy="90" r="90" />
             <path
               d="M125,87.125 L120,87.125 L120,70 L68.5,70 C67.1215,70 66,68.8785 66,67.5 C66,66.1215 67.1215,65 68.5,65 L115,65 L115,60 L68.5,60 C64.3645,60 61,63.3645 61,67.5 L61,111.5 C61,115.6355 64.3645,119 68.5,119 L120,119 L120,102.125 L125,102.125 L125,87.125 Z M115,114 L68.5,114 C67.1215,114 66,112.8785 66,111.5 L66,74.57 C66.7825,74.8475 67.623625,75 68.5,75 L115,75 L115,87.125 L109.25,87.125 C105.1145,87.125 101.75,90.4895 101.75,94.625 C101.75,98.7605 105.1145,102.125 109.25,102.125 L115,102.125 L115,114 Z M120,97.125 L109.25,97.125 C107.8715,97.125 106.75,96.0035 106.75,94.625 C106.75,93.2465 107.8715,92.125 109.25,92.125 L120,92.125 L120,97.125 Z"
               id="Shape"
-              fill="url(#linearGradient-222)"
+              fill="#ffffff"
               fillRule="nonzero"
             />
           </g>

--- a/webapp/src/modules/auction/actions.js
+++ b/webapp/src/modules/auction/actions.js
@@ -110,3 +110,14 @@ export function fetchAuctionRateFailure(token, error) {
     error
   }
 }
+
+// Set selecteted coordinates
+
+export const SET_SELECTED_COORDINATES = 'Set selected coordinates'
+
+export function setSelectedCoordinates(selectedCoordinatesById) {
+  return {
+    type: SET_SELECTED_COORDINATES,
+    selectedCoordinatesById
+  }
+}

--- a/webapp/src/modules/auction/reducer.js
+++ b/webapp/src/modules/auction/reducer.js
@@ -8,7 +8,8 @@ import {
   FETCH_AUCTION_RATE_SUCCESS,
   FETCH_AUCTION_RATE_FAILURE,
   SET_ON_CHAIN_PARCEL_OWNER,
-  CHANGE_AUCTION_CENTER_PARCEL
+  CHANGE_AUCTION_CENTER_PARCEL,
+  SET_SELECTED_COORDINATES
 } from './actions'
 import {
   FETCH_AVAILABLE_PARCEL_REQUEST,
@@ -33,6 +34,9 @@ const INITIAL_STATE = {
     },
     parcelOnChainOwners: {
       /* [parcelId]: owner */
+    },
+    selectedCoordinatesById: {
+      /* [parcelId]: true */
     }
   },
   loading: [],
@@ -122,5 +126,15 @@ export function auctionReducer(state = INITIAL_STATE, action) {
     }
     default:
       return state
+
+    case SET_SELECTED_COORDINATES: {
+      return {
+        ...state,
+        data: {
+          ...state.data,
+          selectedCoordinatesById: action.selectedCoordinatesById
+        }
+      }
+    }
   }
 }

--- a/webapp/src/modules/auction/sagas.js
+++ b/webapp/src/modules/auction/sagas.js
@@ -7,6 +7,7 @@ import { isConnected } from '@dapps/modules/wallet/selectors'
 import { navigateTo } from '@dapps/modules/location/actions'
 import { getPathname } from '@dapps/modules/location/selectors'
 
+import { closeModal } from 'modules/ui/actions'
 import {
   FETCH_AUCTION_PARAMS_REQUEST,
   FETCH_AUCTION_RATE_REQUEST,
@@ -19,7 +20,8 @@ import {
   fetchAuctionParamsSuccess,
   fetchAuctionParamsFailure,
   bidOnParcelsSuccess,
-  bidOnParcelsFailure
+  bidOnParcelsFailure,
+  setSelectedCoordinates
 } from './actions'
 import { locations } from 'locations'
 import { api } from 'lib/api'
@@ -85,6 +87,8 @@ function* handleBidRequest(action) {
     )
 
     yield put(bidOnParcelsSuccess(txHash, xs, ys, beneficiary))
+    yield put(closeModal())
+    yield put(setSelectedCoordinates({}))
     yield put(push(locations.activity()))
   } catch (error) {
     yield put(bidOnParcelsFailure(error.message))

--- a/webapp/src/modules/auction/selectors.js
+++ b/webapp/src/modules/auction/selectors.js
@@ -2,6 +2,8 @@ import queryString from 'query-string'
 import { createSelector } from 'reselect'
 import { getLocation } from '@dapps/modules/location/selectors'
 
+import { getData as getParcels } from 'modules/parcels/selectors'
+
 import { TOKEN_SYMBOLS } from './utils'
 
 export const getState = state => state.auction
@@ -38,4 +40,18 @@ export const getRate = createSelector(
   getRates,
   (selectedToken, rates) =>
     selectedToken in rates ? rates[selectedToken] : null
+)
+
+export const getSelectedCoordinatesById = state =>
+  getData(state).selectedCoordinatesById
+
+export const getParcelsForConfirmation = createSelector(
+  state => getSelectedCoordinatesById(state),
+  state => getParcelOnChainOwners(state),
+  state => getParcels(state),
+  (selectedCoordinatesById, parcelOnChainOwners, parcels) => {
+    return Object.keys(selectedCoordinatesById)
+      .filter(parcelId => !(parcelId in parcelOnChainOwners))
+      .map(parcelId => parcels[parcelId])
+  }
 )


### PR DESCRIPTION
This PR does a bunch of things:

+ defers the update of the owner of the selected parcel so it can be rendered as selected right away

+ refresh the owners of the selected parcels every 10 seconds (configurable)

+ removes sold parcels from the actual purchase (they are deducted from the total of parcels and the total price)

As you can see in this screen recording, the user can select parcels right away, and some of them change to "sold" status after selecting them. They are not accounted for the total price and total LAND amount. They still show up on the list to let the user know that those parcels have been sold, and the user can click on them to remove them from the list (either by clicking the X on the corner of the chip, or by clicking on the tile on the map). Once they are removed from the list, the user can't add them again by clicking on them.

![689b](https://user-images.githubusercontent.com/2781777/49035871-d2452200-f194-11e8-83c5-2119b4b4632f.gif)

I also added small fixes for some issues:

+ Updated the colors of the SVGs in the sign in page

+ Fixed the total price shown in the confirmation modal

+ Updated the copy for "parcels available" as requested by ari.m

Closes #689 