### PR TITLE
feat: make event key more specific

### DIFF
--- a/monitor/processEvents.js
+++ b/monitor/processEvents.js
@@ -43,7 +43,9 @@ const eventCache = {
     eventCache._values[eventCache.getKey(event)] = true
   },
   getKey(event) {
-    return event.tx_hash + event.name
+    return `${event.tx_hash}_${event.name}_${event.block_number}_${
+      event.log_index
+    }`
   },
   size() {
     return Object.keys(eventCache._values).length


### PR DESCRIPTION
Fix when a short reorg happens and the monitor is watching events.

A new event may have the same tx hash and name. Adding the block number and  log index to the key will make it more specific