### PR TITLE
fix: Listed badge style on detail

### DIFF
--- a/webapp/src/components/AssetPage/BaseDetail/BaseDetail.css
+++ b/webapp/src/components/AssetPage/BaseDetail/BaseDetail.css
@@ -41,14 +41,6 @@
   right: 24px;
 }
 
-@media (max-width: 768px) {
-  .BaseDetail .listed-badge {
-    position: absolute;
-    top: 44px;
-    right: 24px;
-  }
-}
-
 .BaseDetail .row {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
On mobile, the badge was not the same distance from the top than from the right because of some old media query, removed it so it is placed accordingly.

This

![image](https://user-images.githubusercontent.com/24811313/149527947-54425e48-7884-4682-b71e-d8266017eef3.png)

Instead of

![image](https://user-images.githubusercontent.com/24811313/149528211-e9053a2a-dcb9-4c0f-8a07-25b781039d64.png)
