### PR TITLE
fix: images for parcels within estates

### DIFF
--- a/webapp/src/components/Atlas/Atlas.tsx
+++ b/webapp/src/components/Atlas/Atlas.tsx
@@ -8,7 +8,7 @@ import { Tile, Props } from './Atlas.types'
 const getCoords = (x: number | string, y: number | string) => `${x},${y}`
 
 const Atlas = (props: Props) => {
-  const { tiles, onNavigate, withNavigation } = props
+  const { tiles, onNavigate, isEstate, withNavigation } = props
 
   const selection = useMemo(
     () =>
@@ -33,13 +33,14 @@ const Atlas = (props: Props) => {
         tile &&
         center.estate_id &&
         tile.estate_id &&
-        center.estate_id === tile.estate_id
+        center.estate_id === tile.estate_id &&
+        isEstate
       ) {
         return true
       }
       return false
     },
-    [selection, tiles]
+    [selection, tiles, isEstate]
   )
 
   const forSaleLayer: Layer = useCallback(

--- a/webapp/src/components/Atlas/Atlas.types.ts
+++ b/webapp/src/components/Atlas/Atlas.types.ts
@@ -7,6 +7,7 @@ export type Tile = AtlasTile & { estate_id?: string }
 export type Props = Partial<AtlasProps> & {
   tiles: Record<string, AtlasTile>
   selection?: { x: number | string; y: number | string }[]
+  isEstate?: boolean
   withNavigation?: boolean
   onNavigate: (path: string) => void
 }

--- a/webapp/src/components/NFTImage/NFTImage.tsx
+++ b/webapp/src/components/NFTImage/NFTImage.tsx
@@ -42,6 +42,7 @@ const NFTImage = (props: Props) => {
           isDraggable={false}
           selection={selection}
           zoom={zoom}
+          isEstate
         />
       )
     }

--- a/webapp/src/components/NFTPage/EstateDetail/EstateDetail.tsx
+++ b/webapp/src/components/NFTPage/EstateDetail/EstateDetail.tsx
@@ -18,7 +18,14 @@ const EstateDetail = (props: Props) => {
   return (
     <>
       <div style={{ height: 420 }}>
-        <Atlas x={x} y={y} isDraggable selection={selection} withNavigation />
+        <Atlas
+          x={x}
+          y={y}
+          isDraggable
+          selection={selection}
+          withNavigation
+          isEstate
+        />
       </div>
       <Container>
         <Title


### PR DESCRIPTION
Added a flag `isEstate` to `Atlas` to apply the "paint all the parcels that share the estate id" (workaround for the incomplete `estate.parcels` issue) ONLY when `isEstate` is `true`.

Before:

<img width="912" alt="Screen Shot 2020-01-28 at 4 30 13 PM" src="https://user-images.githubusercontent.com/2781777/73298442-147c5000-41ec-11ea-82ad-1b83d0449578.png">

After:

<img width="944" alt="Screen Shot 2020-01-28 at 4 30 27 PM" src="https://user-images.githubusercontent.com/2781777/73298478-1f36e500-41ec-11ea-841d-9708ef9cd7b8.png">
