### PR TITLE
feat: change button for link in pagination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "marketplace",
       "version": "2.7.0"
     }
   }

--- a/webapp/src/components/AssetList/AssetList.container.ts
+++ b/webapp/src/components/AssetList/AssetList.container.ts
@@ -17,19 +17,26 @@ import { MapStateProps, MapDispatch, MapDispatchProps } from './AssetList.types'
 import AssetList from './AssetList'
 import { FETCH_ITEMS_REQUEST } from '../../modules/item/actions'
 import { buildBrowseURL } from '../../modules/routing/utils'
+import { getLocation } from 'connected-react-router'
 
-const mapState = (state: RootState): MapStateProps => ({
-  vendor: getVendor(state),
-  assetType: getAssetType(state),
-  nfts: getNFTs(state),
-  items: getItems(state),
-  page: getPage(state),
-  count: getCount(state),
-  isLoading:
-    isLoadingType(getLoadingNFTs(state), FETCH_NFTS_REQUEST) ||
-    isLoadingType(getLoadingItems(state), FETCH_ITEMS_REQUEST),
-  urlNext: buildBrowseURL(state.router.location.pathname, { ...getCurrentBrowseOptions(state), page: (getPage(state) + 1)})  
-})
+const mapState = (state: RootState): MapStateProps => {
+  const page = getPage(state)
+  return ({
+    vendor: getVendor(state),
+    assetType: getAssetType(state),
+    nfts: getNFTs(state),
+    items: getItems(state),
+    page: page,
+    count: getCount(state),
+    isLoading:
+      isLoadingType(getLoadingNFTs(state), FETCH_NFTS_REQUEST) ||
+      isLoadingType(getLoadingItems(state), FETCH_ITEMS_REQUEST),
+    urlNext: buildBrowseURL(
+      getLocation(state).pathname, 
+      { ...getCurrentBrowseOptions(state), page: (page + 1)}
+    )  
+  })
+}
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
   onBrowse: options => dispatch(browse(options))

--- a/webapp/src/components/AssetList/AssetList.container.ts
+++ b/webapp/src/components/AssetList/AssetList.container.ts
@@ -8,13 +8,15 @@ import { getNFTs, getCount, getItems } from '../../modules/ui/browse/selectors'
 import {
   getVendor,
   getPage,
-  getAssetType
+  getAssetType,
+  getCurrentBrowseOptions
 } from '../../modules/routing/selectors'
 import { getLoading as getLoadingNFTs } from '../../modules/nft/selectors'
 import { getLoading as getLoadingItems } from '../../modules/item/selectors'
 import { MapStateProps, MapDispatch, MapDispatchProps } from './AssetList.types'
 import AssetList from './AssetList'
 import { FETCH_ITEMS_REQUEST } from '../../modules/item/actions'
+import { buildBrowseURL } from '../../modules/routing/utils'
 
 const mapState = (state: RootState): MapStateProps => ({
   vendor: getVendor(state),
@@ -25,7 +27,8 @@ const mapState = (state: RootState): MapStateProps => ({
   count: getCount(state),
   isLoading:
     isLoadingType(getLoadingNFTs(state), FETCH_NFTS_REQUEST) ||
-    isLoadingType(getLoadingItems(state), FETCH_ITEMS_REQUEST)
+    isLoadingType(getLoadingItems(state), FETCH_ITEMS_REQUEST),
+  urlNext: buildBrowseURL(state.router.location.pathname, { ...getCurrentBrowseOptions(state), page: (getPage(state) + 1)})  
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({

--- a/webapp/src/components/AssetList/AssetList.tsx
+++ b/webapp/src/components/AssetList/AssetList.tsx
@@ -19,12 +19,14 @@ const AssetList = (props: Props) => {
     page,
     count,
     isLoading,
-    onBrowse
+    onBrowse,
+    urlNext
   } = props
 
   const assets: (NFT | Item)[] = assetType === AssetType.ITEM ? items : nfts
 
-  const handleLoadMore = useCallback(() => {
+  const handleLoadMore = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
     const newPage = page + 1
     onBrowse({ page: newPage })
     getAnalytics().track('Load more', { page: newPage })
@@ -65,7 +67,14 @@ const AssetList = (props: Props) => {
       hasExtraPages &&
       (!isLoading || isLoadingNewPage) ? (
         <div className="load-more">
-          <Button loading={isLoading} inverted primary onClick={handleLoadMore}>
+          <Button 
+            as="a" 
+            href={urlNext} 
+            loading={isLoading} 
+            inverted
+            primary
+            onClick={handleLoadMore}
+          >
             {t('global.load_more')}
           </Button>
         </div>

--- a/webapp/src/components/AssetList/AssetList.types.ts
+++ b/webapp/src/components/AssetList/AssetList.types.ts
@@ -14,12 +14,13 @@ export type Props = {
   page: number
   count?: number
   isLoading: boolean
-  onBrowse: typeof browse
+  onBrowse: typeof browse,
+  urlNext: string
 }
 
 export type MapStateProps = Pick<
   Props,
-  'vendor' | 'nfts' | 'items' | 'page' | 'count' | 'isLoading' | 'assetType'
+  'vendor' | 'nfts' | 'items' | 'page' | 'count' | 'isLoading' | 'assetType' | 'urlNext'
 >
 export type MapDispatchProps = Pick<Props, 'onBrowse'>
 export type MapDispatch = Dispatch<BrowseAction>

--- a/webapp/src/modules/routing/sagas.spec.ts
+++ b/webapp/src/modules/routing/sagas.spec.ts
@@ -8,12 +8,12 @@ import { View } from '../ui/types'
 import { VendorName } from '../vendor'
 import { clearFilters } from './actions'
 import {
-  buildBrowseURL,
   fetchAssetsFromRoute,
-  getCurrentBrowseOptions,
   routingSaga
 } from './sagas'
+import { getCurrentBrowseOptions } from './selectors'
 import { BrowseOptions, SortBy } from './types'
+import { buildBrowseURL } from './utils'
 
 beforeEach(() => {
   jest.spyOn(Date, 'now').mockReturnValue(100)
@@ -54,7 +54,7 @@ describe('when handling the clear filters request action', () => {
 
     return expectSaga(routingSaga)
       .provide([
-        [call(getCurrentBrowseOptions), browseOptions],
+        [select(getCurrentBrowseOptions), browseOptions],
         [select(getLocation), { pathname }],
         [
           call(fetchAssetsFromRoute, browseOptionsWithoutFilters),

--- a/webapp/src/modules/routing/selectors.ts
+++ b/webapp/src/modules/routing/selectors.ts
@@ -17,9 +17,11 @@ import {
   getURLParamArray,
   getURLParam
 } from './search'
-import { SortBy } from './types'
+import { BrowseOptions, SortBy } from './types'
 import { locations } from './locations'
 import { AssetType } from '../asset/types'
+import { getAddress as getWalletAddress } from '../wallet/selectors'
+import { getAddress as getAccountAddress } from '../account/selectors'
 
 export const getState = (state: RootState) => state.routing
 
@@ -246,3 +248,95 @@ export const hasFiltersEnabled = createSelector<
     )
   }
 )
+
+export const getCurrentLocationAddress = createSelector<
+  RootState,
+  string,
+  string | undefined,
+  string | undefined,
+  string | undefined
+>(
+  getPathName,
+  getWalletAddress,
+  getAccountAddress,
+  (pathname, walletAddess, accountAddress) => {
+    let address: string | undefined
+
+    if (pathname === locations.currentAccount()) {
+      address = walletAddess
+    } else {
+      address = accountAddress
+    }
+
+    return address ? address.toLowerCase() : undefined
+  }
+)
+
+export const getPaginationUrlParams = createSelector (
+  getPage,
+  getSortBy,
+  getSearch,
+  (page, sortBy, search) => ({page, sortBy, search})
+)
+
+export const getAssetsUrlParams = createSelector(
+  getOnlyOnSale,
+  getOnlySmart,
+  getIsSoldOut,
+  getItemId,
+  getContracts,
+  (onlyOnSale, onlySmart, isSoldOut, itemId, contracts) => ({
+    onlyOnSale, onlySmart, isSoldOut, itemId, contracts
+  })
+)
+
+export const getLandsUrlParams = createSelector (
+  getIsMap,
+  getIsFullscreen,
+  (isMap, isFullscreen) => ({ isMap, isFullscreen })
+)
+
+export const getWearablesUrlParams = createSelector (
+  getRarities,
+  getWearableGenders,
+  getView,
+  getViewAsGuest,
+  (
+    rarities, wearableGenders, view, viewAsGuest
+  ) => ({
+    rarities, wearableGenders, view, viewAsGuest
+  })
+)
+
+export const getCurrentBrowseOptions = createSelector (
+  getAssetType,
+  getCurrentLocationAddress,
+  getVendor,
+  getSection,
+  getNetwork,
+  getPaginationUrlParams,
+  getAssetsUrlParams,
+  getLandsUrlParams,
+  getWearablesUrlParams,
+  (
+    assetType,
+    address,
+    vendor,
+    section,
+    network,
+    paginationUrlParams,
+    AssetsUrlParams,
+    landsUrlParams,
+    wearablesUrlParams
+) => ({
+    assetType,
+    address,
+    vendor,
+    section,
+    network,
+    ...AssetsUrlParams,
+    ...paginationUrlParams,
+    ...landsUrlParams,
+    ...wearablesUrlParams
+  } as BrowseOptions
+))

--- a/webapp/src/modules/routing/utils.ts
+++ b/webapp/src/modules/routing/utils.ts
@@ -1,2 +1,21 @@
+import { BrowseOptions } from './types'
+import { Section } from '../vendor/decentraland'
+import { getSearchParams } from './search'
+
 export const COLLECTIONS_PER_PAGE = 6
 export const SALES_PER_PAGE = 6
+
+export function buildBrowseURL(
+  pathname: string,
+  browseOptions: BrowseOptions
+): string {
+  let params: URLSearchParams | undefined
+
+  if (browseOptions.section === Section.ON_SALE) {
+    params = getSearchParams({ section: Section.ON_SALE })
+  } else {
+    params = getSearchParams(browseOptions)
+  }
+
+  return params ? `${pathname}?${params.toString()}` : pathname
+}


### PR DESCRIPTION
In order to perform this task, we took out three saga (buildBrowseURL, getCurrentBrowseOptions, getAddress) and put them in utils (buildBrowseURL) and the rest in selectors. 
As part of the process we created selectors that group other selectors, mainly the ones that get parameters from the url (getPaginationUrlParams, getAssetsUrlParams, getLandsUrlParams, getWearablesUrlParams), so we can use them in the getCurrentBrowseOptions selector.
Once this process was finished, the sagas that use these new selectors were updated.
Then we added in the AssetList.container.ts file the urlNext property to send the url to use in the href of the anchor tag.
