### PR TITLE
feat: accept all terms from auction modal

### DIFF
--- a/src/Translation/locales/en.json
+++ b/src/Translation/locales/en.json
@@ -129,7 +129,7 @@
       "There are just two things you need to do before you can start. First, you need to select the tokens you want to buy LAND with. Next, you have to authorize a new smart contract to access those tokens when you buy LAND.",
     "get_started": "Get started",
     "i_agree_with_auction_terms": "I accept the {auction_terms_link}",
-    "i_agree_with_other_terms":
+    "i_agree_with_main_terms":
       "I accept the {decentraland_terms_link} and the {privacy_policy_link}",
     "privacy_policy_link": "Privacy Policy",
     "processing_tx": "Processing Transaction",

--- a/src/Translation/locales/en.json
+++ b/src/Translation/locales/en.json
@@ -116,6 +116,7 @@
     "title": "Auction Finished"
   },
   "auction_modal": {
+    "auction_terms_link": "LAND Auction Terms & Conditions",
     "authorization": "Authorization",
     "authorization_description":
       "Before you can purchase any LAND in the auction using {token}, you must first authorize the {contract_link} contract to access and operate it in your behalf",
@@ -123,13 +124,16 @@
     "confirmation": "Confirmation",
     "confirmation_description":
       "You are about to purchase {parcels} parcels of LAND for {price} {token}",
+    "decentraland_terms_link": "Terms of Service",
     "description":
       "There are just two things you need to do before you can start. First, you need to select the tokens you want to buy LAND with. Next, you have to authorize a new smart contract to access those tokens when you buy LAND.",
     "get_started": "Get started",
-    "i_agree_with_terms": "I accept the {terms_link}",
+    "i_agree_with_auction_terms": "I accept the {auction_terms_link}",
+    "i_agree_with_other_terms":
+      "I accept the {decentraland_terms_link} and the {privacy_policy_link}",
+    "privacy_policy_link": "Privacy Policy",
     "processing_tx": "Processing Transaction",
     "submit": "Proceed",
-    "terms_and_conditions": "Terms & Conditions",
     "tx_failed": "Transaction Failed",
     "video_tutorial": "Video Tutorial",
     "watch_tutorial": "Watch video tutorial"

--- a/src/Translation/locales/es.json
+++ b/src/Translation/locales/es.json
@@ -130,7 +130,7 @@
       "Para participar en esta nueva subasta, deberá autorizar el nuevo contrato {contract_link}.",
     "get_started": "Empezar",
     "i_agree_with_auction_terms": "Acepto el {auction_terms_link}",
-    "i_agree_with_other_terms":
+    "i_agree_with_main_terms":
       "Acepto el {decentraland_terms_link} y el {privacy_policy_link}",
     "privacy_policy_link": "Política de privacidad",
     "processing_tx": "Procesando Transacción",

--- a/src/Translation/locales/es.json
+++ b/src/Translation/locales/es.json
@@ -117,6 +117,7 @@
     "title": "Subasta terminada"
   },
   "auction_modal": {
+    "auction_terms_link": "Términos y condiciones de la subasta LAND",
     "authorization": "Autorización",
     "authorization_description":
       "Antes de poder comprar cualquier LAND en la subasta usando {token}, primero debe autorizar el contrato {contract_link} para acceder y operarlo en su nombre.",
@@ -124,13 +125,16 @@
     "confirmation": "Confirmación",
     "confirmation_description":
       "Está a punto de comprar {parcels} parcelas de LAND por {price} {token}",
+    "decentraland_terms_link": "Términos de servicio",
     "description":
       "Para participar en esta nueva subasta, deberá autorizar el nuevo contrato {contract_link}.",
     "get_started": "Empezar",
-    "i_agree_with_terms": "Acepto los {terms_link}",
+    "i_agree_with_auction_terms": "Acepto el {auction_terms_link}",
+    "i_agree_with_other_terms":
+      "Acepto el {decentraland_terms_link} y el {privacy_policy_link}",
+    "privacy_policy_link": "Política de privacidad",
     "processing_tx": "Procesando Transacción",
     "submit": "Proceder",
-    "terms_and_conditions": "Términos y Condiciones",
     "tx_failed": "Transacción fallida",
     "video_tutorial": "Video Tutorial",
     "watch_tutorial": "Ver video tutorial"

--- a/src/Translation/locales/fr.json
+++ b/src/Translation/locales/fr.json
@@ -132,7 +132,7 @@
       "Vous devez juste faire deux choses avant de pouvoir commencer. ",
     "get_started": "Commencer",
     "i_agree_with_auction_terms": "J'accepte le {auction_terms_link}",
-    "i_agree_with_other_terms":
+    "i_agree_with_main_terms":
       "J'accepte le {decentraland_terms_link} et le {privacy_policy_link}",
     "privacy_policy_link": "Politique de confidentialité",
     "processing_tx": "Traitement de la transaction",

--- a/src/Translation/locales/fr.json
+++ b/src/Translation/locales/fr.json
@@ -119,6 +119,7 @@
     "title": "Enchère terminée"
   },
   "auction_modal": {
+    "auction_terms_link": "Conditions générales de vente LAND",
     "authorization": "Autorisation",
     "authorization_description":
       "Avant de pouvoir acheter un LAND dans la vente aux enchères à l’aide de {token}, vous devez au préalable autoriser le contrat {contract_link} à y accéder et à l’exploiter en votre nom.",
@@ -126,13 +127,16 @@
     "confirmation": "Confirmation",
     "confirmation_description":
       "Vous êtes sur le point d'acheter {parcels} LAND pour {price} {token}",
+    "decentraland_terms_link": "Conditions d'utilisation",
     "description":
       "Vous devez juste faire deux choses avant de pouvoir commencer. ",
     "get_started": "Commencer",
-    "i_agree_with_terms": "J'accepte le {terms_link}",
+    "i_agree_with_auction_terms": "J'accepte le {auction_terms_link}",
+    "i_agree_with_other_terms":
+      "J'accepte le {decentraland_terms_link} et le {privacy_policy_link}",
+    "privacy_policy_link": "Politique de confidentialité",
     "processing_tx": "Traitement de la transaction",
     "submit": "Procéder",
-    "terms_and_conditions": "Termes et conditions",
     "tx_failed": "La transaction a échoué",
     "video_tutorial": "Didacticiel vidéo",
     "watch_tutorial": "Regarder le tutoriel vidéo"

--- a/src/Translation/locales/ja.json
+++ b/src/Translation/locales/ja.json
@@ -112,6 +112,7 @@
     "title": "オークションは終了しました"
   },
   "auction_modal": {
+    "auction_terms_link": "LANDオークション利用規約",
     "authorization": "承認",
     "authorization_description":
       "{token}を使用してLANDを購入するには、まず{contract_link}契約でトークンの使用を承認する必要があります。",
@@ -119,13 +120,16 @@
     "confirmation": "確認",
     "confirmation_description":
       "{parcels}LANDを{price} {token}で購入しようとしています",
+    "decentraland_terms_link": "利用規約",
     "description":
       "始める前に次の2点を確認してください。LAND（土地）購入に使用するトークンを選択できます。そのトークンがLAND購入に使用できるようにスマートコントラクトで承認してください。",
     "get_started": "始める",
-    "i_agree_with_terms": "{terms_link}に同意する",
+    "i_agree_with_auction_terms": "私は{auction_terms_link}を受け入れる",
+    "i_agree_with_other_terms":
+      "私は{decentraland_terms_link}と{privacy_policy_link}を受け入れます",
+    "privacy_policy_link": "個人情報保護方針",
     "processing_tx": "取引処理中",
     "submit": "続ける",
-    "terms_and_conditions": "利用規約",
     "tx_failed": "処理に失敗しました",
     "video_tutorial": "ビデオチュートリアル",
     "watch_tutorial": "ビデオチュートリアルを見る"

--- a/src/Translation/locales/ja.json
+++ b/src/Translation/locales/ja.json
@@ -125,7 +125,7 @@
       "始める前に次の2点を確認してください。LAND（土地）購入に使用するトークンを選択できます。そのトークンがLAND購入に使用できるようにスマートコントラクトで承認してください。",
     "get_started": "始める",
     "i_agree_with_auction_terms": "私は{auction_terms_link}を受け入れる",
-    "i_agree_with_other_terms":
+    "i_agree_with_main_terms":
       "私は{decentraland_terms_link}と{privacy_policy_link}を受け入れます",
     "privacy_policy_link": "個人情報保護方針",
     "processing_tx": "取引処理中",

--- a/src/Translation/locales/ko.json
+++ b/src/Translation/locales/ko.json
@@ -128,7 +128,7 @@
       "이 새로운 경매에 참여하려면 새로운 {contract_link} 계약을 승인해야합니다.",
     "get_started": "시작하다",
     "i_agree_with_auction_terms": "나는 {auction_terms_link}를 받아 들인다.",
-    "i_agree_with_other_terms":
+    "i_agree_with_main_terms":
       "나는 {decentraland_terms_link}와 {privacy_policy_link}을 받아 들인다.",
     "privacy_policy_link": "개인 정보 정책",
     "processing_tx": "거래 처리 중",

--- a/src/Translation/locales/ko.json
+++ b/src/Translation/locales/ko.json
@@ -115,6 +115,7 @@
     "title": "경매 완료"
   },
   "auction_modal": {
+    "auction_terms_link": "LAND 경매 이용 약관",
     "authorization": "권한 부여",
     "authorization_description":
       "{token}를 사용하여 경매에서 LAND을 구입하기 전에 먼저 {contract_link} 계약을 승인하여 사용자를 대신하여 액세스하고 운영해야합니다",
@@ -122,13 +123,16 @@
     "confirmation": "확인",
     "confirmation_description":
       "{price} {token}에 대해 {parcels} LAND을 (를) 구매하려고합니다.",
+    "decentraland_terms_link": "서비스 약관",
     "description":
       "이 새로운 경매에 참여하려면 새로운 {contract_link} 계약을 승인해야합니다.",
     "get_started": "시작하다",
-    "i_agree_with_terms": "나는 {terms_link}를 받아 들인다.",
+    "i_agree_with_auction_terms": "나는 {auction_terms_link}를 받아 들인다.",
+    "i_agree_with_other_terms":
+      "나는 {decentraland_terms_link}와 {privacy_policy_link}을 받아 들인다.",
+    "privacy_policy_link": "개인 정보 정책",
     "processing_tx": "거래 처리 중",
     "submit": "발하다",
-    "terms_and_conditions": "이용 약관",
     "tx_failed": "거래 실패",
     "video_tutorial": "비디오 자습서",
     "watch_tutorial": "비디오 자습서보기"

--- a/src/Translation/locales/zh.json
+++ b/src/Translation/locales/zh.json
@@ -119,7 +119,7 @@
       "在开始之前，您只需要做两件事。首先，选择购买 LAND 的通证，然后授权合约在购买土地时能操作通证",
     "get_started": "开始吧",
     "i_agree_with_auction_terms": "我接受{auction_terms_link}",
-    "i_agree_with_other_terms":
+    "i_agree_with_main_terms":
       "我接受{decentraland_terms_link}和{privacy_policy_link}",
     "privacy_policy_link": "隐私政策",
     "processing_tx": "处理交易",

--- a/src/Translation/locales/zh.json
+++ b/src/Translation/locales/zh.json
@@ -115,6 +115,7 @@
     "authorize_token": "授权{token}通证",
     "confirmation": "确认",
     "confirmation_description": "您即将用 {price} {token} 购买 {parcels} LAND",
+    "decentraland_terms_link": "服务条款",
     "description":
       "在开始之前，您只需要做两件事。首先，选择购买 LAND 的通证，然后授权合约在购买土地时能操作通证",
     "get_started": "开始吧",

--- a/src/Translation/locales/zh.json
+++ b/src/Translation/locales/zh.json
@@ -108,6 +108,7 @@
     "title": "拍卖已结束"
   },
   "auction_modal": {
+    "auction_terms_link": "LAND拍卖条款和条件",
     "authorization": "授权",
     "authorization_description":
       "拍卖中在您用 {token} 购买 LAND 之前，您必须先授权{contract_link}合约访问和操作权限",
@@ -117,10 +118,12 @@
     "description":
       "在开始之前，您只需要做两件事。首先，选择购买 LAND 的通证，然后授权合约在购买土地时能操作通证",
     "get_started": "开始吧",
-    "i_agree_with_terms": "我接受{terms_link}",
+    "i_agree_with_auction_terms": "我接受{auction_terms_link}",
+    "i_agree_with_other_terms":
+      "我接受{decentraland_terms_link}和{privacy_policy_link}",
+    "privacy_policy_link": "隐私政策",
     "processing_tx": "处理交易",
     "submit": "确认",
-    "terms_and_conditions": "条款和条件",
     "tx_failed": "交易失败",
     "video_tutorial": "视频教程",
     "watch_tutorial": "观看视频教程"

--- a/webapp/src/components/Modal/AuctionModal/AuctionModal.css
+++ b/webapp/src/components/Modal/AuctionModal/AuctionModal.css
@@ -20,8 +20,20 @@
   margin-top: 40px;
 }
 
+.AuctionModal .modal-body .agree-to-terms-wrapper {
+  display: flex;
+  justify-content: center;
+}
+
 .AuctionModal .modal-body .agree-to-terms {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   margin: 40px 0;
+}
+
+.AuctionModal .modal-body .agree-to-terms .ui.checkbox + .ui.checkbox {
+  margin-top: 8px;
 }
 
 .AuctionModal .modal-body .ui.checkbox label,

--- a/webapp/src/components/Modal/AuctionModal/AuctionModal.js
+++ b/webapp/src/components/Modal/AuctionModal/AuctionModal.js
@@ -72,6 +72,7 @@ export default class AuctionModal extends React.PureComponent {
         href="https://decentraland.org/terms-auction"
         rel="noopener noreferrer"
         target="_blank"
+        onClick={this.hanleClickExternalLink}
       >
         {t('auction_modal.auction_terms_link')}
       </a>
@@ -84,6 +85,7 @@ export default class AuctionModal extends React.PureComponent {
         href="https://decentraland.org/terms"
         rel="noopener noreferrer"
         target="_blank"
+        onClick={this.hanleClickExternalLink}
       >
         {t('auction_modal.decentraland_terms_link')}
       </a>
@@ -96,10 +98,15 @@ export default class AuctionModal extends React.PureComponent {
         href="https://decentraland.org/privacy"
         rel="noopener noreferrer"
         target="_blank"
+        onClick={this.hanleClickExternalLink}
       >
         {t('auction_modal.privacy_policy_link')}
       </a>
     )
+  }
+
+  hanleClickExternalLink = event => {
+    return event.stopPropagation()
   }
 
   renderTutorial() {

--- a/webapp/src/components/Modal/AuctionModal/AuctionModal.js
+++ b/webapp/src/components/Modal/AuctionModal/AuctionModal.js
@@ -4,6 +4,10 @@ import { Checkbox, Button } from 'semantic-ui-react'
 import { t, T } from '@dapps/modules/translation/utils'
 
 import {
+  hasAgreedToTerms as hasAgreedToOtherTerms,
+  agreeToTerms as agreeToOtherTerms
+} from 'modules/terms/utils'
+import {
   dismissAuctionHelper,
   AUCTION_HELPERS,
   getYoutubeTutorialId
@@ -23,12 +27,17 @@ export default class AuctionModal extends React.PureComponent {
 
     this.state = {
       hasAgreedToTerms: false,
+      hasAgreedToOtherTerms: hasAgreedToOtherTerms(),
       isWatchingTutorial: false
     }
   }
 
   handleTermsAgreement = (_, data) => {
     this.setState({ hasAgreedToTerms: data.checked })
+  }
+
+  handleOtherTermsAgreement = (_, data) => {
+    this.setState({ hasAgreedToOtherTerms: data.checked })
   }
 
   handleWatchTutorial = () => {
@@ -40,6 +49,9 @@ export default class AuctionModal extends React.PureComponent {
   }
 
   handleSubmit = () => {
+    if (!hasAgreedToOtherTerms()) {
+      agreeToOtherTerms()
+    }
     dismissAuctionHelper(AUCTION_HELPERS.SEEN_AUCTION_MODAL)
     this.props.onClose()
   }
@@ -54,14 +66,38 @@ export default class AuctionModal extends React.PureComponent {
     }
   }
 
-  renderTermsOfServiceLink() {
+  renderAuctionTermsLink() {
+    return (
+      <a
+        href="https://decentraland.org/terms-auction"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        {t('auction_modal.auction_terms_link')}
+      </a>
+    )
+  }
+
+  renderDecentralandTermsLink() {
     return (
       <a
         href="https://decentraland.org/terms"
         rel="noopener noreferrer"
         target="_blank"
       >
-        {t('auction_modal.terms_and_conditions')}
+        {t('auction_modal.decentraland_terms_link')}
+      </a>
+    )
+  }
+
+  renderPrivacyPolicyLink() {
+    return (
+      <a
+        href="https://decentraland.org/privacy"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        {t('auction_modal.privacy_policy_link')}
       </a>
     )
   }
@@ -88,8 +124,6 @@ export default class AuctionModal extends React.PureComponent {
   }
 
   renderWelcome() {
-    const { hasAgreedToTerms } = this.state
-
     return (
       <div className="modal-body">
         <div className="modal-header">
@@ -106,25 +140,48 @@ export default class AuctionModal extends React.PureComponent {
 
         <div className="description">{t('auction_modal.description')}</div>
 
-        <div className="agree-to-terms">
-          <Checkbox
-            checked={hasAgreedToTerms}
-            onChange={this.handleTermsAgreement}
-            label={
-              <label>
-                <T
-                  id="auction_modal.i_agree_with_terms"
-                  values={{ terms_link: this.renderTermsOfServiceLink() }}
-                />
-              </label>
-            }
-          />
+        <div className="agree-to-terms-wrapper">
+          <div className="agree-to-terms">
+            <Checkbox
+              checked={this.state.hasAgreedToTerms}
+              onChange={this.handleTermsAgreement}
+              label={
+                <label>
+                  <T
+                    id="auction_modal.i_agree_with_auction_terms"
+                    values={{
+                      auction_terms_link: this.renderAuctionTermsLink()
+                    }}
+                  />
+                </label>
+              }
+            />
+            {!hasAgreedToOtherTerms() ? (
+              <Checkbox
+                checked={this.state.hasAgreedToOtherTerms}
+                onChange={this.handleOtherTermsAgreement}
+                label={
+                  <label>
+                    <T
+                      id={'auction_modal.i_agree_with_other_terms'}
+                      values={{
+                        decentraland_terms_link: this.renderDecentralandTermsLink(),
+                        privacy_policy_link: this.renderPrivacyPolicyLink()
+                      }}
+                    />
+                  </label>
+                }
+              />
+            ) : null}
+          </div>
         </div>
 
         <div className="actions">
           <Button
             primary={true}
-            disabled={!hasAgreedToTerms}
+            disabled={
+              !this.state.hasAgreedToTerms || !this.state.hasAgreedToOtherTerms
+            }
             onClick={this.handleSubmit}
           >
             {t('auction_modal.get_started').toUpperCase()}

--- a/webapp/src/components/Modal/AuctionModal/AuctionModal.js
+++ b/webapp/src/components/Modal/AuctionModal/AuctionModal.js
@@ -4,8 +4,8 @@ import { Checkbox, Button } from 'semantic-ui-react'
 import { t, T } from '@dapps/modules/translation/utils'
 
 import {
-  hasAgreedToTerms as hasAgreedToOtherTerms,
-  agreeToTerms as agreeToOtherTerms
+  hasAgreedToTerms as hasAgreedToMainTerms,
+  agreeToTerms as agreeToMainTerms
 } from 'modules/terms/utils'
 import {
   dismissAuctionHelper,
@@ -27,7 +27,7 @@ export default class AuctionModal extends React.PureComponent {
 
     this.state = {
       hasAgreedToTerms: false,
-      hasAgreedToOtherTerms: hasAgreedToOtherTerms(),
+      hasAgreedToMainTerms: hasAgreedToMainTerms(),
       isWatchingTutorial: false
     }
   }
@@ -37,7 +37,7 @@ export default class AuctionModal extends React.PureComponent {
   }
 
   handleOtherTermsAgreement = (_, data) => {
-    this.setState({ hasAgreedToOtherTerms: data.checked })
+    this.setState({ hasAgreedToMainTerms: data.checked })
   }
 
   handleWatchTutorial = () => {
@@ -49,8 +49,8 @@ export default class AuctionModal extends React.PureComponent {
   }
 
   handleSubmit = () => {
-    if (!hasAgreedToOtherTerms()) {
-      agreeToOtherTerms()
+    if (!hasAgreedToMainTerms()) {
+      agreeToMainTerms()
     }
     dismissAuctionHelper(AUCTION_HELPERS.SEEN_AUCTION_MODAL)
     this.props.onClose()
@@ -156,14 +156,14 @@ export default class AuctionModal extends React.PureComponent {
                 </label>
               }
             />
-            {!hasAgreedToOtherTerms() ? (
+            {!hasAgreedToMainTerms() ? (
               <Checkbox
-                checked={this.state.hasAgreedToOtherTerms}
+                checked={this.state.hasAgreedToMainTerms}
                 onChange={this.handleOtherTermsAgreement}
                 label={
                   <label>
                     <T
-                      id={'auction_modal.i_agree_with_other_terms'}
+                      id={'auction_modal.i_agree_with_main_terms'}
                       values={{
                         decentraland_terms_link: this.renderDecentralandTermsLink(),
                         privacy_policy_link: this.renderPrivacyPolicyLink()
@@ -180,7 +180,7 @@ export default class AuctionModal extends React.PureComponent {
           <Button
             primary={true}
             disabled={
-              !this.state.hasAgreedToTerms || !this.state.hasAgreedToOtherTerms
+              !this.state.hasAgreedToTerms || !this.state.hasAgreedToMainTerms
             }
             onClick={this.handleSubmit}
           >


### PR DESCRIPTION
Closes #743 

Users who haven't accepted Decentraland's Terms of Service and Privacy Policy will see this checkbox instead of the one that only links to the Auction terms:

<img width="1440" alt="screen shot 2018-12-05 at 3 01 12 pm" src="https://user-images.githubusercontent.com/2781777/49533826-d2cd6f00-f89e-11e8-9a5a-fcb9372a648a.png">

And by checking and confirming that modal they won't see the other ToS modal on the rest of the marketplace.