### PR TITLE
fix: hide sort dropdown on mobile

### DIFF
--- a/webapp/src/components/NFTListPage/NFTListPage.tsx
+++ b/webapp/src/components/NFTListPage/NFTListPage.tsx
@@ -428,7 +428,9 @@ const NFTListPage = (props: Props) => {
             })}
             onChange={handleSearch}
           />
-          <Dropdown
+          <Responsive
+            as={Dropdown}
+            minWidth={Responsive.onlyTablet.minWidth}
             direction="left"
             value={sortBy}
             options={dropdownOptions}


### PR DESCRIPTION
Fixes #186 