### PR TITLE
fix: Show all parcels in estate using tiles

### DIFF
--- a/webapp/src/components/NFTPage/EstateDetail/EstateDetail.tsx
+++ b/webapp/src/components/NFTPage/EstateDetail/EstateDetail.tsx
@@ -71,7 +71,7 @@ const EstateDetail = (props: Props) => {
         </Row>
         <ProximityHighlights nft={nft} />
         <Bids nft={nft} />
-        <ParcelCoordinates estate={estate} />
+        <ParcelCoordinates estateId={nft.tokenId} />
         <TransactionHistory nft={nft} />
       </Container>
     </>

--- a/webapp/src/components/NFTPage/EstateDetail/ParcelCoordinates/ParcelCoordinates.container.ts
+++ b/webapp/src/components/NFTPage/EstateDetail/ParcelCoordinates/ParcelCoordinates.container.ts
@@ -1,0 +1,11 @@
+import { connect } from 'react-redux'
+import { RootState } from '../../../../modules/reducer'
+import { getTilesByEstateId } from '../../../../modules/tile/selectors'
+import { MapStateProps, OwnProps } from './ParcelCoordinates.types'
+import ParcelCoordinates from './ParcelCoordinates'
+
+const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => ({
+  parcelCoordinates: getTilesByEstateId(state)[ownProps.estateId] ?? []
+})
+
+export default connect(mapState)(ParcelCoordinates)

--- a/webapp/src/components/NFTPage/EstateDetail/ParcelCoordinates/ParcelCoordinates.tsx
+++ b/webapp/src/components/NFTPage/EstateDetail/ParcelCoordinates/ParcelCoordinates.tsx
@@ -1,12 +1,9 @@
 import React from 'react'
-import { useSelector } from 'react-redux'
 import { Header } from 'decentraland-ui'
 import { Link } from 'react-router-dom'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
-import classNames from 'classnames'
 
 import { locations } from '../../../../modules/routing/locations'
-import { getTilesByEstateId } from '../../../../modules/tile/selectors'
 import { Row } from '../../../Layout/Row'
 import Coordinate from '../../../Coordinate/Coordinate'
 import { Collapsible } from '../../../Collapsible'
@@ -14,16 +11,13 @@ import { Props } from './ParcelCoordinates.types'
 import styles from './ParcelCoordinates.module.css'
 
 const ParcelCoordinates = (props: Props) => {
-  const { estateId } = props
-  const coordinatesClasses = classNames(styles.coordinates)
-  const estateAndParcelCoordinates = useSelector(getTilesByEstateId)
-  const parcelCoordinates = estateAndParcelCoordinates[estateId] ?? []
+  const { parcelCoordinates } = props
 
   return (
     <div className={styles.ParcelCoordinates}>
       <Header sub>{t('parcel_coordinates.title')}</Header>
       <Collapsible collapsedHeight={60}>
-        <Row className={coordinatesClasses}>
+        <Row className={styles.coordinates}>
           {parcelCoordinates.map((parcel, index) => (
             <Link
               to={locations.parcel(parcel.x.toString(), parcel.y.toString())}

--- a/webapp/src/components/NFTPage/EstateDetail/ParcelCoordinates/ParcelCoordinates.tsx
+++ b/webapp/src/components/NFTPage/EstateDetail/ParcelCoordinates/ParcelCoordinates.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
+import { useSelector } from 'react-redux'
 import { Header } from 'decentraland-ui'
 import { Link } from 'react-router-dom'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import classNames from 'classnames'
 
 import { locations } from '../../../../modules/routing/locations'
+import { getTilesByEstateId } from '../../../../modules/tile/selectors'
 import { Row } from '../../../Layout/Row'
 import Coordinate from '../../../Coordinate/Coordinate'
 import { Collapsible } from '../../../Collapsible'
@@ -12,15 +14,17 @@ import { Props } from './ParcelCoordinates.types'
 import styles from './ParcelCoordinates.module.css'
 
 const ParcelCoordinates = (props: Props) => {
-  const { estate } = props
+  const { estateId } = props
   const coordinatesClasses = classNames(styles.coordinates)
+  const estateAndParcelCoordinates = useSelector(getTilesByEstateId)
+  const parcelCoordinates = estateAndParcelCoordinates[estateId] ?? []
 
   return (
     <div className={styles.ParcelCoordinates}>
       <Header sub>{t('parcel_coordinates.title')}</Header>
       <Collapsible collapsedHeight={60}>
         <Row className={coordinatesClasses}>
-          {estate.parcels.map((parcel, index) => (
+          {parcelCoordinates.map((parcel, index) => (
             <Link
               to={locations.parcel(parcel.x.toString(), parcel.y.toString())}
             >

--- a/webapp/src/components/NFTPage/EstateDetail/ParcelCoordinates/ParcelCoordinates.types.ts
+++ b/webapp/src/components/NFTPage/EstateDetail/ParcelCoordinates/ParcelCoordinates.types.ts
@@ -1,5 +1,3 @@
-import { Estate } from '../../../../modules/nft/estate/types'
-
 export type Props = {
-  estate: Estate
+  estateId: string
 }

--- a/webapp/src/components/NFTPage/EstateDetail/ParcelCoordinates/ParcelCoordinates.types.ts
+++ b/webapp/src/components/NFTPage/EstateDetail/ParcelCoordinates/ParcelCoordinates.types.ts
@@ -1,3 +1,10 @@
+import { Tile } from '../../../Atlas/Atlas.types'
+
 export type Props = {
   estateId: string
+  parcelCoordinates: Tile[]
 }
+
+export type OwnProps = Pick<Props, 'estateId'>
+
+export type MapStateProps = Pick<Props, 'parcelCoordinates'>

--- a/webapp/src/components/NFTPage/EstateDetail/ParcelCoordinates/index.ts
+++ b/webapp/src/components/NFTPage/EstateDetail/ParcelCoordinates/index.ts
@@ -1,2 +1,2 @@
-import ParcelCoordinates from './ParcelCoordinates'
+import ParcelCoordinates from './ParcelCoordinates.container'
 export { ParcelCoordinates }


### PR DESCRIPTION
This PR fixes the issue of receiving a lower amount of parcels for a estate because of limitations in the API by loading the parcels from the pre-loaded tiles.

Closes #360 