### PR TITLE
feat: add distict_id to estates and filter bids for distrincts

### DIFF
--- a/migrations/1550588222674_estates-add-district-id.js
+++ b/migrations/1550588222674_estates-add-district-id.js
@@ -1,0 +1,9 @@
+import { Estate } from '../src/Asset'
+
+exports.up = pgm => {
+  const tableName = Estate.tableName
+
+  pgm.addColumns(tableName, {
+    district_id: 'TEXT'
+  })
+}

--- a/monitor/consolidateProccesedEvents.js
+++ b/monitor/consolidateProccesedEvents.js
@@ -1,5 +1,6 @@
 import { Log } from 'decentraland-commons'
 
+import { Estate } from '../src/Asset'
 import { Publication } from '../src/Listing'
 import { Tile } from '../src/Tile'
 import { asyncBatch } from '../src/lib'
@@ -7,12 +8,16 @@ import { asyncBatch } from '../src/lib'
 const log = new Log('consolidateProccesedEvents')
 
 export async function consolidateProccesedEvents() {
+  await Promise.all([cancelInactivePublications(), updateEstateDistrinctIds()])
+}
+
+async function cancelInactivePublications() {
   log.info('Cancelling inactive publications')
   const inactivePublications = await Publication.findInactive()
   await Publication.cancelInactive()
 
   log.info('Updating tiles')
-  await asyncBatch({
+  return asyncBatch({
     elements: inactivePublications,
     callback: async publications => {
       const upserts = publications.map(publication =>
@@ -22,4 +27,9 @@ export async function consolidateProccesedEvents() {
     },
     batchSize: 20
   })
+}
+
+async function updateEstateDistrinctIds() {
+  log.info('Updating estate district ids')
+  return Estate.updateEstateDistrictIds()
 }

--- a/monitor/consolidateProccesedEvents.js
+++ b/monitor/consolidateProccesedEvents.js
@@ -31,5 +31,5 @@ async function cancelInactivePublications() {
 
 async function updateEstateDistrinctIds() {
   log.info('Updating estate district ids')
-  return Estate.updateEstateDistrictIds()
+  return Estate.updateDistrictIds()
 }

--- a/shared/district.js
+++ b/shared/district.js
@@ -9,10 +9,10 @@ export function isPlaza(district_id) {
   return district_id === PLAZA_ID
 }
 
-export function isDistrict(parcel) {
-  return !!parcel.district_id
+export function isDistrict(asset) {
+  return !!asset.district_id
 }
 
-export function getDistrict(parcel, districts = {}) {
-  return parcel && districts[parcel.district_id]
+export function getDistrict(asset, districts = {}) {
+  return asset && districts[asset.district_id]
 }

--- a/shared/listing.js
+++ b/shared/listing.js
@@ -1,3 +1,5 @@
+import { isDistrict } from './district'
+
 export const LISTING_STATUS = Object.freeze({
   open: 'open',
   sold: 'sold',
@@ -76,4 +78,13 @@ export function sortListings(listings, key) {
   return listings.sort(
     (a, b) => (parseInt(a[key], 10) > parseInt(b[key], 10) ? -1 : 1)
   )
+}
+
+/**
+ * Check if asset is listable or not
+ * @param asset
+ * @return boolean - whether is listable or not
+ */
+export function isListable(asset) {
+  return !isDistrict(asset) && asset.owner
 }

--- a/shared/parcel.js
+++ b/shared/parcel.js
@@ -1,7 +1,6 @@
 import { utils } from 'decentraland-commons'
 import { Bounds } from './map'
 import { buildCoordinate } from './coordinates'
-import { isDistrict } from './district'
 
 export const FIRST_AUCTION_DATE = new Date('2018-01-31T00:00:00Z')
 
@@ -96,13 +95,4 @@ export function getParcelsNotIncluded(newParcels, allParcels) {
  */
 export function hasTags(parcel) {
   return parcel && !utils.isEmptyObject(parcel.tags)
-}
-
-/**
- * Check if parcel is listable or not
- * @param parcel
- * @return boolean - whether is listable or not
- */
-export function isListable(parcel) {
-  return !isDistrict(parcel) && parcel.owner
 }

--- a/src/Asset/Estate/Estate.model.js
+++ b/src/Asset/Estate/Estate.model.js
@@ -65,7 +65,7 @@ export class Estate extends Model {
           OR (${BlockchainEventQueries.byArgs('_tokenId', estateId)} AND address = ${address})`)
   }
 
-  static async updateEstateDistrictIds() {
+  static async updateDistrictIds() {
     return this.db.query(
       SQL`UPDATE ${SQL.raw(this.tableName)} 
       SET district_id = P.district_id

--- a/src/Asset/Estate/Estate.model.js
+++ b/src/Asset/Estate/Estate.model.js
@@ -11,6 +11,7 @@ export class Estate extends Model {
     'id',
     'tx_hash',
     'token_id',
+    'district_id',
     'owner',
     'update_operator',
     'data',
@@ -62,5 +63,16 @@ export class Estate extends Model {
       SQL`DELETE FROM ${SQL.raw(BlockchainEvent.tableName)}
         WHERE ${BlockchainEventQueries.byArgs('_estateId', estateId)}
           OR (${BlockchainEventQueries.byArgs('_tokenId', estateId)} AND address = ${address})`)
+  }
+
+  static async updateEstateDistrictIds() {
+    return this.db.query(
+      SQL`UPDATE ${SQL.raw(this.tableName)} 
+      SET district_id = P.district_id
+        FROM parcels as P 
+        WHERE ${SQL.raw(this.tableName)}.id = P.estate_id AND 
+        P.estate_id IS NOT NULL AND 
+        P.district_id IS NOT NULL;`
+    )
   }
 }

--- a/webapp/src/components/EditEstatePage/EstateSelect/EstateSelect.container.js
+++ b/webapp/src/components/EditEstatePage/EstateSelect/EstateSelect.container.js
@@ -24,7 +24,7 @@ const mapState = (state, ownProps) => {
     allParcels: getParcels(state),
     pristineEstate: estate,
     isTxIdle: isEstateTransactionIdle(state),
-    bids: getWalletBidsByAsset(state, estate, ASSET_TYPES.estate)
+    bids: estate ? getWalletBidsByAsset(state, estate, ASSET_TYPES.estate) : []
   }
 }
 

--- a/webapp/src/components/EstateDetailPage/EstateActions/EstateActions.js
+++ b/webapp/src/components/EstateDetailPage/EstateActions/EstateActions.js
@@ -5,9 +5,11 @@ import { Button, Icon } from 'semantic-ui-react'
 
 import { locations } from 'locations'
 import { isOnSale } from 'shared/asset'
+import { isListable } from 'shared/listing'
 import { isFeatureEnabled } from 'lib/featureUtils'
 import { t } from '@dapps/modules/translation/utils'
 import { publicationType, estateType, bidType } from 'components/types'
+
 import './EstateActions.css'
 
 export default class EstateActions extends React.PureComponent {
@@ -60,6 +62,7 @@ export default class EstateActions extends React.PureComponent {
               </Link>
             )}
             {isFeatureEnabled('BIDS') &&
+              isListable(estate) &&
               bids.length === 0 && (
                 <Link to={locations.bidEstate(id)}>
                   <Button primary size="large">

--- a/webapp/src/components/EstateDetailPage/EstateDetailPage.container.js
+++ b/webapp/src/components/EstateDetailPage/EstateDetailPage.container.js
@@ -11,11 +11,12 @@ import { getWalletBidsByAsset } from 'modules/bid/selectors'
 import EstateDetailPage from './EstateDetailPage'
 
 const mapState = (state, ownProps) => {
+  const estate = ownProps.asset
   return {
-    estate: ownProps.asset,
     publications: getPublications(state),
     tiles: getTiles(state),
-    bids: getWalletBidsByAsset(state, ownProps.asset, ASSET_TYPES.estate)
+    bids: getWalletBidsByAsset(state, estate, ASSET_TYPES.estate),
+    estate
   }
 }
 

--- a/webapp/src/components/EstateDetailPage/EstateDetailPage.js
+++ b/webapp/src/components/EstateDetailPage/EstateDetailPage.js
@@ -9,6 +9,7 @@ import { getOpenPublication, ASSET_TYPES } from 'shared/asset'
 import { hasTags } from 'shared/parcel'
 import { calculateMapProps } from 'shared/estate'
 import { buildCoordinate } from 'shared/coordinates'
+import { isDistrict } from 'shared/district'
 import { estateType, publicationType, bidType } from 'components/types'
 import EstateActions from './EstateActions'
 import ParcelTags from 'components/ParcelTags'
@@ -112,33 +113,39 @@ export default class EstateDetailPage extends React.PureComponent {
                 )}
               </Header>
             </Grid.Column>
-            <Grid.Column
-              computer={WITH_ACTION_BUTTONS_WIDTH}
-              mobile={WITHOUT_ACTION_BUTTONS_WIDTH}
-              className="estate-owner-container"
-            >
-              {isOwner ? (
-                <div>
-                  <Button size="tiny" className="link" onClick={onEditMetadata}>
-                    <Icon name="pencil" />
-                    {t('global.edit')}
-                  </Button>
-                  <Button
-                    size="tiny"
-                    className="link manage-button"
-                    onClick={onManageEstate}
-                  >
-                    <Icon name="add user" />
-                    {t('asset_detail.actions.permissions')}
-                  </Button>
-                </div>
-              ) : (
-                <span className="owned-by">
-                  <span>{t('global.owned_by')}</span>
-                  <AddressBlock address={estate.owner} scale={4} />
-                </span>
-              )}
-            </Grid.Column>
+            {!isDistrict(estate) && (
+              <Grid.Column
+                computer={WITH_ACTION_BUTTONS_WIDTH}
+                mobile={WITHOUT_ACTION_BUTTONS_WIDTH}
+                className="estate-owner-container"
+              >
+                {isOwner ? (
+                  <div>
+                    <Button
+                      size="tiny"
+                      className="link"
+                      onClick={onEditMetadata}
+                    >
+                      <Icon name="pencil" />
+                      {t('global.edit')}
+                    </Button>
+                    <Button
+                      size="tiny"
+                      className="link manage-button"
+                      onClick={onManageEstate}
+                    >
+                      <Icon name="add user" />
+                      {t('asset_detail.actions.permissions')}
+                    </Button>
+                  </div>
+                ) : (
+                  <span className="owned-by">
+                    <span>{t('global.owned_by')}</span>
+                    <AddressBlock address={estate.owner} scale={4} />
+                  </span>
+                )}
+              </Grid.Column>
+            )}
           </Grid.Row>
           <Grid.Row>
             {publication && (

--- a/webapp/src/components/ParcelDetailPage/ParcelActions/ParcelActions.js
+++ b/webapp/src/components/ParcelDetailPage/ParcelActions/ParcelActions.js
@@ -6,6 +6,9 @@ import { t } from '@dapps/modules/translation/utils'
 
 import { locations } from 'locations'
 import { isFeatureEnabled } from 'lib/featureUtils'
+import { getOpenPublication } from 'shared/asset'
+import { hasParcelsConnected } from 'shared/parcel'
+import { isListable } from 'shared/listing'
 import {
   parcelType,
   publicationType,
@@ -13,8 +16,6 @@ import {
   bidType
 } from 'components/types'
 import { isLegacyPublication } from 'modules/publication/utils'
-import { getOpenPublication } from 'shared/asset'
-import { hasParcelsConnected, isListable } from 'shared/parcel'
 
 import './ParcelActions.css'
 

--- a/webapp/src/modules/bid/selectors.js
+++ b/webapp/src/modules/bid/selectors.js
@@ -46,10 +46,6 @@ export const getBidByAssetIdFactory = (assetId, assetType) =>
   )
 
 export const getWalletBidsByAsset = (state, asset, assetType) => {
-  if (!asset) {
-    return []
-  }
-
   const allBids = getData(state)
   const walletAddress = getAddress(state)
 

--- a/webapp/src/modules/bid/selectors.js
+++ b/webapp/src/modules/bid/selectors.js
@@ -46,6 +46,10 @@ export const getBidByAssetIdFactory = (assetId, assetType) =>
   )
 
 export const getWalletBidsByAsset = (state, asset, assetType) => {
+  if (!asset) {
+    return []
+  }
+
   const allBids = getData(state)
   const walletAddress = getAddress(state)
 


### PR DESCRIPTION
- Add `distrinct_id` to `Estate` column 
- Set Estate `district_ids` once monitor finished
- Do not index bids for districts
- Do not show bid button on a district details
- Hide `owner of` from Estate details if it is a district

## Note:

`npm run migrate up`
