### PR TITLE
fix: Parcel details is broken without rental contract

### DIFF
--- a/webapp/src/components/AssetPage/ParcelDetail/ParcelDetail.tsx
+++ b/webapp/src/components/AssetPage/ParcelDetail/ParcelDetail.tsx
@@ -78,15 +78,17 @@ const ParcelDetail = ({ nft, isRentalsEnabled }: Props) => {
           <BidList nft={nft} />
           <TransactionHistory asset={nft} />
           {isRentalsEnabled ? (
-            <Button onClick={() => setShowCreateRentalModal(true)}>
-              Create Rental
-            </Button>
+            <>
+              <Button onClick={() => setShowCreateRentalModal(true)}>
+                Create Rental
+              </Button>
+              <CreateRentalModal
+                nft={nft}
+                open={showCreateRentalModal}
+                onCancel={() => setShowCreateRentalModal(false)}
+              />
+            </>
           ) : null}
-          <CreateRentalModal
-            nft={nft}
-            open={showCreateRentalModal}
-            onCancel={() => setShowCreateRentalModal(false)}
-          />
         </>
       }
     />


### PR DESCRIPTION
This PR fixes an issue where the `ParcelDetail` view was broken due to it being unable to load the rentals contract for the ethereum mainnet.