### PR TITLE
chore: Rename "Decentraland" tab to collectibles

### DIFF
--- a/webapp/src/components/Navigation/Navigation.tsx
+++ b/webapp/src/components/Navigation/Navigation.tsx
@@ -12,7 +12,7 @@ const Navigation = (props: Props) => {
       <Tabs.Left>
         <Link to={locations.browse()}>
           <Tabs.Tab active={activeTab === NavigationTab.BROWSE}>
-            {t('navigation.decentraland')}
+            {t('navigation.collectibles')}
           </Tabs.Tab>
         </Link>
         <Link to={locations.partners()}>

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -29,7 +29,7 @@
     "known_origin": "KnownOrigin"
   },
   "navigation": {
-    "decentraland": "Decentraland",
+    "collectibles": "Collectibles",
     "partners": "Partners",
     "my_assets": "My Assets",
     "my_bids": "My Bids",

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -29,7 +29,7 @@
     "known_origin": "KnownOrigin"
   },
   "navigation": {
-    "decentraland": "Decentraland",
+    "collectibles": "Coleccionables",
     "partners": "Socios",
     "my_assets": "Mi Inventario",
     "my_bids": "Mis Ofertas",

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -29,7 +29,7 @@
     "known_origin": "KnownOrigin"
   },
   "navigation": {
-    "decentraland": "Decentraland",
+    "collectibles": "藏品",
     "partners": "伙伴",
     "my_assets": "我的资产",
     "my_bids": "我的出价",


### PR DESCRIPTION
This PR renames the `Decentraland` tab to "Collectibles".

<img width="565" alt="Screen Shot 2021-07-22 at 16 57 00" src="https://user-images.githubusercontent.com/1120791/126701652-5fdca941-7553-46f9-bbac-7ca8d03b3932.png">

Closes #328 