### PR TITLE
fix: current account

### DIFF
--- a/webapp/src/components/AccountPage/AccountPage.tsx
+++ b/webapp/src/components/AccountPage/AccountPage.tsx
@@ -17,7 +17,8 @@ import './AccountPage.css'
 const AccountPage = (props: Props) => {
   const { address, wallet, isConnecting, onNavigate } = props
 
-  const isCurrentAccount = address === undefined
+  const isCurrentAccount =
+    address === undefined || (wallet && wallet.address === address)
 
   const handleOnNavigate = useCallback(
     (options?: SearchOptions) =>


### PR DESCRIPTION
When you click on the `Owner` blockie of one of your own assets, it takes you to `/accounts/0x...` and you would see the Header and the `My account` tab would not be highlighted. This PR fixes that so you will se the same as if you went to `/account`