### PR TITLE
fix: Add browse tests

### DIFF
--- a/webapp/src/modules/routing/sagas.spec.ts
+++ b/webapp/src/modules/routing/sagas.spec.ts
@@ -9,6 +9,7 @@ import { View } from '../ui/types'
 import { VendorName } from '../vendor'
 import { Section } from '../vendor/decentraland'
 import {
+  browse,
   clearFilters,
   fetchAssetsFromRoute as FetchAssetsFromRouteAction
 } from './actions'
@@ -82,5 +83,602 @@ describe('when handling the fetchAssetsFromRoute request action', () => {
       .put(fetchTrendingItemsRequest())
       .dispatch(FetchAssetsFromRouteAction(browseOptions))
       .run({ silenceTimeout: true })
+  })
+})
+
+describe('when handling the browse action', () => {
+  let browseOptions: BrowseOptions
+  let newBrowseOptions: BrowseOptions
+  let expectedBrowseOptions: BrowseOptions
+  let pathname: string
+
+  beforeEach(() => {
+    pathname = 'aPathName'
+    browseOptions = {
+      onlyOnSale: undefined,
+      sortBy: undefined,
+      page: 1,
+      onlyOnRent: undefined,
+      isMap: undefined,
+      isFullscreen: undefined,
+      viewAsGuest: undefined,
+      assetType: AssetType.NFT,
+      section: Section.LAND,
+      view: undefined,
+      vendor: VendorName.DECENTRALAND
+    }
+    newBrowseOptions = {}
+  })
+
+  describe('and the onlyOnRent filter is to be set', () => {
+    beforeEach(() => {
+      newBrowseOptions.onlyOnRent = true
+    })
+
+    describe('and the browse action has a new non rental sort to be set', () => {
+      beforeEach(() => {
+        newBrowseOptions.sortBy = undefined
+      })
+
+      describe('and no previous sort is set', () => {
+        beforeEach(() => {
+          browseOptions.sortBy = undefined
+          expectedBrowseOptions = {
+            ...browseOptions,
+            ...newBrowseOptions,
+            sortBy: undefined
+          }
+        })
+
+        it('should fetch the assets and put the new url using with the sortBy option as undefined', () => {
+          return expectSaga(routingSaga)
+            .provide([
+              [select(getCurrentBrowseOptions), browseOptions],
+              [select(getLocation), { pathname }],
+              [
+                call(fetchAssetsFromRoute, expectedBrowseOptions),
+                Promise.resolve()
+              ]
+            ])
+            .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+            .dispatch(browse(newBrowseOptions))
+            .run({ silenceTimeout: true })
+        })
+      })
+
+      describe('and a previous sort is set', () => {
+        beforeEach(() => {
+          browseOptions.sortBy = SortBy.NEWEST
+          expectedBrowseOptions = {
+            ...browseOptions,
+            ...newBrowseOptions,
+            sortBy: undefined
+          }
+        })
+
+        it('should fetch the assets and put the new url using with the sortBy option as undefined', () => {
+          return expectSaga(routingSaga)
+            .provide([
+              [select(getCurrentBrowseOptions), browseOptions],
+              [select(getLocation), { pathname }],
+              [
+                call(fetchAssetsFromRoute, expectedBrowseOptions),
+                Promise.resolve()
+              ]
+            ])
+            .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+            .dispatch(browse(newBrowseOptions))
+            .run({ silenceTimeout: true })
+        })
+      })
+    })
+
+    describe('and the browse action has a new rental sort', () => {
+      beforeEach(() => {
+        newBrowseOptions.sortBy = SortBy.RENTAL_LISTING_DATE
+        expectedBrowseOptions = {
+          ...browseOptions,
+          ...newBrowseOptions
+        }
+      })
+
+      it('should fetch the assets and put the new url using with the sortBy option as the new rental sort', () => {
+        return expectSaga(routingSaga)
+          .provide([
+            [select(getCurrentBrowseOptions), browseOptions],
+            [select(getLocation), { pathname }],
+            [
+              call(fetchAssetsFromRoute, expectedBrowseOptions),
+              Promise.resolve()
+            ]
+          ])
+          .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+          .dispatch(browse(newBrowseOptions))
+          .run({ silenceTimeout: true })
+      })
+    })
+
+    describe('and the browse action has a previous non rental sort', () => {
+      beforeEach(() => {
+        browseOptions.sortBy = SortBy.RECENTLY_SOLD
+        expectedBrowseOptions = {
+          ...browseOptions,
+          ...newBrowseOptions,
+          sortBy: undefined
+        }
+      })
+
+      it('should fetch the assets and put the new url using with the sortBy option as undefined', () => {
+        return expectSaga(routingSaga)
+          .provide([
+            [select(getCurrentBrowseOptions), browseOptions],
+            [select(getLocation), { pathname }],
+            [
+              call(fetchAssetsFromRoute, expectedBrowseOptions),
+              Promise.resolve()
+            ]
+          ])
+          .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+          .dispatch(browse(newBrowseOptions))
+          .run({ silenceTimeout: true })
+      })
+    })
+  })
+
+  describe('and the onlyOnRent filter is already set', () => {
+    beforeEach(() => {
+      browseOptions.onlyOnRent = true
+    })
+
+    describe('and the browse action has a new non rental sort to be set', () => {
+      beforeEach(() => {
+        newBrowseOptions.sortBy = SortBy.CHEAPEST
+      })
+
+      describe('and no previous sort is set', () => {
+        beforeEach(() => {
+          browseOptions.sortBy = undefined
+          expectedBrowseOptions = {
+            ...browseOptions,
+            ...newBrowseOptions,
+            sortBy: undefined
+          }
+        })
+
+        it('should fetch the assets and put the new url using with the sortBy option as undefined', () => {
+          return expectSaga(routingSaga)
+            .provide([
+              [select(getCurrentBrowseOptions), browseOptions],
+              [select(getLocation), { pathname }],
+              [
+                call(fetchAssetsFromRoute, expectedBrowseOptions),
+                Promise.resolve()
+              ]
+            ])
+            .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+            .dispatch(browse(newBrowseOptions))
+            .run({ silenceTimeout: true })
+        })
+      })
+
+      describe('and a previous sort is set', () => {
+        beforeEach(() => {
+          browseOptions.sortBy = SortBy.NEWEST
+          expectedBrowseOptions = {
+            ...browseOptions,
+            ...newBrowseOptions,
+            sortBy: undefined
+          }
+        })
+
+        it('should fetch the assets and put the new url using with the sortBy option as undefined', () => {
+          return expectSaga(routingSaga)
+            .provide([
+              [select(getCurrentBrowseOptions), browseOptions],
+              [select(getLocation), { pathname }],
+              [
+                call(fetchAssetsFromRoute, expectedBrowseOptions),
+                Promise.resolve()
+              ]
+            ])
+            .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+            .dispatch(browse(newBrowseOptions))
+            .run({ silenceTimeout: true })
+        })
+      })
+    })
+
+    describe('and the browse action does not have a new sort to be set', () => {
+      beforeEach(() => {
+        newBrowseOptions.sortBy = undefined
+      })
+
+      describe('and the previous sort is not set', () => {
+        beforeEach(() => {
+          browseOptions.sortBy = undefined
+          expectedBrowseOptions = {
+            ...browseOptions,
+            ...newBrowseOptions,
+            sortBy: undefined
+          }
+        })
+
+        it('should fetch the assets and put the new url using with the sortBy option as undefined', () => {
+          return expectSaga(routingSaga)
+            .provide([
+              [select(getCurrentBrowseOptions), browseOptions],
+              [select(getLocation), { pathname }],
+              [
+                call(fetchAssetsFromRoute, expectedBrowseOptions),
+                Promise.resolve()
+              ]
+            ])
+            .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+            .dispatch(browse(newBrowseOptions))
+            .run({ silenceTimeout: true })
+        })
+      })
+
+      describe('and the previous sort is set to a non rental sort', () => {
+        beforeEach(() => {
+          browseOptions.sortBy = SortBy.CHEAPEST
+          expectedBrowseOptions = {
+            ...browseOptions,
+            ...newBrowseOptions
+          }
+        })
+
+        it('should fetch the assets and put the new url using with the sortBy option as the previous one', () => {
+          return expectSaga(routingSaga)
+            .provide([
+              [select(getCurrentBrowseOptions), browseOptions],
+              [select(getLocation), { pathname }],
+              [
+                call(fetchAssetsFromRoute, expectedBrowseOptions),
+                Promise.resolve()
+              ]
+            ])
+            .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+            .dispatch(browse(newBrowseOptions))
+            .run({ silenceTimeout: true })
+        })
+      })
+
+      describe('and the previous sort is set to a rental sort', () => {
+        beforeEach(() => {
+          browseOptions.sortBy = SortBy.RENTAL_LISTING_DATE
+          expectedBrowseOptions = {
+            ...browseOptions,
+            ...newBrowseOptions
+          }
+        })
+
+        it('should fetch the assets and put the new url using with the sortBy option as the previous one', () => {
+          return expectSaga(routingSaga)
+            .provide([
+              [select(getCurrentBrowseOptions), browseOptions],
+              [select(getLocation), { pathname }],
+              [
+                call(fetchAssetsFromRoute, expectedBrowseOptions),
+                Promise.resolve()
+              ]
+            ])
+            .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+            .dispatch(browse(newBrowseOptions))
+            .run({ silenceTimeout: true })
+        })
+      })
+    })
+
+    describe('and the browse action has a new rental sort to be set', () => {
+      beforeEach(() => {
+        newBrowseOptions.sortBy = SortBy.RENTAL_LISTING_DATE
+        expectedBrowseOptions = {
+          ...browseOptions,
+          ...newBrowseOptions
+        }
+      })
+
+      it('should fetch the assets and put the new url using with the sortBy option as the new rental sort', () => {
+        return expectSaga(routingSaga)
+          .provide([
+            [select(getCurrentBrowseOptions), browseOptions],
+            [select(getLocation), { pathname }],
+            [
+              call(fetchAssetsFromRoute, expectedBrowseOptions),
+              Promise.resolve()
+            ]
+          ])
+          .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+          .dispatch(browse(newBrowseOptions))
+          .run({ silenceTimeout: true })
+      })
+    })
+  })
+
+  describe('and the onlyOnSell filter is to be set', () => {
+    beforeEach(() => {
+      newBrowseOptions.onlyOnSale = true
+    })
+
+    describe('and the browse action has a new non sell sort to be set', () => {
+      beforeEach(() => {
+        newBrowseOptions.sortBy = undefined
+      })
+
+      describe('and no previous sort is set', () => {
+        beforeEach(() => {
+          browseOptions.sortBy = undefined
+          expectedBrowseOptions = {
+            ...browseOptions,
+            ...newBrowseOptions,
+            sortBy: undefined
+          }
+        })
+
+        it('should fetch the assets and put the new url using with the sortBy option as undefined', () => {
+          return expectSaga(routingSaga)
+            .provide([
+              [select(getCurrentBrowseOptions), browseOptions],
+              [select(getLocation), { pathname }],
+              [
+                call(fetchAssetsFromRoute, expectedBrowseOptions),
+                Promise.resolve()
+              ]
+            ])
+            .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+            .dispatch(browse(newBrowseOptions))
+            .run({ silenceTimeout: true })
+        })
+      })
+
+      describe('and a previous sort is set', () => {
+        beforeEach(() => {
+          browseOptions.sortBy = SortBy.NEWEST
+          expectedBrowseOptions = {
+            ...browseOptions,
+            ...newBrowseOptions,
+            sortBy: undefined
+          }
+        })
+
+        it('should fetch the assets and put the new url using with the sortBy option as undefined', () => {
+          return expectSaga(routingSaga)
+            .provide([
+              [select(getCurrentBrowseOptions), browseOptions],
+              [select(getLocation), { pathname }],
+              [
+                call(fetchAssetsFromRoute, expectedBrowseOptions),
+                Promise.resolve()
+              ]
+            ])
+            .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+            .dispatch(browse(newBrowseOptions))
+            .run({ silenceTimeout: true })
+        })
+      })
+    })
+
+    describe('and the browse action has a new sell sort', () => {
+      beforeEach(() => {
+        newBrowseOptions.sortBy = SortBy.RECENTLY_SOLD
+        expectedBrowseOptions = {
+          ...browseOptions,
+          ...newBrowseOptions
+        }
+      })
+
+      it('should fetch the assets and put the new url using with the sortBy option as the new sell sort', () => {
+        return expectSaga(routingSaga)
+          .provide([
+            [select(getCurrentBrowseOptions), browseOptions],
+            [select(getLocation), { pathname }],
+            [
+              call(fetchAssetsFromRoute, expectedBrowseOptions),
+              Promise.resolve()
+            ]
+          ])
+          .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+          .dispatch(browse(newBrowseOptions))
+          .run({ silenceTimeout: true })
+      })
+    })
+
+    describe('and the browse action has a previous non sell sort', () => {
+      beforeEach(() => {
+        browseOptions.sortBy = SortBy.RENTAL_LISTING_DATE
+        expectedBrowseOptions = {
+          ...browseOptions,
+          ...newBrowseOptions,
+          sortBy: undefined
+        }
+      })
+
+      it('should fetch the assets and put the new url using with the sortBy option as undefined', () => {
+        return expectSaga(routingSaga)
+          .provide([
+            [select(getCurrentBrowseOptions), browseOptions],
+            [select(getLocation), { pathname }],
+            [
+              call(fetchAssetsFromRoute, expectedBrowseOptions),
+              Promise.resolve()
+            ]
+          ])
+          .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+          .dispatch(browse(newBrowseOptions))
+          .run({ silenceTimeout: true })
+      })
+    })
+  })
+
+  describe('and the onlyOnSell filter is set', () => {
+    beforeEach(() => {
+      browseOptions.onlyOnSale = true
+    })
+
+    describe('and the browse action has a new non sell sort to be set', () => {
+      beforeEach(() => {
+        newBrowseOptions.sortBy = SortBy.MAX_RENTAL_PRICE
+      })
+
+      describe('and no previous sort is set', () => {
+        beforeEach(() => {
+          browseOptions.sortBy = undefined
+          expectedBrowseOptions = {
+            ...browseOptions,
+            ...newBrowseOptions,
+            sortBy: undefined
+          }
+        })
+
+        it('should fetch the assets and put the new url using with the sortBy option as undefined', () => {
+          return expectSaga(routingSaga)
+            .provide([
+              [select(getCurrentBrowseOptions), browseOptions],
+              [select(getLocation), { pathname }],
+              [
+                call(fetchAssetsFromRoute, expectedBrowseOptions),
+                Promise.resolve()
+              ]
+            ])
+            .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+            .dispatch(browse(newBrowseOptions))
+            .run({ silenceTimeout: true })
+        })
+      })
+
+      describe('and a previous sort is set', () => {
+        beforeEach(() => {
+          browseOptions.sortBy = SortBy.NEWEST
+          expectedBrowseOptions = {
+            ...browseOptions,
+            ...newBrowseOptions,
+            sortBy: undefined
+          }
+        })
+
+        it('should fetch the assets and put the new url using with the sortBy option as undefined', () => {
+          return expectSaga(routingSaga)
+            .provide([
+              [select(getCurrentBrowseOptions), browseOptions],
+              [select(getLocation), { pathname }],
+              [
+                call(fetchAssetsFromRoute, expectedBrowseOptions),
+                Promise.resolve()
+              ]
+            ])
+            .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+            .dispatch(browse(newBrowseOptions))
+            .run({ silenceTimeout: true })
+        })
+      })
+    })
+
+    describe('and the browse action does not have a new sort to be set', () => {
+      beforeEach(() => {
+        newBrowseOptions.sortBy = undefined
+      })
+
+      describe('and the previous sort is not set', () => {
+        beforeEach(() => {
+          browseOptions.sortBy = undefined
+          expectedBrowseOptions = {
+            ...browseOptions,
+            ...newBrowseOptions,
+            sortBy: undefined
+          }
+        })
+
+        it('should fetch the assets and put the new url using with the sortBy option as undefined', () => {
+          return expectSaga(routingSaga)
+            .provide([
+              [select(getCurrentBrowseOptions), browseOptions],
+              [select(getLocation), { pathname }],
+              [
+                call(fetchAssetsFromRoute, expectedBrowseOptions),
+                Promise.resolve()
+              ]
+            ])
+            .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+            .dispatch(browse(newBrowseOptions))
+            .run({ silenceTimeout: true })
+        })
+      })
+
+      describe('and the previous sort is set to a non rental sort', () => {
+        beforeEach(() => {
+          browseOptions.sortBy = SortBy.CHEAPEST
+          expectedBrowseOptions = {
+            ...browseOptions,
+            ...newBrowseOptions
+          }
+        })
+
+        it('should fetch the assets and put the new url using with the sortBy option as the previous one', () => {
+          return expectSaga(routingSaga)
+            .provide([
+              [select(getCurrentBrowseOptions), browseOptions],
+              [select(getLocation), { pathname }],
+              [
+                call(fetchAssetsFromRoute, expectedBrowseOptions),
+                Promise.resolve()
+              ]
+            ])
+            .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+            .dispatch(browse(newBrowseOptions))
+            .run({ silenceTimeout: true })
+        })
+      })
+
+      describe('and the previous sort is set to a rental sort', () => {
+        beforeEach(() => {
+          browseOptions.sortBy = SortBy.RENTAL_LISTING_DATE
+          expectedBrowseOptions = {
+            ...browseOptions,
+            ...newBrowseOptions
+          }
+        })
+
+        it('should fetch the assets and put the new url using with the sortBy option as the previous one', () => {
+          return expectSaga(routingSaga)
+            .provide([
+              [select(getCurrentBrowseOptions), browseOptions],
+              [select(getLocation), { pathname }],
+              [
+                call(fetchAssetsFromRoute, expectedBrowseOptions),
+                Promise.resolve()
+              ]
+            ])
+            .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+            .dispatch(browse(newBrowseOptions))
+            .run({ silenceTimeout: true })
+        })
+      })
+    })
+
+    describe('and the browse action has a new sell sort to be set', () => {
+      beforeEach(() => {
+        newBrowseOptions.sortBy = SortBy.CHEAPEST
+        expectedBrowseOptions = {
+          ...browseOptions,
+          ...newBrowseOptions
+        }
+      })
+
+      it('should fetch the assets and put the new url using with the sortBy option as the new sell sort', () => {
+        return expectSaga(routingSaga)
+          .provide([
+            [select(getCurrentBrowseOptions), browseOptions],
+            [select(getLocation), { pathname }],
+            [
+              call(fetchAssetsFromRoute, expectedBrowseOptions),
+              Promise.resolve()
+            ]
+          ])
+          .put(push(buildBrowseURL(pathname, expectedBrowseOptions)))
+          .dispatch(browse(newBrowseOptions))
+          .run({ silenceTimeout: true })
+      })
+    })
   })
 })

--- a/webapp/src/modules/routing/sagas.ts
+++ b/webapp/src/modules/routing/sagas.ts
@@ -146,9 +146,8 @@ export function* handleBrowse(action: BrowseAction) {
     getNewBrowseOptions,
     action.payload.options
   )
-
   const { pathname }: ReturnType<typeof getLocation> = yield select(getLocation)
-  yield fetchAssetsFromRoute(options)
+  yield call(fetchAssetsFromRoute, options)
   yield put(push(buildBrowseURL(pathname, options)))
 }
 
@@ -414,6 +413,9 @@ function* deriveCurrentOptions(
     onlyOnRent: current.hasOwnProperty('onlyOnRent')
       ? current.onlyOnRent
       : previous.onlyOnRent,
+    onlyOnSale: current.hasOwnProperty('onlyOnSale')
+      ? current.onlyOnSale
+      : previous.onlyOnSale,
     assetType: current.assetType || previous.assetType,
     section: current.section || previous.section
   }


### PR DESCRIPTION
This PR adds tests for the browse sagas when setting the `onlyOnRent` or `onlyOnSell` filters.