### PR TITLE
chore: Add NFT Service tests

### DIFF
--- a/webapp/src/modules/vendor/decentraland/NFTService.spec.ts
+++ b/webapp/src/modules/vendor/decentraland/NFTService.spec.ts
@@ -70,12 +70,11 @@ describe("Decentraland's NFTService", () => {
     })
 
     describe('when the fetch is successful', () => {
-      let total: number
+      const total = 3
       let nftResults: NFTResult[]
       let anotherNFT: NFT
 
       beforeEach(() => {
-        total = 3
         anotherNFT = { ...nft, owner: 'anotherAddress', id: 'anotherNFTID' }
         nftResults = [
           { nft, order },
@@ -138,10 +137,9 @@ describe("Decentraland's NFTService", () => {
     })
 
     describe('when the fetch is successful', () => {
-      let total: number
+      const total = 1
 
       beforeEach(() => {
-        total = 1
         ;(api.nftAPI.fetch as jest.Mock).mockResolvedValueOnce({ total })
       })
 

--- a/webapp/src/modules/vendor/decentraland/NFTService.spec.ts
+++ b/webapp/src/modules/vendor/decentraland/NFTService.spec.ts
@@ -1,0 +1,344 @@
+import { Network, ChainId } from '@dcl/schemas'
+import { ContractData } from 'decentraland-transactions'
+import * as walletUtils from 'decentraland-dapps/dist/modules/wallet/utils'
+import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
+import ERC721Abi from '../../../contracts/ERC721Abi'
+import { NFT, NFTsCountParams, NFTsFetchParams } from '../../nft/types'
+import { VendorName } from '../types'
+import { NFTService } from './NFTService'
+import * as api from './nft/api'
+import { NFTResult, NFTsFetchFilters } from './nft'
+import { Order } from '../../order/types'
+
+jest.mock('decentraland-dapps/dist/modules/wallet/utils')
+jest.mock('./nft/api')
+
+const aTxHash = 'txHash'
+const anAddress = 'anAddress'
+const aBasicErrorMessage = 'error'
+
+describe("Decentraland's NFTService", () => {
+  let nftService: NFTService
+  let nft: NFT
+  let order: Order
+  let wallet: Wallet | null
+  let erc721Contract: {
+    transferFrom: jest.Mock
+  }
+  let filters: NFTsFetchFilters
+
+  beforeEach(() => {
+    nftService = new NFTService()
+    nft = {
+      id: 'aNFTID',
+      chainId: 1,
+      contractAddress: '0x2323233423',
+      tokenId: 'aTokenId',
+      owner: anAddress
+    } as NFT
+    erc721Contract = {
+      transferFrom: jest.fn().mockReturnValue('transferFrom')
+    }
+    wallet = { address: anAddress } as Wallet
+    order = { id: 'anID' } as Order
+    filters = { isWearableAccessory: true }
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('when fetching NFTs', () => {
+    let fetchParams: NFTsFetchParams
+
+    beforeEach(() => {
+      fetchParams = { first: 1, skip: 1, onlyOnSale: true }
+    })
+
+    describe('when the fetch fails', () => {
+      beforeEach(() => {
+        ;(api.nftAPI.fetch as jest.Mock).mockRejectedValueOnce(
+          aBasicErrorMessage
+        )
+      })
+
+      it("should reject with the fetch's error", () => {
+        return expect(nftService.fetch(fetchParams, filters)).rejects.toEqual(
+          aBasicErrorMessage
+        )
+      })
+    })
+
+    describe('when the fetch is successful', () => {
+      let total: number
+      let nftResults: NFTResult[]
+      let anotherNFT: NFT
+
+      beforeEach(() => {
+        total = 3
+        anotherNFT = { ...nft, owner: 'anotherAddress', id: 'anotherNFTID' }
+        nftResults = [
+          { nft, order },
+          { nft: anotherNFT, order: null }
+        ]
+        ;(api.nftAPI.fetch as jest.Mock).mockResolvedValueOnce({
+          data: nftResults,
+          total
+        })
+      })
+
+      it('should have fetched the NFTs with the filter and NFT params', async () => {
+        await nftService.fetch(fetchParams, filters)
+        expect(api.nftAPI.fetch as jest.Mock).toHaveBeenCalledWith(
+          fetchParams,
+          filters
+        )
+      })
+
+      it('should return the NFTs, the accounts, the orders and the total', () => {
+        return expect(nftService.fetch(fetchParams, filters)).resolves.toEqual([
+          [
+            { ...nft, vendor: VendorName.DECENTRALAND },
+            { ...anotherNFT, vendor: VendorName.DECENTRALAND }
+          ],
+          [
+            { address: nft.owner, id: nft.owner, nftIds: [nft.id] },
+            {
+              address: anotherNFT.owner,
+              id: anotherNFT.owner,
+              nftIds: [anotherNFT.id]
+            }
+          ],
+          [order],
+          total
+        ])
+      })
+    })
+  })
+
+  describe('when fetching the number of NFTs', () => {
+    let countParams: NFTsCountParams
+
+    beforeEach(() => {
+      countParams = { search: 'somethingToSearch' }
+    })
+
+    describe('when the fetch fails', () => {
+      beforeEach(() => {
+        ;(api.nftAPI.fetch as jest.Mock).mockRejectedValueOnce(
+          aBasicErrorMessage
+        )
+      })
+
+      it("should reject with the fetch's error", () => {
+        return expect(nftService.count(countParams, filters)).rejects.toEqual(
+          aBasicErrorMessage
+        )
+      })
+    })
+
+    describe('when the fetch is successful', () => {
+      let total: number
+
+      beforeEach(() => {
+        total = 1
+        ;(api.nftAPI.fetch as jest.Mock).mockResolvedValueOnce({ total })
+      })
+
+      it('should have fetched the NFTs with the count and filter params, with the first and skip params as 0', async () => {
+        await nftService.count(countParams, filters)
+        expect(api.nftAPI.fetch as jest.Mock).toHaveBeenCalledWith(
+          {
+            ...countParams,
+            skip: 0,
+            first: 0
+          },
+          filters
+        )
+      })
+
+      it('should resolve with the number of NFTs', () => {
+        return expect(nftService.count(countParams, filters)).resolves.toBe(
+          total
+        )
+      })
+    })
+  })
+
+  describe('when fetching one NFT', () => {
+    describe('when the fetch fails', () => {
+      beforeEach(() => {
+        ;(api.nftAPI.fetchOne as jest.Mock).mockRejectedValueOnce(
+          aBasicErrorMessage
+        )
+      })
+
+      it("should reject with the fetch's error", () => {
+        return expect(
+          nftService.fetchOne(nft.contractAddress, nft.id)
+        ).rejects.toEqual(aBasicErrorMessage)
+      })
+    })
+
+    describe('when the fetch is successful', () => {
+      beforeEach(() => {
+        ;(api.nftAPI.fetchOne as jest.Mock).mockResolvedValueOnce({
+          order,
+          nft
+        })
+      })
+
+      it('should fetch the NFT with the provided address and the token ID', async () => {
+        await nftService.fetchOne(nft.contractAddress, nft.id)
+        expect(api.nftAPI.fetchOne as jest.Mock).toHaveBeenCalledWith(
+          nft.contractAddress,
+          nft.id
+        )
+      })
+
+      it('should return the NFT with its vendor and the order', () => {
+        return expect(
+          nftService.fetchOne(nft.contractAddress, nft.id)
+        ).resolves.toEqual([{ ...nft, vendor: VendorName.DECENTRALAND }, order])
+      })
+    })
+  })
+
+  describe('when transferring a NFT', () => {
+    describe('when the wallet it null', () => {
+      beforeEach(() => {
+        wallet = null
+      })
+      it('should reject into a "Wallet must be connected" error', () => {
+        return expect(
+          nftService.transfer(null, 'anAddress', nft)
+        ).rejects.toThrowError('Invalid address. Wallet must be connected.')
+      })
+    })
+
+    describe('when the NFT network is Ethereum', () => {
+      beforeEach(() => {
+        nft.network = Network.ETHEREUM
+      })
+      describe('when the transaction fails', () => {
+        beforeEach(() => {
+          ;(walletUtils.sendTransaction as jest.Mock).mockRejectedValueOnce(
+            aBasicErrorMessage
+          )
+        })
+
+        it("should reject with the transaction's error", () => {
+          return expect(
+            nftService.transfer(wallet, anAddress, nft)
+          ).rejects.toBe(aBasicErrorMessage)
+        })
+      })
+
+      describe('when the transaction is successful', () => {
+        beforeEach(() => {
+          ;(walletUtils.sendTransaction as jest.Mock).mockResolvedValueOnce(
+            aTxHash
+          )
+        })
+
+        it("should have called send transaction with the erc721's crafted contract using the nft's chain id, the contract address and the ABI", async () => {
+          await nftService.transfer(wallet, anAddress, nft)
+          expect(walletUtils.sendTransaction as jest.Mock).toHaveBeenCalled()
+
+          const firstParameter = (walletUtils.sendTransaction as jest.Mock).mock
+            .calls[0][0] as ContractData
+          expect(firstParameter.chainId).toBe(nft.chainId)
+          expect(firstParameter.name).toBe('ERC721')
+          expect(firstParameter.abi).toBe(ERC721Abi)
+          expect(firstParameter.address).toBe(nft.contractAddress)
+        })
+
+        it("should have called send transaction with the contract's createOrder order operation", async () => {
+          await nftService.transfer(wallet, anAddress, nft)
+          expect(walletUtils.sendTransaction as jest.Mock).toHaveBeenCalled()
+
+          const secondParameter = (walletUtils.sendTransaction as jest.Mock)
+            .mock.calls[0][1]
+          const parametrizedContractExecutionResult = secondParameter(
+            erc721Contract
+          )
+          expect(parametrizedContractExecutionResult).toBe('transferFrom')
+          expect(erc721Contract.transferFrom).toHaveBeenCalledWith(
+            wallet!.address,
+            anAddress,
+            nft.tokenId
+          )
+        })
+
+        it("should resolve with the transaction's hash", () => {
+          return expect(
+            nftService.transfer(wallet, 'anAddress', nft)
+          ).resolves.toBe(aTxHash)
+        })
+      })
+    })
+
+    describe('when the NFT network is not Ethereum', () => {
+      beforeEach(() => {
+        nft.network = Network.MATIC
+        nft.chainId = ChainId.MATIC_MAINNET
+      })
+
+      describe('when the transaction fails', () => {
+        beforeEach(() => {
+          ;(walletUtils.sendTransaction as jest.Mock).mockRejectedValueOnce(
+            aBasicErrorMessage
+          )
+        })
+
+        it("should reject with the transaction's error", () => {
+          return expect(
+            nftService.transfer(wallet, anAddress, nft)
+          ).rejects.toBe(aBasicErrorMessage)
+        })
+      })
+
+      describe('when the transaction is successful', () => {
+        beforeEach(() => {
+          ;(walletUtils.sendTransaction as jest.Mock).mockResolvedValueOnce(
+            aTxHash
+          )
+        })
+
+        it("should have called send transaction with the erc721's contract using the nft's chain id and contract address", async () => {
+          await nftService.transfer(wallet, anAddress, nft)
+          expect(walletUtils.sendTransaction as jest.Mock).toHaveBeenCalled()
+
+          const firstParameter = (walletUtils.sendTransaction as jest.Mock).mock
+            .calls[0][0] as ContractData
+          expect(firstParameter.chainId).toBe(nft.chainId)
+          expect(firstParameter.name).toBe('Decentraland Collection')
+          expect(firstParameter.address).toBe(nft.contractAddress)
+        })
+
+        it("should have called send transaction with the contract's createOrder order operation", async () => {
+          await nftService.transfer(wallet, anAddress, nft)
+          expect(walletUtils.sendTransaction as jest.Mock).toHaveBeenCalled()
+
+          const secondParameter = (walletUtils.sendTransaction as jest.Mock)
+            .mock.calls[0][1]
+          const parametrizedContractExecutionResult = secondParameter(
+            erc721Contract
+          )
+          expect(parametrizedContractExecutionResult).toBe('transferFrom')
+          expect(erc721Contract.transferFrom).toHaveBeenCalledWith(
+            wallet!.address,
+            anAddress,
+            nft.tokenId
+          )
+        })
+
+        it("should resolve with the transaction's hash", () => {
+          return expect(
+            nftService.transfer(wallet, 'anAddress', nft)
+          ).resolves.toBe(aTxHash)
+        })
+      })
+    })
+  })
+})

--- a/webapp/src/modules/vendor/decentraland/NFTService.spec.ts
+++ b/webapp/src/modules/vendor/decentraland/NFTService.spec.ts
@@ -241,14 +241,16 @@ describe("Decentraland's NFTService", () => {
 
         it("should have called send transaction with the erc721's crafted contract using the nft's chain id, the contract address and the ABI", async () => {
           await nftService.transfer(wallet, anAddress, nft)
-          expect(walletUtils.sendTransaction as jest.Mock).toHaveBeenCalled()
-
-          const firstParameter = (walletUtils.sendTransaction as jest.Mock).mock
-            .calls[0][0] as ContractData
-          expect(firstParameter.chainId).toBe(nft.chainId)
-          expect(firstParameter.name).toBe('ERC721')
-          expect(firstParameter.abi).toBe(ERC721Abi)
-          expect(firstParameter.address).toBe(nft.contractAddress)
+          expect(walletUtils.sendTransaction as jest.Mock).toHaveBeenCalledWith(
+            {
+              name: 'ERC721',
+              abi: ERC721Abi,
+              address: nft.contractAddress,
+              chainId: nft.chainId,
+              version: '1'
+            },
+            expect.any(Function)
+          )
         })
 
         it("should have called send transaction with the contract's createOrder order operation", async () => {
@@ -305,13 +307,14 @@ describe("Decentraland's NFTService", () => {
 
         it("should have called send transaction with the erc721's contract using the nft's chain id and contract address", async () => {
           await nftService.transfer(wallet, anAddress, nft)
-          expect(walletUtils.sendTransaction as jest.Mock).toHaveBeenCalled()
-
-          const firstParameter = (walletUtils.sendTransaction as jest.Mock).mock
-            .calls[0][0] as ContractData
-          expect(firstParameter.chainId).toBe(nft.chainId)
-          expect(firstParameter.name).toBe('Decentraland Collection')
-          expect(firstParameter.address).toBe(nft.contractAddress)
+          expect(walletUtils.sendTransaction as jest.Mock).toHaveBeenCalledWith(
+            expect.objectContaining({
+              chainId: nft.chainId,
+              name: 'Decentraland Collection',
+              address: nft.contractAddress
+            }),
+            expect.any(Function)
+          )
         })
 
         it("should have called send transaction with the contract's createOrder order operation", async () => {

--- a/webapp/src/modules/vendor/decentraland/NFTService.ts
+++ b/webapp/src/modules/vendor/decentraland/NFTService.ts
@@ -10,7 +10,7 @@ import { NFT, NFTsFetchParams, NFTsCountParams } from '../../nft/types'
 import { Account } from '../../account/types'
 import ERC721Abi from '../../../contracts/ERC721Abi'
 import { NFTService as NFTServiceInterface } from '../services'
-import { NFTsFetchFilters } from './nft/types'
+import { NFTResult, NFTsFetchFilters } from './nft/types'
 import { VendorName } from '../types'
 import { nftAPI } from './nft/api'
 import { Order } from '../../order/types'
@@ -20,21 +20,28 @@ export class NFTService
   async fetch(params: NFTsFetchParams, filters?: NFTsFetchFilters) {
     const { data: results, total } = await nftAPI.fetch(params, filters)
 
-    const accounts: Account[] = []
-    const nfts: NFT[] = []
-    const orders: Order[] = []
-    for (const result of results) {
-      const address = result.nft.owner
-      let account = accounts.find(account => account.id === address)
-      if (!account) {
-        account = this.toAccount(address)
-      }
-      account.nftIds.push(result.nft.id)
-      nfts.push({ ...result.nft, vendor: VendorName.DECENTRALAND })
-      if (result.order) {
-        orders.push(result.order)
-      }
-    }
+    const accounts: Account[] = results.reduce(
+      (accumulator: Account[], nftResult: NFTResult) => {
+        const address = nftResult.nft.owner
+        let account = accumulator.find(account => account.id === address)
+        if (!account) {
+          account = this.toAccount(address)
+          accumulator.push(account)
+        }
+        account.nftIds.push(nftResult.nft.id)
+        return accumulator
+      },
+      [] as Account[]
+    )
+
+    const nfts: NFT[] = results.map(nftResult => ({
+      ...nftResult.nft,
+      vendor: VendorName.DECENTRALAND
+    }))
+
+    const orders: Order[] = results
+      .filter(nftResult => nftResult.order)
+      .map(nftResult => nftResult.order as Order)
 
     return [nfts, accounts, orders, total] as const
   }

--- a/webapp/src/modules/vendor/decentraland/NFTService.ts
+++ b/webapp/src/modules/vendor/decentraland/NFTService.ts
@@ -10,7 +10,7 @@ import { NFT, NFTsFetchParams, NFTsCountParams } from '../../nft/types'
 import { Account } from '../../account/types'
 import ERC721Abi from '../../../contracts/ERC721Abi'
 import { NFTService as NFTServiceInterface } from '../services'
-import { NFTResult, NFTsFetchFilters } from './nft/types'
+import { NFTsFetchFilters } from './nft/types'
 import { VendorName } from '../types'
 import { nftAPI } from './nft/api'
 import { Order } from '../../order/types'
@@ -20,19 +20,16 @@ export class NFTService
   async fetch(params: NFTsFetchParams, filters?: NFTsFetchFilters) {
     const { data: results, total } = await nftAPI.fetch(params, filters)
 
-    const accounts: Account[] = results.reduce(
-      (accumulator: Account[], nftResult: NFTResult) => {
-        const address = nftResult.nft.owner
-        let account = accumulator.find(account => account.id === address)
-        if (!account) {
-          account = this.toAccount(address)
-          accumulator.push(account)
-        }
-        account.nftIds.push(nftResult.nft.id)
-        return accumulator
-      },
-      [] as Account[]
-    )
+    const accounts: Account[] = results.reduce((accumulator, nftResult) => {
+      const address = nftResult.nft.owner
+      let account = accumulator.find(account => account.id === address)
+      if (!account) {
+        account = this.toAccount(address)
+        accumulator.push(account)
+      }
+      account.nftIds.push(nftResult.nft.id)
+      return accumulator
+    }, [] as Account[])
 
     const nfts: NFT[] = results.map(nftResult => ({
       ...nftResult.nft,


### PR DESCRIPTION
This PR does the following:
- Adds tests for the NFT Service.
- Rewrites the fetch method, fixing a bug where the accounts were not computed correctly.