### PR TITLE
fix: use ERC721 from decentraland-transaction for all transfers

### DIFF
--- a/webapp/src/modules/vendor/decentraland/NFTService.spec.ts
+++ b/webapp/src/modules/vendor/decentraland/NFTService.spec.ts
@@ -1,14 +1,17 @@
 import { Network, ChainId } from '@dcl/schemas'
-import { ContractData } from 'decentraland-transactions'
 import * as walletUtils from 'decentraland-dapps/dist/modules/wallet/utils'
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
-import ERC721Abi from '../../../contracts/ERC721Abi'
 import { NFT, NFTsCountParams, NFTsFetchParams } from '../../nft/types'
 import { VendorName } from '../types'
 import { NFTService } from './NFTService'
 import * as api from './nft/api'
 import { NFTResult, NFTsFetchFilters } from './nft'
 import { Order } from '../../order/types'
+import {
+  ContractData,
+  ContractName,
+  getContract
+} from 'decentraland-transactions'
 
 jest.mock('decentraland-dapps/dist/modules/wallet/utils')
 jest.mock('./nft/api')
@@ -240,15 +243,13 @@ describe("Decentraland's NFTService", () => {
         })
 
         it("should have called send transaction with the erc721's crafted contract using the nft's chain id, the contract address and the ABI", async () => {
+          const contract: ContractData = {
+            ...getContract(ContractName.ERC721, nft.chainId),
+            address: nft.contractAddress
+          }
           await nftService.transfer(wallet, anAddress, nft)
           expect(walletUtils.sendTransaction as jest.Mock).toHaveBeenCalledWith(
-            {
-              name: 'ERC721',
-              abi: ERC721Abi,
-              address: nft.contractAddress,
-              chainId: nft.chainId,
-              version: '1'
-            },
+            contract,
             expect.any(Function)
           )
         })
@@ -306,13 +307,13 @@ describe("Decentraland's NFTService", () => {
         })
 
         it("should have called send transaction with the erc721's contract using the nft's chain id and contract address", async () => {
+          const contract: ContractData = {
+            ...getContract(ContractName.ERC721, nft.chainId),
+            address: nft.contractAddress
+          }
           await nftService.transfer(wallet, anAddress, nft)
           expect(walletUtils.sendTransaction as jest.Mock).toHaveBeenCalledWith(
-            expect.objectContaining({
-              chainId: nft.chainId,
-              name: 'Decentraland Collection',
-              address: nft.contractAddress
-            }),
+            contract,
             expect.any(Function)
           )
         })

--- a/webapp/src/modules/vendor/decentraland/NFTService.ts
+++ b/webapp/src/modules/vendor/decentraland/NFTService.ts
@@ -1,4 +1,3 @@
-import { Network } from '@dcl/schemas'
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { sendTransaction } from 'decentraland-dapps/dist/modules/wallet/utils'
 import {
@@ -8,7 +7,6 @@ import {
 } from 'decentraland-transactions'
 import { NFT, NFTsFetchParams, NFTsCountParams } from '../../nft/types'
 import { Account } from '../../account/types'
-import ERC721Abi from '../../../contracts/ERC721Abi'
 import { NFTService as NFTServiceInterface } from '../services'
 import { NFTsFetchFilters } from './nft/types'
 import { VendorName } from '../types'
@@ -62,19 +60,10 @@ export class NFTService
       throw new Error('Invalid address. Wallet must be connected.')
     }
 
-    const contract: ContractData =
-      nft.network !== Network.ETHEREUM
-        ? {
-            ...getContract(ContractName.ERC721CollectionV2, nft.chainId),
-            address: nft.contractAddress
-          }
-        : {
-            name: 'ERC721',
-            abi: ERC721Abi as any,
-            address: nft.contractAddress,
-            chainId: nft.chainId,
-            version: '1'
-          }
+    const contract: ContractData = {
+      ...getContract(ContractName.ERC721, nft.chainId),
+      address: nft.contractAddress
+    }
 
     return sendTransaction(contract, erc721 =>
       erc721.transferFrom(wallet.address, to, nft.tokenId)


### PR DESCRIPTION
We were using an ABI from the files generated by web3x which at some point changed from being a plain ABI to be a class, which made the transfer stopped working. Now it's using the ERC721 contract data from `decentraland-transactions`. I also used that one for collections on polygon since the `transferFrom` method is the same for those too.