### PR TITLE
fix: Replace webapp installation script with npm ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ build:
   script:
     - cd webapp
     - ./setupEnv.sh
-    - npm install && npm run build
+    - npm ci && npm run build
     - dcl-lock-sync
     - cd .ci && npm ci && dcl-up website-market
     - dcl-sync-release && cd ..


### PR DESCRIPTION
This PR replaces the `npm install` command used to install and build the webapp with `npm ci`