### PR TITLE
fix: Redirect to root page if address is not valid

### DIFF
--- a/webapp/src/components/AccountPage/AccountPage.tsx
+++ b/webapp/src/components/AccountPage/AccountPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo } from 'react'
+import { utils } from 'ethers'
 import { Page, Loader } from 'decentraland-ui'
 import { View } from '../../modules/ui/types'
 import { Navbar } from '../Navbar'
@@ -31,6 +32,13 @@ const AccountPage = ({
       onRedirect(locations.signIn())
     }
   }, [addressInUrl, isConnecting, wallet, onRedirect])
+
+  // Redirect to root page if the address provided is not a valid one
+  useEffect(() => {
+    if (address && !utils.isAddress(address)) {
+      onRedirect(locations.root())
+    }
+  }, [address, onRedirect])
 
   const content = useMemo(() => {
     if (!address) {


### PR DESCRIPTION
Checks if the address is valid using [ether.js utils method](https://docs.ethers.io/v5/api/utils/address/#utils-isAddress) `isAddress`, redirecting to the root page in case it returns `false`.


https://user-images.githubusercontent.com/8763687/149975358-3c599526-574e-474f-98b2-d753d98dad38.mov

