### PR TITLE
feat: show smart wearable badge + filter by smart wearables

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1449,9 +1449,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "@dcl/schemas": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-3.1.1.tgz",
-      "integrity": "sha512-LsNpyjf6T8OM8FkuHrzO2vPoSAggBj1iKY3myoH5K+YYM1s4xBD6wZK9JTcXa9dhBfPnlrr7aJWIsJ81oztlIQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-3.4.1.tgz",
+      "integrity": "sha512-xtt11/QGplk9ohwBIHub9l9kRQvYX+FIcXke58hhkRDATAcGx01ONSvp4qX+EoXQhERtNjfuxheC2uCrwqDakg==",
       "requires": {
         "ajv": "^7.1.0"
       }
@@ -2667,9 +2667,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.10.2.tgz",
-      "integrity": "sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ=="
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
+      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA=="
     },
     "@redux-saga/core": {
       "version": "1.1.3",
@@ -3544,9 +3544,9 @@
       }
     },
     "@types/react-virtualized": {
-      "version": "9.21.15",
-      "resolved": "https://registry.npmjs.org/@types/react-virtualized/-/react-virtualized-9.21.15.tgz",
-      "integrity": "sha512-R4ntUW+Y/a7RgRpfeYz3iRe+kaDWtXieMeQum4AoYjjZsR/QhpKqFu4muSBhzA7OHJHd6qA0KkeTzxj5ah5tmQ==",
+      "version": "9.21.16",
+      "resolved": "https://registry.npmjs.org/@types/react-virtualized/-/react-virtualized-9.21.16.tgz",
+      "integrity": "sha512-25QMrouz1VKq5T68+9JfRq3GP4JmN20ARi+hl5z7NMmriy07XmGd1Yh3I4EIZjmifpXhHZoQS/ny2fzZRyiAiw==",
       "requires": {
         "@types/prop-types": "*",
         "@types/react": "*"
@@ -7345,11 +7345,11 @@
       "integrity": "sha512-2IGiWe362J5Wp9DIeEc2wwKP7w9CVNc5EvCU55MuljJBtMx+DnwUf4+JIEjKBmJ+mPaBvxB9yEhMQA5nDcmX7A=="
     },
     "decentraland-ui": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.15.0.tgz",
-      "integrity": "sha512-iyRJESj5St9cbUH13AShaFkMJwywJJDhRsWdk0E4lm2Abrn26u1XYCU6lfDSZVkM6NAiO5Illnd39PVoR0+jtA==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.17.0.tgz",
+      "integrity": "sha512-0y4ieEuEMGpgVcR/wcRNLmoUzDlyhbW1oVwqUeCUR9pwnpHhP5Dob349gsd82Vyx5vqaocLZwtbJpZuC9uVfaQ==",
       "requires": {
-        "@dcl/schemas": "^0.2.0",
+        "@dcl/schemas": "^3.1.1",
         "balloon-css": "^0.5.0",
         "ethereum-blockies": "^0.1.1",
         "parallax-js": "^3.1.0",
@@ -7359,16 +7359,6 @@
         "react-tile-map": "^0.3.2",
         "semantic-ui-css": "^2.4.1",
         "semantic-ui-react": "^2.0.3"
-      },
-      "dependencies": {
-        "@dcl/schemas": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-0.2.0.tgz",
-          "integrity": "sha512-mvjMQryY+in8TKNNOzyp+ibq4gvnbnI0AX+KgbFLCD4LJyQPi59jeeyqGHAmassKqQiC2iCDvZc5FxDw9FxqRQ==",
-          "requires": {
-            "ajv": "^7.1.0"
-          }
-        }
       }
     },
     "decimal.js": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -2,7 +2,7 @@
   "name": "marketplace-ui",
   "version": "0.4.0",
   "dependencies": {
-    "@dcl/schemas": "^3.1.1",
+    "@dcl/schemas": "^3.4.1",
     "apollo-boost": "^0.4.7",
     "bn.js": "^5.2.0",
     "classnames": "^2.3.1",
@@ -13,7 +13,7 @@
     "dcl-crypto": "^2.2.0",
     "decentraland-dapps": "^12.33.2",
     "decentraland-transactions": "^1.29.1",
-    "decentraland-ui": "^3.15.0",
+    "decentraland-ui": "^3.17.0",
     "dotenv": "^10.0.0",
     "graphql": "^14.7.0",
     "history": "^4.10.1",

--- a/webapp/src/components/AssetBrowse/AssetBrowse.container.ts
+++ b/webapp/src/components/AssetBrowse/AssetBrowse.container.ts
@@ -11,7 +11,8 @@ import {
   getIsMap,
   getOnlyOnSale,
   getAssetType,
-  getSection
+  getSection,
+  getOnlySmart
 } from '../../modules/routing/selectors'
 import { getView } from '../../modules/ui/browse/selectors'
 import { FETCH_ITEMS_REQUEST } from '../../modules/item/actions'
@@ -32,7 +33,8 @@ const mapState = (state: RootState): MapStateProps => ({
     isLoadingType(getLoadingNFTs(state), FETCH_NFTS_REQUEST) ||
     isLoadingType(getLoadingItems(state), FETCH_ITEMS_REQUEST),
   assetType: getAssetType(state),
-  viewInState: getView(state)
+  viewInState: getView(state),
+  onlySmart: getOnlySmart(state)
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({

--- a/webapp/src/components/AssetBrowse/AssetBrowse.tsx
+++ b/webapp/src/components/AssetBrowse/AssetBrowse.tsx
@@ -64,6 +64,7 @@ const AssetBrowse = (props: Props) => {
     sections,
     assetType,
     onlyOnSale,
+    onlySmart,
     viewInState
   } = props
 
@@ -89,7 +90,8 @@ const AssetBrowse = (props: Props) => {
         view,
         section,
         address,
-        onlyOnSale
+        onlyOnSale,
+        onlySmart
       })
       setHasFetched(true)
     }
@@ -99,6 +101,7 @@ const AssetBrowse = (props: Props) => {
     section,
     address,
     onlyOnSale,
+    onlySmart,
     viewInState,
     onFetchAssetsFromRoute,
     hasFetched

--- a/webapp/src/components/AssetBrowse/AssetBrowse.types.ts
+++ b/webapp/src/components/AssetBrowse/AssetBrowse.types.ts
@@ -27,11 +27,18 @@ export type Props = {
   onFetchAssetsFromRoute: typeof fetchAssetsFromRoute
   onBrowse: typeof browse
   onlyOnSale?: boolean
+  onlySmart?: boolean
 }
 
 export type MapStateProps = Pick<
   Props,
-  'isMap' | 'isLoading' | 'onlyOnSale' | 'viewInState' | 'section' | 'assetType'
+  | 'isMap'
+  | 'isLoading'
+  | 'onlyOnSale'
+  | 'viewInState'
+  | 'section'
+  | 'assetType'
+  | 'onlySmart'
 >
 export type MapDispatchProps = Pick<
   Props,

--- a/webapp/src/components/AssetCard/WearableTags/WearableTags.css
+++ b/webapp/src/components/AssetCard/WearableTags/WearableTags.css
@@ -101,6 +101,12 @@
   background-size: 14px 14px;
 }
 
+.WearableTags .dcl.smart-icon {
+  width: 14px;
+  height: 14px;
+  margin: 5px;
+}
+
 @media (min-width: 768px) and (max-width: 992px) {
   .WearableTags .icon {
     display: none;

--- a/webapp/src/components/AssetCard/WearableTags/WearableTags.tsx
+++ b/webapp/src/components/AssetCard/WearableTags/WearableTags.tsx
@@ -1,4 +1,5 @@
 import { BodyShape, Rarity } from '@dcl/schemas'
+import { SmartIcon } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { isUnisex, isGender } from '../../../modules/nft/wearable/utils'
 import { Props } from './WearableTags.types'
@@ -32,6 +33,11 @@ const WearableTags = (props: Props) => {
           }
         />
       )}
+      {wearable.isSmart ? (
+        <div className="icon smart" title={t(`wearable.smart`)}>
+          <SmartIcon />
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/webapp/src/components/AssetPage/BaseDetail/BaseDetail.css
+++ b/webapp/src/components/AssetPage/BaseDetail/BaseDetail.css
@@ -22,6 +22,7 @@
   margin-top: 15px;
   display: flex;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 .BaseDetail .right > .box {

--- a/webapp/src/components/AssetPage/IconBadge/IconBadge.css
+++ b/webapp/src/components/AssetPage/IconBadge/IconBadge.css
@@ -20,6 +20,10 @@
   background-repeat: no-repeat;
 }
 
+.IconBadge .custom-icon {
+  margin-right: 10px;
+}
+
 /* Icons */
 
 .IconBadge .BaseMale {

--- a/webapp/src/components/AssetPage/IconBadge/IconBadge.tsx
+++ b/webapp/src/components/AssetPage/IconBadge/IconBadge.tsx
@@ -3,10 +3,14 @@ import classNames from 'classnames'
 import { Props } from './IconBadge.types'
 import './IconBadge.css'
 
-const IconBadge = ({ icon, text, onClick }: Props) => {
+const IconBadge = ({ icon, text, onClick, className, children }: Props) => {
   return (
-    <div className="IconBadge" onClick={onClick}>
-      <span className={classNames('icon', icon)} />
+    <div className={classNames('IconBadge', className)} onClick={onClick}>
+      {children ? (
+        <span className="custom-icon">{children}</span>
+      ) : (
+        <span className={classNames('icon', icon)} />
+      )}
       <span className="text">{text}</span>
     </div>
   )

--- a/webapp/src/components/AssetPage/IconBadge/IconBadge.types.ts
+++ b/webapp/src/components/AssetPage/IconBadge/IconBadge.types.ts
@@ -1,5 +1,9 @@
+import React from 'react'
+
 export type Props = {
-  icon: string
+  className?: string
+  icon?: string
   text: string
   onClick: () => void
+  children?: React.ReactNode
 }

--- a/webapp/src/components/AssetPage/ItemDetail/ItemDetail.tsx
+++ b/webapp/src/components/AssetPage/ItemDetail/ItemDetail.tsx
@@ -11,6 +11,7 @@ import RarityBadge from '../RarityBadge'
 import { AssetType } from '../../../modules/asset/types'
 import GenderBadge from '../GenderBadge'
 import CategoryBadge from '../CategoryBadge'
+import SmartBadge from '../SmartBadge'
 import { Owner } from '../Owner'
 import Collection from '../Collection'
 import Price from '../Price'
@@ -38,6 +39,7 @@ const ItemDetail = ({ item, wallet }: Props) => {
           <RarityBadge rarity={item.rarity} assetType={AssetType.ITEM} />
           <CategoryBadge wearable={wearable} assetType={AssetType.ITEM} />
           <GenderBadge wearable={wearable} assetType={AssetType.ITEM} />
+          {wearable.isSmart ? <SmartBadge assetType={AssetType.ITEM} /> : null}
         </>
       }
       left={

--- a/webapp/src/components/AssetPage/SmartBadge/SmartBadge.container.ts
+++ b/webapp/src/components/AssetPage/SmartBadge/SmartBadge.container.ts
@@ -1,0 +1,25 @@
+import { push } from 'connected-react-router'
+import { connect } from 'react-redux'
+import { Dispatch } from 'redux'
+import { locations } from '../../../modules/routing/locations'
+import { Section } from '../../../modules/vendor/decentraland'
+import SmartBadge from './SmartBadge'
+import { MapDispatchProps, OwnProps } from './SmartBadge.types'
+
+const mapDispatch = (
+  dispatch: Dispatch,
+  { assetType }: OwnProps
+): MapDispatchProps => ({
+  onClick: () =>
+    dispatch(
+      push(
+        locations.browse({
+          assetType,
+          section: Section.WEARABLES,
+          onlySmart: true
+        })
+      )
+    )
+})
+
+export default connect(null, mapDispatch)(SmartBadge)

--- a/webapp/src/components/AssetPage/SmartBadge/SmartBadge.css
+++ b/webapp/src/components/AssetPage/SmartBadge/SmartBadge.css
@@ -1,0 +1,5 @@
+.SmartBadge .dcl.smart-icon {
+  top: 2px;
+  width: 14px;
+  height: 14px;
+}

--- a/webapp/src/components/AssetPage/SmartBadge/SmartBadge.tsx
+++ b/webapp/src/components/AssetPage/SmartBadge/SmartBadge.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import { SmartIcon } from 'decentraland-ui'
+import IconBadge from '../IconBadge'
+import { Props } from './SmartBadge.types'
+import './SmartBadge.css'
+
+const SmartBadge = ({ onClick }: Props) => {
+  return (
+    <IconBadge
+      className="SmartBadge"
+      text={t('wearable.smart_badge')}
+      onClick={onClick}
+    >
+      <SmartIcon />
+    </IconBadge>
+  )
+}
+
+export default React.memo(SmartBadge)

--- a/webapp/src/components/AssetPage/SmartBadge/SmartBadge.types.ts
+++ b/webapp/src/components/AssetPage/SmartBadge/SmartBadge.types.ts
@@ -1,0 +1,9 @@
+import { AssetType } from '../../../modules/asset/types'
+
+export type Props = {
+  assetType: AssetType
+  onClick: () => void
+}
+
+export type MapDispatchProps = Pick<Props, 'onClick'>
+export type OwnProps = Pick<Props, 'assetType'>

--- a/webapp/src/components/AssetPage/SmartBadge/index.ts
+++ b/webapp/src/components/AssetPage/SmartBadge/index.ts
@@ -1,0 +1,3 @@
+import SmartBadge from './SmartBadge.container'
+
+export default SmartBadge

--- a/webapp/src/components/AssetPage/WearableDetail/WearableDetail.tsx
+++ b/webapp/src/components/AssetPage/WearableDetail/WearableDetail.tsx
@@ -8,6 +8,7 @@ import { Props } from './WearableDetail.types'
 import RarityBadge from '../RarityBadge'
 import { AssetType } from '../../../modules/asset/types'
 import GenderBadge from '../GenderBadge'
+import SmartBadge from '../SmartBadge'
 import CategoryBadge from '../CategoryBadge'
 import { Owner } from '../Owner'
 import Collection from '../Collection'
@@ -33,6 +34,7 @@ const WearableDetail = ({ nft }: Props) => {
           <RarityBadge rarity={wearable.rarity} assetType={AssetType.NFT} />
           <CategoryBadge wearable={wearable} assetType={AssetType.NFT} />
           <GenderBadge wearable={wearable} assetType={AssetType.NFT} />
+          {wearable.isSmart ? <SmartBadge assetType={AssetType.NFT} /> : null}
         </>
       }
       left={

--- a/webapp/src/components/Vendor/NFTFilters/ArrayFilter/ArrayFilter.css
+++ b/webapp/src/components/Vendor/NFTFilters/ArrayFilter/ArrayFilter.css
@@ -14,6 +14,10 @@
   margin-bottom: 8px;
 }
 
+.ArrayFilter .options .option:last-child {
+  margin-right: 0px;
+}
+
 .ArrayFilter .options .option.selected {
   background-color: var(--primary);
 }

--- a/webapp/src/components/Vendor/NFTFilters/FiltersMenu/FiltersMenu.tsx
+++ b/webapp/src/components/Vendor/NFTFilters/FiltersMenu/FiltersMenu.tsx
@@ -113,14 +113,6 @@ const FiltersMenu = (props: Props) => {
             checked={isOnlySmart}
             onChange={handleOnlySmartClick}
           />
-          {/* <div
-            className={classNames(`smart-toggle`, {
-              'is-enabled': isOnlySmart
-            })}
-            onClick={handleOnlySmartClick}
-          >
-            <SmartIcon />
-          </div> */}
         </Mobile>
         <NotMobile>
           <Popup

--- a/webapp/src/components/Vendor/NFTFilters/FiltersMenu/FiltersMenu.tsx
+++ b/webapp/src/components/Vendor/NFTFilters/FiltersMenu/FiltersMenu.tsx
@@ -1,7 +1,17 @@
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
+import classNames from 'classnames'
 import { Network, NFTCategory, Rarity } from '@dcl/schemas'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
-import { Row, Column } from 'decentraland-ui'
+import {
+  Row,
+  Column,
+  SmartIcon,
+  Popup,
+  Mobile,
+  NotMobile,
+  Header,
+  Radio
+} from 'decentraland-ui'
 import { WearableGender } from '../../../../modules/nft/wearable/types'
 import { contracts } from '../../../../modules/contract/utils'
 import { ArrayFilter } from '../ArrayFilter'
@@ -16,10 +26,12 @@ const FiltersMenu = (props: Props) => {
     selectedRarities,
     selectedGenders,
     selectedNetwork,
+    isOnlySmart,
     onCollectionsChange,
     onRaritiesChange,
     onGendersChange,
-    onNetworkChange
+    onNetworkChange,
+    onOnlySmartChange
   } = props
 
   const collectionOptions = useMemo(() => {
@@ -71,6 +83,11 @@ const FiltersMenu = (props: Props) => {
     ]
   }, [])
 
+  const handleOnlySmartClick = useCallback(
+    () => onOnlySmartChange(!isOnlySmart),
+    [onOnlySmartChange, isOnlySmart]
+  )
+
   return (
     <>
       <Row>
@@ -88,6 +105,39 @@ const FiltersMenu = (props: Props) => {
           options={networkOptions}
           onChange={network => onNetworkChange(network as Network)}
         />
+        <Mobile>
+          <Header sub>{t('nft_filters.smart_wearables')}</Header>
+          <Radio
+            className="smart-toggle-mobile"
+            toggle
+            checked={isOnlySmart}
+            onChange={handleOnlySmartClick}
+          />
+          {/* <div
+            className={classNames(`smart-toggle`, {
+              'is-enabled': isOnlySmart
+            })}
+            onClick={handleOnlySmartClick}
+          >
+            <SmartIcon />
+          </div> */}
+        </Mobile>
+        <NotMobile>
+          <Popup
+            content={t('nft_filters.smart_wearables')}
+            position="top center"
+            trigger={
+              <div
+                className={classNames(`smart-toggle`, {
+                  'is-enabled': isOnlySmart
+                })}
+                onClick={handleOnlySmartClick}
+              >
+                <SmartIcon />
+              </div>
+            }
+          ></Popup>
+        </NotMobile>
       </Row>
       <Row>
         <Column>

--- a/webapp/src/components/Vendor/NFTFilters/FiltersMenu/FiltersMenu.types.ts
+++ b/webapp/src/components/Vendor/NFTFilters/FiltersMenu/FiltersMenu.types.ts
@@ -7,8 +7,10 @@ export type Props = {
   selectedRarities: string[]
   selectedGenders: string[]
   selectedNetwork?: Network
+  isOnlySmart: boolean
   onCollectionsChange: (contract?: string) => void
   onGendersChange: (options: string[]) => void
   onRaritiesChange: (options: string[]) => void
   onNetworkChange: (network: Network) => void
+  onOnlySmartChange: (onlySmart: boolean) => void
 }

--- a/webapp/src/components/Vendor/NFTFilters/NFTFilters.css
+++ b/webapp/src/components/Vendor/NFTFilters/NFTFilters.css
@@ -60,6 +60,11 @@
 
 .NFTFilters .filters .dcl.row .Filter {
   flex: 1 0 auto;
+  margin-left: auto;
+}
+
+.NFTFilters .filters .dcl.row .dcl.column:first-child .Filter {
+  margin-left: 0px;
 }
 
 .NFTFilters .filters .dcl.row .Filter + .Filter {
@@ -215,6 +220,21 @@
   color: var(--text);
 }
 
+.NFTFilters .smart-toggle {
+  background: #37333d;
+  padding: 8px;
+  border-radius: 6px;
+  width: 32px;
+  height: 32px;
+  margin-left: 20px;
+  margin-top: 27px;
+  cursor: pointer;
+}
+
+.NFTFilters .smart-toggle.is-enabled {
+  background: var(--primary);
+}
+
 @media (max-width: 768px) {
   .NFTFilters .topbar {
     align-items: normal;
@@ -224,6 +244,12 @@
     align-items: flex-start;
     flex-direction: column;
     justify-content: stretch;
+  }
+
+  .FiltersModal .smart-toggle-mobile {
+    margin-top: 12px;
+    margin-left: 0px;
+    margin-bottom: 20px;
   }
 }
 

--- a/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.container.ts
+++ b/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.container.ts
@@ -2,7 +2,10 @@ import { connect } from 'react-redux'
 
 import { RootState } from '../../../../modules/reducer'
 import { clearFilters } from '../../../../modules/routing/actions'
-import { hasFiltersEnabled } from '../../../../modules/routing/selectors'
+import {
+  getOnlySmart,
+  hasFiltersEnabled
+} from '../../../../modules/routing/selectors'
 import { getCount } from '../../../../modules/ui/browse/selectors'
 import {
   getSection,
@@ -32,6 +35,7 @@ const mapState = (state: RootState): MapStateProps => ({
   sortBy: getSortBy(state),
   search: getSearch(state),
   onlyOnSale: getOnlyOnSale(state),
+  onlySmart: getOnlySmart(state),
   isMap: getIsMap(state),
   wearableRarities: getWearableRarities(state),
   wearableGenders: getWearableGenders(state),

--- a/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.tsx
+++ b/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.tsx
@@ -32,6 +32,7 @@ const NFTFilters = (props: Props) => {
     search,
     count,
     onlyOnSale,
+    onlySmart,
     isMap,
     wearableRarities,
     wearableGenders,
@@ -85,6 +86,11 @@ const NFTFilters = (props: Props) => {
   if (contracts.length > 0) {
     appliedFilters.push(t('nft_filters.collection'))
   }
+
+  const handleToggleOnlySmart = useCallback(
+    (newOnlySmart: boolean) => onBrowse({ onlySmart: newOnlySmart }),
+    [onBrowse]
+  )
 
   const handleOnlyOnSaleChange = useCallback(
     (_, props: CheckboxProps) => {
@@ -286,10 +292,12 @@ const NFTFilters = (props: Props) => {
             selectedCollection={contracts[0]}
             selectedRarities={wearableRarities}
             selectedGenders={wearableGenders}
+            isOnlySmart={!!onlySmart}
             onCollectionsChange={handleCollectionsChange}
             onGendersChange={handleGendersChange}
             onRaritiesChange={handleRaritiesChange}
             onNetworkChange={handleNetworkChange}
+            onOnlySmartChange={handleToggleOnlySmart}
           />
         </Responsive>
       ) : null}
@@ -330,10 +338,12 @@ const NFTFilters = (props: Props) => {
                 selectedCollection={contracts[0]}
                 selectedRarities={wearableRarities}
                 selectedGenders={wearableGenders}
+                isOnlySmart={!!onlySmart}
                 onCollectionsChange={handleCollectionsChange}
                 onGendersChange={handleGendersChange}
                 onRaritiesChange={handleRaritiesChange}
                 onNetworkChange={handleNetworkChange}
+                onOnlySmartChange={handleToggleOnlySmart}
               />
             </>
           ) : null}

--- a/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.types.ts
+++ b/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.types.ts
@@ -16,6 +16,7 @@ export type Props = {
   sortBy?: SortBy
   search: string
   onlyOnSale?: boolean
+  onlySmart?: boolean
   isMap?: boolean
   wearableRarities: Rarity[]
   wearableGenders: WearableGender[]
@@ -34,6 +35,7 @@ export type MapStateProps = Pick<
   | 'sortBy'
   | 'search'
   | 'onlyOnSale'
+  | 'onlySmart'
   | 'isMap'
   | 'wearableRarities'
   | 'wearableGenders'

--- a/webapp/src/modules/routing/sagas.ts
+++ b/webapp/src/modules/routing/sagas.ts
@@ -31,7 +31,8 @@ import {
   getNetwork,
   getAssetType,
   getVendor,
-  getViewAsGuest
+  getViewAsGuest,
+  getOnlySmart
 } from '../routing/selectors'
 import { getAddress as getWalletAddress } from '../wallet/selectors'
 import { getAddress as getAccountAddress } from '../account/selectors'
@@ -195,7 +196,7 @@ export function* fetchAssetsFromRoute(options: BrowseOptions) {
   const page = options.page!
   const section = options.section!
   const sortBy = options.sortBy!
-  const { search, onlyOnSale, isMap, contracts } = options
+  const { search, onlyOnSale, onlySmart, isMap, contracts } = options
 
   const address = options.address || ((yield getAddress()) as string)
 
@@ -251,6 +252,7 @@ export function* fetchAssetsFromRoute(options: BrowseOptions) {
               wearableCategory,
               isWearableHead,
               isWearableAccessory,
+              isWearableSmart: onlySmart,
               search,
               rarities: wearableRarities,
               contractAddress: contracts && contracts[0],
@@ -297,6 +299,7 @@ export function* getCurrentBrowseOptions(): Generator<
     sortBy: yield select(getSortBy),
     search: yield select(getSearch),
     onlyOnSale: yield select(getOnlyOnSale),
+    onlySmart: yield select(getOnlySmart),
     isMap: yield select(getIsMap),
     isFullscreen: yield select(getIsFullscreen),
     wearableRarities: yield select(getWearableRarities),
@@ -452,6 +455,7 @@ function* deriveCurrentOptions(
           search: yield select(getSearch),
           network: yield select(getNetwork),
           contracts: yield select(getContracts),
+          onlySmart: yield select(getOnlySmart),
           ...newOptions
         }
       }

--- a/webapp/src/modules/routing/search.ts
+++ b/webapp/src/modules/routing/search.ts
@@ -84,6 +84,10 @@ export function getSearchParams(options?: BrowseOptions) {
     if (options.viewAsGuest !== undefined) {
       params.set('viewAsGuest', options.viewAsGuest.toString())
     }
+
+    if (options.onlySmart !== undefined) {
+      params.set('onlySmart', options.onlySmart.toString())
+    }
   }
   return params
 }

--- a/webapp/src/modules/routing/selectors.ts
+++ b/webapp/src/modules/routing/selectors.ts
@@ -216,6 +216,10 @@ export const getViewAsGuest = createSelector<RootState, string, boolean>(
   getRouterSearch,
   search => getURLParam(search, 'viewAsGuest') === 'true'
 )
+export const getOnlySmart = createSelector<RootState, string, boolean>(
+  getRouterSearch,
+  search => getURLParam(search, 'onlySmart') === 'true'
+)
 
 export const hasFiltersEnabled = createSelector<
   RootState,

--- a/webapp/src/modules/routing/types.ts
+++ b/webapp/src/modules/routing/types.ts
@@ -29,6 +29,7 @@ export type BrowseOptions = {
   section?: string
   sortBy?: SortBy
   onlyOnSale?: boolean
+  onlySmart?: boolean
   isMap?: boolean
   isFullscreen?: boolean
   wearableRarities?: Rarity[]

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -187,7 +187,8 @@
     "collection": "Collection",
     "all_collections": "All Collections",
     "network": "Network",
-    "all_networks": "All Networks"
+    "all_networks": "All Networks",
+    "smart_wearables": "Smart Wearables"
   },
   "nft_card": {
     "expires_at": "Expires {date}"
@@ -306,7 +307,9 @@
       "tiara": "Tiara",
       "top_head": "Top Head",
       "upper_body": "Upper Body"
-    }
+    },
+    "smart": "Smart Wearable",
+    "smart_badge": "Smart"
   },
   "sell_page": {
     "title": "List for sale",

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -185,7 +185,8 @@
     "collection": "Colección",
     "all_collections": "Todas las colecciones",
     "network": "Red",
-    "all_networks": "Todas las redes"
+    "all_networks": "Todas las redes",
+    "smart_wearables": "Vestimentas Interactivas"
   },
   "nft_card": {
     "expires_at": "Expira {date}"
@@ -304,7 +305,9 @@
       "tiara": "Tiara",
       "top_head": "Cabeza",
       "upper_body": "Torso"
-    }
+    },
+    "smart": "Vestimenta Interactiva",
+    "smart_badge": "Interactivo"
   },
   "sell_page": {
     "title": "Poner en venta",

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -185,7 +185,8 @@
     "collection": "珍藏",
     "all_collections": "所有珍藏",
     "network": "网络",
-    "all_networks": "所有网络"
+    "all_networks": "所有网络",
+    "smart_wearables": "智能穿戴"
   },
   "nft_card": {
     "expires_at": "{date}到期"
@@ -304,7 +305,9 @@
       "tiara": "头饰",
       "top_head": "头顶",
       "upper_body": "上半身"
-    }
+    },
+    "smart": "智能穿戴",
+    "smart_badge": "聪明的"
   },
   "sell_page": {
     "title": "待售列表",

--- a/webapp/src/modules/vendor/decentraland/item/api.ts
+++ b/webapp/src/modules/vendor/decentraland/item/api.ts
@@ -69,6 +69,10 @@ class ItemAPI extends BaseAPI {
       queryParams.append('isWearableAccessory', 'true')
     }
 
+    if (filters.isWearableSmart) {
+      queryParams.append('isWearableSmart', 'true')
+    }
+
     if (filters.wearableCategory) {
       queryParams.append('wearableCategory', filters.wearableCategory)
     }

--- a/webapp/src/modules/vendor/decentraland/item/types.ts
+++ b/webapp/src/modules/vendor/decentraland/item/types.ts
@@ -17,6 +17,7 @@ export type ItemFilters = {
   search?: string
   isWearableHead?: boolean
   isWearableAccessory?: boolean
+  isWearableSmart?: boolean
   wearableCategory?: WearableCategory
   rarities?: Rarity[]
   wearableGenders?: WearableGender[]

--- a/webapp/src/modules/vendor/decentraland/nft/api.ts
+++ b/webapp/src/modules/vendor/decentraland/nft/api.ts
@@ -98,6 +98,9 @@ class NFTAPI extends BaseAPI {
       if (filters.isWearableAccessory) {
         queryParams.append('isWearableAccessory', 'true')
       }
+      if (filters.isWearableSmart) {
+        queryParams.append('isWearableSmart', 'true')
+      }
       if (filters.wearableCategory) {
         queryParams.append('wearableCategory', filters.wearableCategory)
       }

--- a/webapp/src/modules/vendor/decentraland/nft/types.ts
+++ b/webapp/src/modules/vendor/decentraland/nft/types.ts
@@ -13,6 +13,7 @@ export type NFTsFetchFilters = {
   isLand?: boolean
   isWearableHead?: boolean
   isWearableAccessory?: boolean
+  isWearableSmart?: boolean
   wearableCategory?: WearableCategory
   wearableRarities?: Rarity[]
   wearableGenders?: WearableGender[]

--- a/webapp/src/modules/vendor/utils.ts
+++ b/webapp/src/modules/vendor/utils.ts
@@ -29,12 +29,19 @@ export function getFilters(
           ? getSearchWearableCategory(section!)
           : undefined
 
-      const { wearableRarities, wearableGenders, contracts, network } = options
+      const {
+        wearableRarities,
+        wearableGenders,
+        contracts,
+        network,
+        onlySmart
+      } = options
 
       return {
         isLand,
         isWearableHead,
         isWearableAccessory,
+        isWearableSmart: onlySmart,
         wearableCategory,
         wearableRarities,
         wearableGenders,


### PR DESCRIPTION
This PR:

+ Adds a Smart Wearable badge to `AssetCard`
+ Adds a Smart Wearable badge to `ItemDetailPage` and `NFTDetailPage`
+ Adds a Smart Wearable filter to the `AssetBrowse` component, to filter for only wearables that are smart.
+ The filter is also supported in mobile, where it's shown as a `Radio` to keep it consistent with the "On Sale" one.


<img width="1180" alt="Screen Shot 2022-01-18 at 13 54 32" src="https://user-images.githubusercontent.com/2781777/149982511-be566a2a-f0a7-4a1d-a787-ecd92c7524a1.png">

<img width="449" alt="Screen Shot 2022-01-18 at 13 54 42" src="https://user-images.githubusercontent.com/2781777/149982553-e18fddde-4306-4f6e-be6a-22461d21e4bb.png">

<img width="593" alt="Screen Shot 2022-01-18 at 13 54 58" src="https://user-images.githubusercontent.com/2781777/149982570-692ee139-7a51-4772-9bd8-f6bd5f4f6e93.png">

