### PR TITLE
fix: ignore old fetch requests

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -5077,9 +5077,9 @@
       }
     },
     "decentraland-ui": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-2.14.1.tgz",
-      "integrity": "sha512-A8EOR6FdPdge7qNZDYG3o0c7k7l0wP4D9crFZCQ4QrBIUsXZyu2lc+nrx8GoQK+VB1J0uvA4ayFXvzjM15mYWg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-2.16.1.tgz",
+      "integrity": "sha512-323dTUe0QYzeOv8mzrL9pSofLnrDaD4K8zSkOxgPjqgIbuq+MIIq60CuNei69Tz2ovKZ/n+XtCBUXiKcJEsyvA==",
       "requires": {
         "balloon-css": "^0.5.0",
         "ethereum-blockies": "^0.1.1",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1042,9 +1042,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "@formatjs/intl-displaynames": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-1.2.0.tgz",
-      "integrity": "sha512-mUGI2sc6OABkrMj42HlOpK1h96EVrN+gOhzbyCTMH9SVH/gPPLr/zFRH3KFWtBwxqhYsDghvUwm8xkdFOK0kTg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-1.2.1.tgz",
+      "integrity": "sha512-gAkRtcCbRrvNX8AhJ+PACWZyh6Txn7FXdoqgYSmfhEMD/O4qwsd6dYTVbuXOlhBzcNSYU4mCn1ov15nrcp4pxg==",
       "requires": {
         "@formatjs/intl-utils": "^2.2.0"
       }
@@ -1077,11 +1077,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.2.0.tgz",
       "integrity": "sha512-+Az7tR1av1DHZu9668D8uh9atT6vp+FFmEF8BrEssv0OqzpVjpVBGVmcgPzQP8k2PQjVlm/h2w8cTt0knn132w=="
-    },
-    "@formatjs/macro": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/macro/-/macro-0.2.6.tgz",
-      "integrity": "sha512-DfdnLJf8+PwLHzJECZ1Xfa8+sI9akQnUuLN2UdkaExTQmlY0Vs36rMzEP0JoVDBMk+KdQbJNt72rPeZkBNcKWg=="
     },
     "@hapi/address": {
       "version": "2.1.4",
@@ -1932,9 +1927,9 @@
       "integrity": "sha512-Oo+1ZQPMlmAXWnE2du97uWOyifMbRWdbmQZDWkXGgZppMLmQB55kAFREf0Z5AfMUD2iymqGJgmu+FsbK8+QNsw=="
     },
     "@types/sinon": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.1.tgz",
-      "integrity": "sha512-EZQUP3hSZQyTQRfiLqelC9NMWd1kqLcmQE0dMiklxBkgi84T+cHOhnKpgk4NnOWpGX863yE6+IaGnOXUNFqDnQ=="
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
+      "integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg=="
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -1978,9 +1973,9 @@
       }
     },
     "@types/uuid": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.7.tgz",
-      "integrity": "sha512-C2j2FWgQkF1ru12SjZJyMaTPxs/f6n90+5G5qNakBxKXjTBc/YTSelHh4Pz1HUDwxFXD9WvpQhOGCDC+/Y4mIQ=="
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.8.tgz",
+      "integrity": "sha512-zHWce3allXWSmRx6/AGXKCtSOA7JjeWd2L3t4aHfysNk8mouQnWCocveaT7a4IEIlPVHp81jzlnknqTgCjCLXA=="
     },
     "@types/ws": {
       "version": "6.0.4",
@@ -5029,9 +5024,9 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decentraland-dapps": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-7.1.1.tgz",
-      "integrity": "sha512-kWkO+tr27E/tdAFlukfhCo27+lrNfYKRA+OTrtjBw5sGShegKt+a0f5ogYzfXguMeu3PUHgPcg7XY+djOYE25g==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-7.3.0.tgz",
+      "integrity": "sha512-eDCZf30y5lVhz4A7+6UksOIgH5z2jwPCMPt+t7DnUNtenqU1E6FvJAXVNHDIfQVYIY8Bd5FEezoUMxvkQskn2Q==",
       "requires": {
         "@types/flat": "0.0.28",
         "@types/node": "^10.1.2",
@@ -5056,9 +5051,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.15.tgz",
-          "integrity": "sha512-daFGV9GSs6USfPgxceDA8nlSe48XrVCJfDeYm7eokxq/ye7iuOH87hKXgMtEAVLFapkczbZsx868PMDT1Y0a6A=="
+          "version": "10.17.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
+          "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
         },
         "@types/react-redux": {
           "version": "6.0.14",
@@ -7391,9 +7386,9 @@
       }
     },
     "http-cache-semantics": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-Z2EICWNJou7Tr9Bd2M2UqDJq3A9F2ePG9w3lIpjoyuSyXFP9QbniJVu3XQYytuw5ebmG7dXSXO9PgAjJG8DDKA=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
     "http-deceiver": {
       "version": "1.2.7",
@@ -7635,11 +7630,6 @@
       "version": "4.2.21",
       "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-4.2.21.tgz",
       "integrity": "sha512-6pZlBdqTRUuuwRWywPItHY1JQwzQxWcpBHv6w4M8T6bGzAsiL/QmI+XsdOhsqJLaL4ZmTATn1kIkNlMk4VzSLQ=="
-    },
-    "intl-locales-supported": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/intl-locales-supported/-/intl-locales-supported-1.8.4.tgz",
-      "integrity": "sha512-wO0JhDqhshhkq8Pa9CLcstqd1aCXjfMgfMzjD6mDreS3mTSDbjGiMU+07O8BdJGxed7Q0Wf3TFVjGq0W3Y0n1w=="
     },
     "intl-messageformat": {
       "version": "7.8.4",
@@ -12230,24 +12220,32 @@
       "integrity": "sha512-ueZzLmHltszTshDMwyfELDq8zOA803wQ1ZuzCccXa1m57k1PxSHfflPD5W9YIiTXLs0JTLzoj6o1LuM5N6zzNA=="
     },
     "react-intl": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-3.12.0.tgz",
-      "integrity": "sha512-VQWkFYSKKoi85p3gOXgG80KkBImdBJXwJxssO9gqdelW/fuVnxQLXgYOKuOqWrUz5beXK+qBve6bTpblh1ep2g==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-3.12.1.tgz",
+      "integrity": "sha512-cgumW29mwROIqyp8NXStYsoIm27+8FqnxykiLSawWjOxGIBeLuN/+p2srei5SRIumcJefOkOIHP+NDck05RgHg==",
       "requires": {
         "@formatjs/intl-displaynames": "^1.2.0",
-        "@formatjs/intl-listformat": "^1.3.7",
-        "@formatjs/intl-relativetimeformat": "^4.5.7",
-        "@formatjs/intl-unified-numberformat": "^3.0.4",
-        "@formatjs/intl-utils": "^2.0.4",
-        "@formatjs/macro": "^0.2.6",
+        "@formatjs/intl-listformat": "^1.4.1",
+        "@formatjs/intl-relativetimeformat": "^4.5.9",
+        "@formatjs/intl-unified-numberformat": "^3.2.0",
+        "@formatjs/intl-utils": "^2.2.0",
         "@types/hoist-non-react-statics": "^3.3.1",
         "@types/invariant": "^2.2.31",
-        "hoist-non-react-statics": "^3.3.1",
-        "intl-format-cache": "^4.2.19",
-        "intl-locales-supported": "^1.8.4",
-        "intl-messageformat": "^7.8.2",
-        "intl-messageformat-parser": "^3.6.2",
+        "hoist-non-react-statics": "^3.3.2",
+        "intl-format-cache": "^4.2.21",
+        "intl-messageformat": "^7.8.4",
+        "intl-messageformat-parser": "^3.6.4",
         "shallow-equal": "^1.2.1"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        }
       }
     },
     "react-is": {
@@ -15123,9 +15121,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.15.tgz",
-          "integrity": "sha512-daFGV9GSs6USfPgxceDA8nlSe48XrVCJfDeYm7eokxq/ye7iuOH87hKXgMtEAVLFapkczbZsx868PMDT1Y0a6A=="
+          "version": "10.17.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
+          "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
         },
         "ws": {
           "version": "6.2.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -20,7 +20,7 @@
     "connected-react-router": "^6.6.1",
     "date-fns": "^2.8.1",
     "dcl-tslint-config-standard": "^2.0.0",
-    "decentraland-dapps": "^7.1.1",
+    "decentraland-dapps": "^7.3.0",
     "decentraland-ui": "^2.14.1",
     "dotenv": "^8.2.0",
     "graphql": "^14.5.8",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -21,7 +21,7 @@
     "date-fns": "^2.8.1",
     "dcl-tslint-config-standard": "^2.0.0",
     "decentraland-dapps": "^7.3.0",
-    "decentraland-ui": "^2.14.1",
+    "decentraland-ui": "^2.16.1",
     "dotenv": "^8.2.0",
     "graphql": "^14.5.8",
     "history": "^4.10.1",

--- a/webapp/src/components/NFTListPage/ArrayFilter/ArrayFilter.tsx
+++ b/webapp/src/components/NFTListPage/ArrayFilter/ArrayFilter.tsx
@@ -28,6 +28,7 @@ const ArrayFilter = (props: Props) => {
       <div className="options">
         {options.map(option => (
           <div
+            key={option.text}
             className={getClasses(option.value, values)}
             onClick={() => onChange(getNewValues(option.value, values))}
           >

--- a/webapp/src/modules/nft/actions.ts
+++ b/webapp/src/modules/nft/actions.ts
@@ -53,16 +53,28 @@ export const DEFAULT_FETCH_NFTS_OPTIONS: FetchNFTsOptions = {
 }
 
 export const fetchNFTsRequest = (options: Partial<FetchNFTsOptions> = {}) =>
-  action(FETCH_NFTS_REQUEST, { options })
+  action(FETCH_NFTS_REQUEST, { options, timestamp: Date.now() })
 export const fetchNFTsSuccess = (
   options: FetchNFTsOptions,
   nfts: NFT[],
   accounts: Account[],
   orders: Order[],
-  count: number
-) => action(FETCH_NFTS_SUCCESS, { options, nfts, accounts, orders, count })
-export const fetchNFTsFailure = (options: FetchNFTsOptions, error: string) =>
-  action(FETCH_NFTS_FAILURE, { options, error })
+  count: number,
+  timestamp: number
+) =>
+  action(FETCH_NFTS_SUCCESS, {
+    options,
+    nfts,
+    accounts,
+    orders,
+    count,
+    timestamp
+  })
+export const fetchNFTsFailure = (
+  options: FetchNFTsOptions,
+  error: string,
+  timestamp: number
+) => action(FETCH_NFTS_FAILURE, { options, error, timestamp })
 
 export type FetchNFTsRequestAction = ReturnType<typeof fetchNFTsRequest>
 export type FetchNFTsSuccessAction = ReturnType<typeof fetchNFTsSuccess>

--- a/webapp/src/modules/nft/sagas.ts
+++ b/webapp/src/modules/nft/sagas.ts
@@ -29,6 +29,7 @@ export function* nftSaga() {
 }
 
 function* handleFetchNFTsRequest(action: FetchNFTsRequestAction) {
+  const { timestamp } = action.payload
   const options = {
     ...DEFAULT_FETCH_NFTS_OPTIONS,
     ...action.payload.options,
@@ -42,9 +43,11 @@ function* handleFetchNFTsRequest(action: FetchNFTsRequestAction) {
     const [nfts, accounts, orders, count] = yield call(() =>
       nftAPI.fetch(options)
     )
-    yield put(fetchNFTsSuccess(options, nfts, accounts, orders, count))
+    yield put(
+      fetchNFTsSuccess(options, nfts, accounts, orders, count, timestamp)
+    )
   } catch (error) {
-    yield put(fetchNFTsFailure(options, error.message))
+    yield put(fetchNFTsFailure(options, error.message, timestamp))
   }
 }
 

--- a/webapp/src/modules/ui/reducer.ts
+++ b/webapp/src/modules/ui/reducer.ts
@@ -18,6 +18,7 @@ import {
 
 export type UIState = {
   nftIds: string[]
+  lastTimestamp: number
   homepageWearableIds: string[]
   homepageLandIds: string[]
   homepageENSIds: string[]
@@ -37,7 +38,8 @@ const INITIAL_STATE: UIState = {
   bidderBidIds: [],
   archivedBidIds: [],
   nftBidIds: [],
-  assetCount: null
+  assetCount: null,
+  lastTimestamp: 0
 }
 
 type UIReducerAction =
@@ -60,13 +62,17 @@ export function uiReducer(
       }
     }
     case FETCH_NFTS_SUCCESS: {
+      if (action.payload.timestamp < state.lastTimestamp) {
+        return state
+      }
       switch (action.payload.options.view) {
         case View.MARKET:
         case View.ACCOUNT: {
           return {
             ...state,
             nftIds: action.payload.nfts.map(nft => nft.id),
-            assetCount: action.payload.count
+            assetCount: action.payload.count,
+            timestamp: action.payload.timestamp
           }
         }
         case View.LOAD_MORE: {
@@ -76,7 +82,8 @@ export function uiReducer(
               ...state.nftIds,
               ...action.payload.nfts.map(nft => nft.id)
             ],
-            assetCount: action.payload.count
+            assetCount: action.payload.count,
+            timestamp: action.payload.timestamp
           }
         }
         case View.HOME_WEARABLES: {


### PR DESCRIPTION
This PR adds a check in the `ui/reducer` to ignore old `FETCH_NFTS_SUCCESS` actions. Also updates decentraland libraries and removes a warning.