### PR TITLE
fix: Asset provider parameters not being used correctly

### DIFF
--- a/webapp/src/components/AssetProviderPage/AssetProviderPage.tsx
+++ b/webapp/src/components/AssetProviderPage/AssetProviderPage.tsx
@@ -22,14 +22,14 @@ const AssetProviderPage = (props: Props) => {
   const { type, isConnecting, children } = props
   return (
     <AssetProvider type={type}>
-      {(asset, order, isAssetLoading) => {
+      {(asset, order, rental, isAssetLoading) => {
         const isLoading = isConnecting || isAssetLoading
 
         return (
           <>
             {isLoading ? <Loading /> : null}
             {!isLoading && !asset ? <NotFound /> : null}
-            {!isLoading && asset ? children(asset, order) : null}
+            {!isLoading && asset ? children(asset, order, rental) : null}
           </>
         )
       }}

--- a/webapp/src/components/AssetProviderPage/AssetProviderPage.types.ts
+++ b/webapp/src/components/AssetProviderPage/AssetProviderPage.types.ts
@@ -1,10 +1,14 @@
-import { Order } from '@dcl/schemas'
+import { Order, RentalListing } from '@dcl/schemas'
 import { Asset, AssetType } from '../../modules/asset/types'
 
 export type Props<T extends AssetType = AssetType> = {
   type: T
   isConnecting: boolean
-  children: (asset: Asset<T>, order: Order | null) => React.ReactNode | null
+  children: (
+    asset: Asset<T>,
+    order: Order | null,
+    rental: RentalListing | null
+  ) => React.ReactNode | null
 }
 
 export type MapStateProps = Pick<Props, 'isConnecting'>

--- a/webapp/src/components/Bid/Bid.tsx
+++ b/webapp/src/components/Bid/Bid.tsx
@@ -53,7 +53,7 @@ const Bid = (props: Props) => {
                 contractAddress={bid.contractAddress}
                 tokenId={bid.tokenId}
               >
-                {(nft, isLoading) => (
+                {(nft, _order, _rental, isLoading) => (
                   <>
                     {!nft && isLoading ? <Loader active /> : null}
                     {nft ? (


### PR DESCRIPTION
This PR fixes the some issues related to how the parameters are passed to the `AssetProvider` children once it gets rendered. After adding the `rental` property, the arguments changed positions, breaking some components.