### PR TITLE
fix: use PUBLIC_URL so json can be fetched from CDN once it is deployed

### DIFF
--- a/webapp/src/modules/proximity/sagas.ts
+++ b/webapp/src/modules/proximity/sagas.ts
@@ -17,7 +17,7 @@ export function* proximitySaga() {
 function* handleFetchProximityRequest(_action: FetchProximityRequestAction) {
   try {
     const proximity: Record<string, Proximity> = yield call(async () => {
-      const resp = await fetch('/proximity.json')
+      const resp = await fetch(process.env.PUBLIC_URL + '/proximity.json')
       return resp.json()
     })
     yield put(fetchProximitySuccess(proximity))


### PR DESCRIPTION
This was broken after switching deployments to rollouts