### PR TITLE
feat: prevent deploying wrong network

### DIFF
--- a/indexer/README.md
+++ b/indexer/README.md
@@ -2,15 +2,11 @@
 
 It uses [thegraph](https://thegraph.com)
 
-**Run**
+**Deploy**
 
 ```bash
-npm run build-data -- --network mainnet
-
 npm run codegen
-npm run build
-
-npm run deploy -- --network mainnet
+npm run deploy:ropsten # or deploy:mainnet
 ```
 
 If a new collection in Ethereum is added you will need to add it as following

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -7,8 +7,9 @@
     "codegen": "graph codegen --debug --output-dir src/entities/",
     "build": "graph build",
     "build-data": "ts-node ./scripts/buildData.ts",
-    "deploy": "ts-node ./scripts/deploy.ts",
-    "deploy-studio:mainnet": "graph deploy --studio decentraland-marketplace-ethereum-mainnet"
+    "deploy-studio:mainnet": "graph deploy --studio decentraland-marketplace-ethereum-mainnet",
+    "deploy:ropsten": "ts-node ./scripts/buildData.ts --network ropsten && ts-node ./scripts/deploy.ts --network ropsten",
+    "deploy:mainnet": "ts-node ./scripts/buildData.ts --network mainnet && ts-node ./scripts/deploy.ts --network mainnet"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "^0.19.0",


### PR DESCRIPTION
I replaced the `deploy` command with `deploy:ropsten` and `deploy:mainnet`, which performs a build prior to deploying, to prevent deploying the wrong network to a subgraph.