### PR TITLE
feat: remove re-center button on mini-map

### DIFF
--- a/webapp/src/components/AuctionPage/AuctionPage.js
+++ b/webapp/src/components/AuctionPage/AuctionPage.js
@@ -316,7 +316,7 @@ export default class AuctionPage extends React.PureComponent {
             selected={validSelectedParcels}
             isDraggable
             showPopup
-            showControls={true}
+            showControls={false}
             showMinimap={true}
             onClick={this.handleSelectUnownedParcel}
           />


### PR DESCRIPTION
This also removes the `+ -` buttons, if it's not a good enough tradeoff we can close this issue without merging

Closes #719 
