### PR TITLE
fix: user stores responsiveness + transation history

### DIFF
--- a/webapp/src/components/AssetBrowse/AssetBrowse.tsx
+++ b/webapp/src/components/AssetBrowse/AssetBrowse.tsx
@@ -1,11 +1,11 @@
 import React, { ReactNode, useCallback, useEffect, useState } from 'react'
-import { Container, Page, Responsive } from 'decentraland-ui'
+import { Container, Mobile, NotMobile, Page, Tabs } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { View } from '../../modules/ui/types'
 import { Section as DecentralandSection } from '../../modules/vendor/decentraland'
 import { AssetType } from '../../modules/asset/types'
 import { VendorName } from '../../modules/vendor'
-import { Section } from '../../modules/vendor/routing/types'
+import { Section, Sections } from '../../modules/vendor/routing/types'
 import { Atlas } from '../Atlas'
 import { AccountSidebar } from '../AccountSidebar'
 import { AssetList } from '../AssetList'
@@ -142,7 +142,7 @@ const AssetBrowse = (props: Props) => {
           ]}
         />
       )}
-      <Responsive minWidth={Responsive.onlyTablet.minWidth}>
+      <NotMobile>
         {view === View.ACCOUNT ? (
           <AccountSidebar address={address!} />
         ) : view === View.CURRENT_ACCOUNT ? (
@@ -150,7 +150,7 @@ const AssetBrowse = (props: Props) => {
         ) : (
           <NFTSidebar section={section} sections={sections} />
         )}
-      </Responsive>
+      </NotMobile>
     </>
   )
 
@@ -199,22 +199,49 @@ const AssetBrowse = (props: Props) => {
       )
   }
 
+  const mobileSections = [
+    Sections.decentraland.COLLECTIONS,
+    Sections.decentraland.LAND,
+    Sections.decentraland.WEARABLES,
+    Sections.decentraland.ENS,
+    Sections.decentraland.ON_SALE,
+    Sections.decentraland.SALES,
+    Sections.decentraland.BIDS,
+    Sections.decentraland.STORE_SETTINGS
+  ]
+
   return (
-    <Page
-      className={classNames('AssetBrowse', isMap && 'is-map')}
-      isFullscreen={isFullscreen}
-    >
-      <Row>
-        {!isFullscreen && (
-          <Column align="left" className="sidebar">
-            {left}
+    <>
+      <Mobile>
+        <Tabs isFullscreen>
+          <Tabs.Left>
+            {mobileSections.map(value => (
+              <Tabs.Tab
+                active={section === value}
+                onClick={() => onBrowse({ section: value })}
+              >
+                {t(`menu.${value}`)}
+              </Tabs.Tab>
+            ))}
+          </Tabs.Left>
+        </Tabs>
+      </Mobile>
+      <Page
+        className={classNames('AssetBrowse', isMap && 'is-map')}
+        isFullscreen={isFullscreen}
+      >
+        <Row>
+          {!isFullscreen && (
+            <Column align="left" className="sidebar">
+              {left}
+            </Column>
+          )}
+          <Column align="right" grow={true}>
+            {right}
           </Column>
-        )}
-        <Column align="right" grow={true}>
-          {right}
-        </Column>
-      </Row>
-    </Page>
+        </Row>
+      </Page>
+    </>
   )
 }
 

--- a/webapp/src/components/AssetBrowse/AssetBrowse.tsx
+++ b/webapp/src/components/AssetBrowse/AssetBrowse.tsx
@@ -212,20 +212,22 @@ const AssetBrowse = (props: Props) => {
 
   return (
     <>
-      <Mobile>
-        <Tabs isFullscreen>
-          <Tabs.Left>
-            {mobileSections.map(value => (
-              <Tabs.Tab
-                active={section === value}
-                onClick={() => onBrowse({ section: value })}
-              >
-                {t(`menu.${value}`)}
-              </Tabs.Tab>
-            ))}
-          </Tabs.Left>
-        </Tabs>
-      </Mobile>
+      {view === View.CURRENT_ACCOUNT ? (
+        <Mobile>
+          <Tabs isFullscreen>
+            <Tabs.Left>
+              {mobileSections.map(value => (
+                <Tabs.Tab
+                  active={section === value}
+                  onClick={() => onBrowse({ section: value })}
+                >
+                  {t(`menu.${value}`)}
+                </Tabs.Tab>
+              ))}
+            </Tabs.Left>
+          </Tabs>
+        </Mobile>
+      ) : null}
       <Page
         className={classNames('AssetBrowse', isMap && 'is-map')}
         isFullscreen={isFullscreen}

--- a/webapp/src/components/AssetPage/ENSDetail/ENSDetail.tsx
+++ b/webapp/src/components/AssetPage/ENSDetail/ENSDetail.tsx
@@ -30,7 +30,7 @@ const ENSDetail = ({ nft }: Props) => (
     below={
       <>
         <BidList nft={nft} />
-        <TransactionHistory nft={nft} />
+        <TransactionHistory asset={nft} />
       </>
     }
   />

--- a/webapp/src/components/AssetPage/EstateDetail/EstateDetail.tsx
+++ b/webapp/src/components/AssetPage/EstateDetail/EstateDetail.tsx
@@ -76,7 +76,7 @@ const EstateDetail = ({ nft }: Props) => {
         <>
           <BidList nft={nft} />
           {estate.size > 0 && <ParcelCoordinates estateId={nft.tokenId} />}
-          <TransactionHistory nft={nft} />
+          <TransactionHistory asset={nft} />
         </>
       }
     />

--- a/webapp/src/components/AssetPage/ItemDetail/ItemDetail.tsx
+++ b/webapp/src/components/AssetPage/ItemDetail/ItemDetail.tsx
@@ -16,6 +16,7 @@ import Collection from '../Collection'
 import Price from '../Price'
 import BaseDetail from '../BaseDetail'
 import { getBuilderCollectionDetailUrl } from '../../../modules/collection/utils'
+import { TransactionHistory } from '../TransactionHistory'
 import { AssetImage } from '../../AssetImage'
 import styles from './ItemDetail.module.css'
 
@@ -96,6 +97,7 @@ const ItemDetail = ({ item, wallet }: Props) => {
           )}
         </>
       }
+      below={<TransactionHistory asset={item} />}
     />
   )
 }

--- a/webapp/src/components/AssetPage/ParcelDetail/ParcelDetail.tsx
+++ b/webapp/src/components/AssetPage/ParcelDetail/ParcelDetail.tsx
@@ -72,7 +72,7 @@ const ParcelDetail = ({ nft }: Props) => {
       below={
         <>
           <BidList nft={nft} />
-          <TransactionHistory nft={nft} />
+          <TransactionHistory asset={nft} />
         </>
       }
     />

--- a/webapp/src/components/AssetPage/TransactionHistory/TransactionHistory.css
+++ b/webapp/src/components/AssetPage/TransactionHistory/TransactionHistory.css
@@ -18,3 +18,7 @@
 .TransactionHistory .mobile-tx-history-row .when {
   color: var(--secondary-text);
 }
+
+.TransactionHistory tbody.is-loading tr {
+  opacity: 0.5;
+}

--- a/webapp/src/components/AssetPage/TransactionHistory/TransactionHistory.types.ts
+++ b/webapp/src/components/AssetPage/TransactionHistory/TransactionHistory.types.ts
@@ -1,18 +1,8 @@
-import { Bid, Order } from '@dcl/schemas'
-import { NFT } from '../../../modules/nft/types'
+import { Asset } from '../../../modules/asset/types'
 
 export type Props = {
-  nft: NFT | null
+  asset: Asset | null
 }
-
-export type HistoryEvent = {
-  from: string
-  to: string
-  price: string
-  updatedAt: number
-}
-
-export type UnionOrderBid = Partial<Order & Bid>
 
 export type MapStateProps = {}
 export type MapDispatchProps = {}

--- a/webapp/src/components/AssetPage/WearableDetail/WearableDetail.tsx
+++ b/webapp/src/components/AssetPage/WearableDetail/WearableDetail.tsx
@@ -67,7 +67,7 @@ const WearableDetail = ({ nft }: Props) => {
       below={
         <>
           <BidList nft={nft} />
-          <TransactionHistory nft={nft} />
+          <TransactionHistory asset={nft} />
         </>
       }
     />

--- a/webapp/src/components/Navigation/Navigation.tsx
+++ b/webapp/src/components/Navigation/Navigation.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
-import { Tabs, Responsive } from 'decentraland-ui'
+import { Tabs, Mobile } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { locations } from '../../modules/routing/locations'
 import { VendorName } from '../../modules/vendor'
@@ -36,13 +36,13 @@ const Navigation = (props: Props) => {
             {t('navigation.my_store')}
           </Tabs.Tab>
         </Link>
-        <Responsive maxWidth={Responsive.onlyMobile.maxWidth}>
+        <Mobile>
           <Link to={locations.activity()}>
             <Tabs.Tab active={activeTab === NavigationTab.ACTIVITY}>
               {t('navigation.activity')}
             </Tabs.Tab>
           </Link>
-        </Responsive>
+        </Mobile>
       </Tabs.Left>
     </Tabs>
   )

--- a/webapp/src/components/OnSaleList/AssetCell/AssetCell.tsx
+++ b/webapp/src/components/OnSaleList/AssetCell/AssetCell.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Table } from 'decentraland-ui'
 import { Link } from 'react-router-dom'
 import { NFTCategory } from '@dcl/schemas'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
@@ -28,19 +27,17 @@ const AssetCell = ({ asset }: Props) => {
       : locations.item(asset.contractAddress, asset.itemId!)
 
   return (
-    <Table.Cell>
-      <Link to={link}>
-        <div className={styles.firstCell}>
-          <div className={styles.imageContainer}>
-            <AssetImage asset={asset} isSmall />
-          </div>
-          <div>
-            <div className={styles.title}>{asset.name}</div>
-            {subtitle && <div className={styles.subtitle}>{subtitle}</div>}
-          </div>
+    <Link to={link}>
+      <div className={styles.firstCell}>
+        <div className={styles.imageContainer}>
+          <AssetImage asset={asset} isSmall />
         </div>
-      </Link>
-    </Table.Cell>
+        <div>
+          <div className={styles.title}>{asset.name}</div>
+          {subtitle && <div className={styles.subtitle}>{subtitle}</div>}
+        </div>
+      </div>
+    </Link>
   )
 }
 

--- a/webapp/src/components/OnSaleList/OnSaleList.tsx
+++ b/webapp/src/components/OnSaleList/OnSaleList.tsx
@@ -4,14 +4,15 @@ import {
   Loader,
   TextFilter,
   Dropdown,
-  Pagination
+  Pagination,
+  NotMobile
 } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Props } from './OnSaleList.types'
 import OnSaleListElement from './OnSaleListElement'
 import { SortBy } from '../../modules/routing/types'
-import styles from './OnSaleList.module.css'
 import { useProcessedElements } from './utils'
+import styles from './OnSaleList.module.css'
 
 const OnSaleList = ({ elements, isLoading }: Props) => {
   const perPage = useRef(12)
@@ -67,14 +68,16 @@ const OnSaleList = ({ elements, isLoading }: Props) => {
       ) : (
         <>
           <Table basic="very">
-            <Table.Header>
-              <Table.Row>
-                <Table.HeaderCell>{t('global.item')}</Table.HeaderCell>
-                <Table.HeaderCell>{t('global.type')}</Table.HeaderCell>
-                <Table.HeaderCell>{t('global.sale_type')}</Table.HeaderCell>
-                <Table.HeaderCell>{t('global.sell_price')}</Table.HeaderCell>
-              </Table.Row>
-            </Table.Header>
+            <NotMobile>
+              <Table.Header>
+                <Table.Row>
+                  <Table.HeaderCell>{t('global.item')}</Table.HeaderCell>
+                  <Table.HeaderCell>{t('global.type')}</Table.HeaderCell>
+                  <Table.HeaderCell>{t('global.sale_type')}</Table.HeaderCell>
+                  <Table.HeaderCell>{t('global.sell_price')}</Table.HeaderCell>
+                </Table.Row>
+              </Table.Header>
+            </NotMobile>
             <Table.Body>
               {processedElements.paginated.map(element => (
                 <OnSaleListElement

--- a/webapp/src/components/OnSaleList/OnSaleListElement/OnSaleListElement.css
+++ b/webapp/src/components/OnSaleList/OnSaleListElement/OnSaleListElement.css
@@ -1,0 +1,14 @@
+.mobile-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.mobile-row .ui.header.dcl.mana {
+  margin: 0px;
+}
+
+.mobile-row a {
+  color: var(--text);
+}

--- a/webapp/src/components/OnSaleList/OnSaleListElement/OnSaleListElement.tsx
+++ b/webapp/src/components/OnSaleList/OnSaleListElement/OnSaleListElement.tsx
@@ -1,25 +1,42 @@
 import React from 'react'
-import { Table } from 'decentraland-ui'
+import { Mobile, NotMobile, Table } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Mana } from '../../Mana'
 import { formatMANA } from '../../../lib/mana'
 import { Props } from './OnSaleListElement.types'
 import AssetCell from '../AssetCell'
+import './OnSaleListElement.css'
 
 const OnSaleListElement = ({ nft, item, order }: Props) => {
   const category = item?.category || nft!.category
 
   return (
-    <Table.Row>
-      <AssetCell asset={item || nft!} />
-      <Table.Cell>{t(`global.${category}`)}</Table.Cell>
-      <Table.Cell>{t(`global.${item ? 'primary' : 'secondary'}`)}</Table.Cell>
-      <Table.Cell>
-        <Mana network={item?.network || nft!.network} inline>
-          {formatMANA(item?.price || order!.price)}
-        </Mana>
-      </Table.Cell>
-    </Table.Row>
+    <>
+      <Mobile>
+        <div className="mobile-row">
+          <AssetCell asset={item || nft!} />
+          <Mana network={item?.network || nft!.network} inline>
+            {formatMANA(item?.price || order!.price)}
+          </Mana>
+        </div>
+      </Mobile>
+      <NotMobile>
+        <Table.Row>
+          <Table.Cell>
+            <AssetCell asset={item || nft!} />
+          </Table.Cell>
+          <Table.Cell>{t(`global.${category}`)}</Table.Cell>
+          <Table.Cell>
+            {t(`global.${item ? 'primary' : 'secondary'}`)}
+          </Table.Cell>
+          <Table.Cell>
+            <Mana network={item?.network || nft!.network} inline>
+              {formatMANA(item?.price || order!.price)}
+            </Mana>
+          </Table.Cell>
+        </Table.Row>
+      </NotMobile>
+    </>
   )
 }
 

--- a/webapp/src/components/Sales/Activity/Activity.css
+++ b/webapp/src/components/Sales/Activity/Activity.css
@@ -17,3 +17,22 @@
   margin-top: 18px;
   margin-bottom: 18px;
 }
+
+.Activity .mobile-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.Activity .mobile-row:last-child {
+  margin-bottom: 0px;
+}
+
+.Activity .mobile-row a {
+  color: var(--text);
+}
+
+.Activity .mobile-row .dcl.mana {
+  margin: 0;
+}

--- a/webapp/src/components/Sales/Activity/Activity.tsx
+++ b/webapp/src/components/Sales/Activity/Activity.tsx
@@ -1,7 +1,14 @@
 import React, { ReactNode } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
-import { Header, Loader, Pagination, Table } from 'decentraland-ui'
+import {
+  Header,
+  Loader,
+  Mobile,
+  NotMobile,
+  Pagination,
+  Table
+} from 'decentraland-ui'
 import { Profile } from 'decentraland-dapps/dist/containers'
 import { Link } from 'react-router-dom'
 import { SALES_PER_PAGE } from '../../../modules/routing/utils'
@@ -33,44 +40,67 @@ const Activity = ({
         </div>
       ) : (
         <>
-          <Table basic="very">
-            <Table.Header>
-              <Table.Row>
-                <Table.HeaderCell>{t('global.item')}</Table.HeaderCell>
-                <Table.HeaderCell>{t('global.time')}</Table.HeaderCell>
-                <Table.HeaderCell>{t('global.buyer')}</Table.HeaderCell>
-                <Table.HeaderCell>{t('global.price')}</Table.HeaderCell>
-              </Table.Row>
-            </Table.Header>
-            <Table.Body>
-              {sales.reduce((acc, sale) => {
-                const asset = assets[sale.id]
-                if (asset) {
-                  acc.push(
-                    <Table.Row key={sale.id}>
-                      <AssetCell asset={assets[sale.id]} />
-                      <Table.Cell>
-                        {formatDistanceToNow(sale.timestamp, {
-                          addSuffix: true
-                        })}
-                      </Table.Cell>
-                      <Table.Cell>
-                        <Link to={locations.account(sale.buyer)}>
-                          <Profile address={sale.buyer} inline />
-                        </Link>
-                      </Table.Cell>
-                      <Table.Cell>
-                        <Mana network={sale.network} inline>
-                          {formatMANA(sale.price)}
-                        </Mana>
-                      </Table.Cell>
-                    </Table.Row>
-                  )
-                }
-                return acc
-              }, [] as ReactNode[])}
-            </Table.Body>
-          </Table>
+          <Mobile>
+            {sales.reduce((acc, sale) => {
+              const asset = assets[sale.id]
+              if (asset) {
+                acc.push(
+                  <div key={sale.id} className="mobile-row">
+                    <AssetCell asset={assets[sale.id]} />
+
+                    <Mana network={sale.network} inline>
+                      {formatMANA(sale.price)}
+                    </Mana>
+                  </div>
+                )
+              }
+              return acc
+            }, [] as ReactNode[])}
+          </Mobile>
+          <NotMobile>
+            <Table basic="very">
+              <Table.Header>
+                <Table.Row>
+                  <Table.HeaderCell>{t('global.item')}</Table.HeaderCell>
+                  <Table.HeaderCell>{t('global.time')}</Table.HeaderCell>
+                  <Table.HeaderCell>{t('global.buyer')}</Table.HeaderCell>
+                  <Table.HeaderCell>{t('global.type')}</Table.HeaderCell>
+                  <Table.HeaderCell>{t('global.price')}</Table.HeaderCell>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                {sales.reduce((acc, sale) => {
+                  const asset = assets[sale.id]
+                  if (asset) {
+                    acc.push(
+                      <Table.Row key={sale.id}>
+                        <Table.Cell>
+                          <AssetCell asset={assets[sale.id]} />
+                        </Table.Cell>
+                        <Table.Cell>
+                          {formatDistanceToNow(sale.timestamp, {
+                            addSuffix: true
+                          })}
+                        </Table.Cell>
+                        <Table.Cell>
+                          <Link to={locations.account(sale.buyer)}>
+                            <Profile address={sale.buyer} inline />
+                          </Link>
+                        </Table.Cell>
+                        <Table.Cell>{t(`global.${sale.type}`)}</Table.Cell>
+                        <Table.Cell>
+                          <Mana network={sale.network} inline>
+                            {formatMANA(sale.price)}
+                          </Mana>
+                        </Table.Cell>
+                      </Table.Row>
+                    )
+                  }
+                  return acc
+                }, [] as ReactNode[])}
+              </Table.Body>
+            </Table>
+          </NotMobile>
           {hasPagination && (
             <div className="pagination">
               <Pagination

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -36,7 +36,10 @@
     "price": "Price",
     "collection": "Collection",
     "time": "Time",
-    "buyer": "Buyer"
+    "buyer": "Buyer",
+    "bid": "Bid",
+    "order": "Listing",
+    "mint": "Mint"
   },
   "error_boundary": {
     "message": "Oops! Something went wrong..."
@@ -247,9 +250,10 @@
     "invalid_fingerprint_on_bid_placed": "This asset has been modified since this bid was made and it's not valid anymore unless you update it"
   },
   "transaction_history": {
-    "title": "Transaction History",
+    "title": "Latest Sales",
     "from": "From",
     "to": "To",
+    "type": "Type",
     "when": "When",
     "price": "Price"
   },

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -36,7 +36,10 @@
     "price": "Precio",
     "collection": "Colección",
     "time": "Tiempo",
-    "buyer": "Comprador"
+    "buyer": "Comprador",
+    "bid": "Oferta",
+    "order": "Clasificado",
+    "mint": "Venta"
   },
   "error_boundary": {
     "message": "Oops! Algo salió mal..."
@@ -245,9 +248,10 @@
     "invalid_fingerprint_on_bid_placed": "Este artículo ha sido modificado desde que realizaste esta oferta y ya no es valida, a menos que la actualices"
   },
   "transaction_history": {
-    "title": "Historial de Transacciones",
+    "title": "Últimas ventas",
     "from": "Vendedor",
     "to": "Comprador",
+    "type": "Tipo",
     "when": "Fecha",
     "price": "Precio"
   },

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -36,7 +36,10 @@
     "price": "价格",
     "collection": "珍藏",
     "time": "时间",
-    "buyer": "买方"
+    "buyer": "买方",
+    "bid": "投标",
+    "order": "清单",
+    "mint": "薄荷"
   },
   "error_boundary": {
     "message": "糟糕！出了点问题......"
@@ -245,9 +248,10 @@
     "invalid_fingerprint_on_bid_placed": "此资产自出价后就已被修改，除非您对其进行更新，否则它将不再有效"
   },
   "transaction_history": {
-    "title": "交易记录",
+    "title": "最新销售",
     "from": "从",
     "to": "至",
+    "type": "类型",
     "when": "时间",
     "price": "价格"
   },


### PR DESCRIPTION
Closes #504

This PR:

- Fixes the responsiveness of the `Sales` and `On Sale` sections of `My Store`. 
- Since the `CurrentAccountSidebar` was completely removed on mobile, it was not possible to navigate the `My Store` page, so I added some `Tabs` to allow navigation on this view on mobile.
- Added the sale `type` to the sales information in `Sales`, `On Sale`, and `TransactionHistory`.
- I also took the chance to get rid of the deprecated `Responsive` component and replace it with `Mobile` and `NotMobile`. 
- Finally, I modified the `TransactionHistory` component to use the new `/sales` API, added pagination to it, and made it so it support both `NFT` and `Item`, so I added it to the `ItemDetail` as well:


My Store responsive tables:
<img width="485" alt="Screen Shot 2021-12-30 at 12 31 43" src="https://user-images.githubusercontent.com/2781777/147789901-56469a7c-548b-499f-a028-714e5175ca82.png">

ItemDetail with latest sales:
<img width="1026" alt="Screen Shot 2021-12-30 at 18 39 20" src="https://user-images.githubusercontent.com/2781777/147790018-c336c2c8-5be1-41b5-b255-ea34dd393cd5.png">



