### PR TITLE
fix: Profiles not loading

### DIFF
--- a/webapp/src/modules/store/sagas.ts
+++ b/webapp/src/modules/store/sagas.ts
@@ -1,4 +1,4 @@
-import { call, put, select, takeEvery, takeLatest } from 'redux-saga/effects'
+import { call, put, select, takeEvery } from 'redux-saga/effects'
 import { LocationChangeAction, LOCATION_CHANGE } from 'connected-react-router'
 import { getAddress } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { AuthIdentity } from 'dcl-crypto'
@@ -24,8 +24,8 @@ import {
 import { getIsLocalStoreDirty } from './selectors'
 
 export function* storeSaga(client: CatalystClient) {
-  yield takeLatest(FETCH_STORE_REQUEST, handleFetchStoreRequest)
-  yield takeLatest(UPDATE_STORE_REQUEST, handleUpdateStoreRequest)
+  yield takeEvery(FETCH_STORE_REQUEST, handleFetchStoreRequest)
+  yield takeEvery(UPDATE_STORE_REQUEST, handleUpdateStoreRequest)
   yield takeEvery(LOCATION_CHANGE, handleLocationChange)
 
   function* handleLocationChange({


### PR DESCRIPTION
Closes #573 

This was due to the `takeLatest` effect being used to handle the action. As two fetches are being dispatched, only the latest is considered so 2 REQUESTS are in the loading store but only one is removed at the end because only one SUCCESS or FAILURE is called.

Happened arbitrarily, not only when the user was not connected.