### PR TITLE
fix: Do a CI install instead of a plain one

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ build:
     - ./setupEnv.sh
     - npm install && npm run build
     - dcl-lock-sync
-    - cd .ci && npm install && dcl-up website-market
+    - cd .ci && npm ci && dcl-up website-market
     - dcl-sync-release && cd ..
     - dcl-upload build
     - cd .ci && dcl-cache-invalidation


### PR DESCRIPTION
This PR changes the `npm install` command for a `npm ci`, preventing any minor versions from breaking the CI procedure.