### PR TITLE
feat: Add emote controls in the try-on screen

### DIFF
--- a/webapp/src/components/AssetImage/AssetImage.container.ts
+++ b/webapp/src/components/AssetImage/AssetImage.container.ts
@@ -5,7 +5,8 @@ import { RootState } from '../../modules/reducer'
 import { getWallet } from '../../modules/wallet/selectors'
 import {
   getIsTryingOn,
-  getIsPlayingEmote
+  getIsPlayingEmote,
+  getWearablePreviewController
 } from '../../modules/ui/preview/selectors'
 import {
   MapStateProps,
@@ -13,7 +14,10 @@ import {
   MapDispatch
 } from './AssetImage.types'
 import AssetImage from './AssetImage'
-import { setIsTryingOn } from '../../modules/ui/preview/actions'
+import {
+  setIsTryingOn,
+  setWearablePreviewController
+} from '../../modules/ui/preview/actions'
 
 const mapState = (state: RootState): MapStateProps => {
   const profiles = getProfiles(state)
@@ -25,13 +29,16 @@ const mapState = (state: RootState): MapStateProps => {
   }
   return {
     avatar,
+    wearableController: getWearablePreviewController(state),
     isTryingOn: getIsTryingOn(state),
     isPlayingEmote: getIsPlayingEmote(state)
   }
 }
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
-  onSetIsTryingOn: value => dispatch(setIsTryingOn(value))
+  onSetIsTryingOn: value => dispatch(setIsTryingOn(value)),
+  onSetWearablePreviewController: controller =>
+    dispatch(setWearablePreviewController(controller))
 })
 
 export default connect(mapState, mapDispatch)(AssetImage)

--- a/webapp/src/components/AssetImage/AssetImage.container.ts
+++ b/webapp/src/components/AssetImage/AssetImage.container.ts
@@ -3,7 +3,10 @@ import { Avatar } from '@dcl/schemas'
 import { connect } from 'react-redux'
 import { RootState } from '../../modules/reducer'
 import { getWallet } from '../../modules/wallet/selectors'
-import { getIsTryingOn } from '../../modules/ui/preview/selectors'
+import {
+  getIsTryingOn,
+  getIsPlayingEmote
+} from '../../modules/ui/preview/selectors'
 import {
   MapStateProps,
   MapDispatchProps,
@@ -22,7 +25,8 @@ const mapState = (state: RootState): MapStateProps => {
   }
   return {
     avatar,
-    isTryingOn: getIsTryingOn(state)
+    isTryingOn: getIsTryingOn(state),
+    isPlayingEmote: getIsPlayingEmote(state)
   }
 }
 

--- a/webapp/src/components/AssetImage/AssetImage.css
+++ b/webapp/src/components/AssetImage/AssetImage.css
@@ -157,6 +157,12 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  margin-bottom: 1px;
+}
+
+.AssetImage .zoom-controls > .ui.button.zoom-control:hover {
+  transform: none;
+  background-color: var(--secondary) !important;
 }
 
 .AssetImage .zoom-controls > .ui.button.zoom-control i.icon {

--- a/webapp/src/components/AssetImage/AssetImage.css
+++ b/webapp/src/components/AssetImage/AssetImage.css
@@ -138,3 +138,40 @@
 .AssetImage .preview-toggle-wrapper .preview-toggle.is-disabled:hover {
   background-color: var(--secondary);
 }
+
+.AssetImage .zoom-controls {
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 12px;
+  left: 12px;
+}
+
+.AssetImage .zoom-controls > .ui.button.zoom-control {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  min-width: unset;
+  background-color: rgba(0, 0, 0, 0.64) !important;
+  border-radius: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.AssetImage .zoom-controls > .ui.button.zoom-control i.icon {
+  margin: 0 !important;
+}
+
+.AssetImage .zoom-controls > .ui.button.zoom-in-control {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  min-width: unset;
+}
+
+.AssetImage .play-emote-control {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+}

--- a/webapp/src/components/AssetImage/AssetImage.tsx
+++ b/webapp/src/components/AssetImage/AssetImage.tsx
@@ -103,7 +103,7 @@ const AssetImage = (props: Props) => {
   }, [isTryingOn, onSetIsTryingOn])
   const handleControlActionChange = useCallback(
     async (action: ControlOptionAction) => {
-      const ZOOM_DELTA = 0.1
+      const ZOOM_DELTA = 0.03
 
       if (wearableController) {
         switch (action) {
@@ -352,6 +352,7 @@ const AssetImage = (props: Props) => {
       const zoomControls = (
         <div className="zoom-controls">
           <Button
+            animated={false}
             className="zoom-control zoom-in-control"
             onClick={() =>
               handleControlActionChange(ControlOptionAction.ZOOM_IN)
@@ -360,6 +361,7 @@ const AssetImage = (props: Props) => {
             <Icon name="plus" />
           </Button>
           <Button
+            animated={false}
             className="zoom-control zoom-out-control"
             onClick={() =>
               handleControlActionChange(ControlOptionAction.ZOOM_OUT)

--- a/webapp/src/components/AssetImage/AssetImage.tsx
+++ b/webapp/src/components/AssetImage/AssetImage.tsx
@@ -1,13 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { LazyImage } from 'react-lazy-images'
 import classNames from 'classnames'
-import {
-  BodyShape,
-  IPreviewController,
-  NFTCategory,
-  PreviewEmote,
-  Rarity
-} from '@dcl/schemas'
+import { BodyShape, NFTCategory, PreviewEmote, Rarity } from '@dcl/schemas'
 import { T, t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
 import {
@@ -69,9 +63,11 @@ const AssetImage = (props: Props) => {
     isSmall,
     showMonospace,
     avatar,
+    wearableController,
     isTryingOn,
     isPlayingEmote,
-    onSetIsTryingOn
+    onSetIsTryingOn,
+    onSetWearablePreviewController
   } = props
   const { parcel, estate, wearable, emote, ens } = asset.data
 
@@ -79,19 +75,15 @@ const AssetImage = (props: Props) => {
     isDraggable
   )
   const [wearablePreviewError, setWearablePreviewError] = useState(false)
-  const [
-    wearableController,
-    setWearableController
-  ] = useState<IPreviewController | null>(null)
   const handleLoad = useCallback(() => {
     setIsLoadingWearablePreview(false)
     setWearablePreviewError(false)
     if (asset.category === NFTCategory.EMOTE && !wearableController) {
-      setWearableController(
-        WearablePreview.createController('try-on-wearable-preview')
+      onSetWearablePreviewController(
+        WearablePreview.createController('wearable-preview')
       )
     }
-  }, [asset.category, wearableController])
+  }, [asset.category, wearableController, onSetWearablePreviewController])
   const handleError = useCallback(error => {
     console.warn(error)
     setWearablePreviewError(true)
@@ -163,6 +155,11 @@ const AssetImage = (props: Props) => {
         mode: isTryingOn ? 'avatar' : 'wearable'
       })
       setIsTracked(true)
+    }
+    return () => {
+      if (asset.category === NFTCategory.EMOTE && wearableController) {
+        onSetWearablePreviewController(null)
+      }
     }
   }, []) // eslint-disable-line
 
@@ -397,7 +394,7 @@ const AssetImage = (props: Props) => {
         wearablePreview = (
           <>
             <WearablePreview
-              id="try-on-wearable-preview"
+              id="wearable-preview"
               contractAddress={asset.contractAddress}
               itemId={itemId}
               tokenId={tokenId}

--- a/webapp/src/components/AssetImage/AssetImage.tsx
+++ b/webapp/src/components/AssetImage/AssetImage.tsx
@@ -372,6 +372,7 @@ const AssetImage = (props: Props) => {
       const playButton = (
         <div className="play-emote-control">
           <Button
+            size="small"
             onClick={() =>
               handleControlActionChange(
                 isPlayingEmote

--- a/webapp/src/components/AssetImage/AssetImage.types.ts
+++ b/webapp/src/components/AssetImage/AssetImage.types.ts
@@ -18,9 +18,20 @@ export type Props = {
   showMonospace?: boolean
   avatar?: Avatar
   isTryingOn: boolean
+  isPlayingEmote?: boolean
   onSetIsTryingOn: typeof setIsTryingOn
 }
 
-export type MapStateProps = Pick<Props, 'avatar' | 'isTryingOn'>
+export enum ControlOptionAction {
+  ZOOM_IN,
+  ZOOM_OUT,
+  PLAY_EMOTE,
+  STOP_EMOTE
+}
+
+export type MapStateProps = Pick<
+  Props,
+  'avatar' | 'isTryingOn' | 'isPlayingEmote'
+>
 export type MapDispatchProps = Pick<Props, 'onSetIsTryingOn'>
 export type MapDispatch = Dispatch<SetIsTryingOnAction>

--- a/webapp/src/components/AssetImage/AssetImage.types.ts
+++ b/webapp/src/components/AssetImage/AssetImage.types.ts
@@ -1,10 +1,12 @@
 import { Dispatch } from 'redux'
-import { Avatar } from '@dcl/schemas'
+import { Avatar, IPreviewController } from '@dcl/schemas'
 import { Item } from '@dcl/schemas'
 import { NFT } from '../../modules/nft/types'
 import {
   setIsTryingOn,
-  SetIsTryingOnAction
+  SetIsTryingOnAction,
+  setWearablePreviewController,
+  SetWearablePreviewControllerAction
 } from '../../modules/ui/preview/actions'
 
 export type Props = {
@@ -17,9 +19,11 @@ export type Props = {
   isSmall?: boolean
   showMonospace?: boolean
   avatar?: Avatar
+  wearableController?: IPreviewController | null
   isTryingOn: boolean
   isPlayingEmote?: boolean
   onSetIsTryingOn: typeof setIsTryingOn
+  onSetWearablePreviewController: typeof setWearablePreviewController
 }
 
 export enum ControlOptionAction {
@@ -31,7 +35,12 @@ export enum ControlOptionAction {
 
 export type MapStateProps = Pick<
   Props,
-  'avatar' | 'isTryingOn' | 'isPlayingEmote'
+  'avatar' | 'wearableController' | 'isTryingOn' | 'isPlayingEmote'
 >
-export type MapDispatchProps = Pick<Props, 'onSetIsTryingOn'>
-export type MapDispatch = Dispatch<SetIsTryingOnAction>
+export type MapDispatchProps = Pick<
+  Props,
+  'onSetIsTryingOn' | 'onSetWearablePreviewController'
+>
+export type MapDispatch = Dispatch<
+  SetIsTryingOnAction | SetWearablePreviewControllerAction
+>

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -459,7 +459,9 @@
       "male": "male",
       "female": "female",
       "message": "This wearable doesn't have a {bodyShape} representation"
-    }
+    },
+    "play_emote": "Play Emote",
+    "stop_emote": "Stop Emote"
   },
   "sell_page": {
     "title": "List for sale",

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -455,7 +455,9 @@
       "male": "hombre",
       "female": "mujer",
       "message": "Esta vestimenta no tiene representación de {bodyShape}"
-    }
+    },
+    "play_emote": "Reproducir Emote",
+    "stop_emote": "Parar Emote"
   },
   "sell_page": {
     "title": "Poner en venta",

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -456,7 +456,9 @@
       "male": "男",
       "female": "女",
       "message": "这个可穿戴设备没有 {bodyShape} 表示"
-    }
+    },
+    "play_emote": "玩表情",
+    "stop_emote": "停止表情"
   },
   "sell_page": {
     "title": "待售列表",

--- a/webapp/src/modules/ui/preview/actions.ts
+++ b/webapp/src/modules/ui/preview/actions.ts
@@ -1,6 +1,19 @@
 import { action } from 'typesafe-actions'
+import { IPreviewController } from '@dcl/schemas'
 
 export const SET_IS_TRYING_ON = 'Set is trying on'
 export const setIsTryingOn = (value: boolean) =>
   action(SET_IS_TRYING_ON, { value })
 export type SetIsTryingOnAction = ReturnType<typeof setIsTryingOn>
+
+export const SET_EMOTE_PLAYING = 'Set emote playing'
+export const SET_WEARABLE_PREVIEW_CONTROLLER = 'Set wearable preview controller'
+export const setEmotePlaying = (isPlayingEmote: boolean) =>
+  action(SET_EMOTE_PLAYING, { isPlayingEmote })
+export const setWearablePreviewController = (
+  controller: IPreviewController | null
+) => action(SET_WEARABLE_PREVIEW_CONTROLLER, { controller })
+export type SetEmotePlayingAction = ReturnType<typeof setEmotePlaying>
+export type SetWearablePreviewControllerAction = ReturnType<
+  typeof setWearablePreviewController
+>

--- a/webapp/src/modules/ui/preview/reducer.spec.ts
+++ b/webapp/src/modules/ui/preview/reducer.spec.ts
@@ -1,0 +1,45 @@
+import { IPreviewController } from '@dcl/schemas'
+import { setWearablePreviewController, setEmotePlaying } from './actions'
+import { previewReducer, INITIAL_STATE, PreviewState } from './reducer'
+
+let state: PreviewState
+
+beforeEach(() => {
+  state = { ...INITIAL_STATE }
+})
+
+describe('when reducing the successful action of setting the wearable preview', () => {
+  const controller = {} as IPreviewController
+
+  it('should return a state with the created wearable preview', () => {
+    expect(
+      previewReducer(state, setWearablePreviewController(controller))
+    ).toEqual({
+      ...INITIAL_STATE,
+      wearablePreviewController: controller
+    })
+  })
+
+  it('should return a state with the unloaded wearable preview', () => {
+    expect(previewReducer(state, setWearablePreviewController(null))).toEqual({
+      ...INITIAL_STATE,
+      wearablePreviewController: null
+    })
+  })
+})
+
+describe('when reducing the successful action of setting the playing emote state', () => {
+  it('should return a state with the setting the playing emote state play', () => {
+    expect(previewReducer(state, setEmotePlaying(true))).toEqual({
+      ...INITIAL_STATE,
+      isPlayingEmote: true
+    })
+  })
+
+  it('should return a state with the setting the playing emote state stop', () => {
+    expect(previewReducer(state, setEmotePlaying(false))).toEqual({
+      ...INITIAL_STATE,
+      isPlayingEmote: false
+    })
+  })
+})

--- a/webapp/src/modules/ui/preview/reducer.spec.ts
+++ b/webapp/src/modules/ui/preview/reducer.spec.ts
@@ -8,7 +8,7 @@ beforeEach(() => {
   state = { ...INITIAL_STATE }
 })
 
-describe('when reducing the successful action of setting the wearable preview', () => {
+describe('when reducing action of setting the wearable preview', () => {
   it('should return a state with the created wearable preview', () => {
     const controller = { scene: {}, emote: {} } as IPreviewController
     expect(
@@ -18,7 +18,9 @@ describe('when reducing the successful action of setting the wearable preview', 
       wearablePreviewController: controller
     })
   })
+})
 
+describe('when reducing action of setting the wearable preview to null', () => {
   it('should return a state with the unloaded wearable preview', () => {
     expect(previewReducer(state, setWearablePreviewController(null))).toEqual({
       ...INITIAL_STATE,
@@ -27,14 +29,16 @@ describe('when reducing the successful action of setting the wearable preview', 
   })
 })
 
-describe('when reducing the successful action of setting the playing emote state', () => {
+describe('when reducing action of setting the playing emote state to true', () => {
   it('should return a state with the playing emote state true', () => {
     expect(previewReducer(state, setEmotePlaying(true))).toEqual({
       ...INITIAL_STATE,
       isPlayingEmote: true
     })
   })
+})
 
+describe('when reducing action of setting the playing emote state to false', () => {
   it('should return a state with the playing emote state false', () => {
     expect(previewReducer(state, setEmotePlaying(false))).toEqual({
       ...INITIAL_STATE,

--- a/webapp/src/modules/ui/preview/reducer.spec.ts
+++ b/webapp/src/modules/ui/preview/reducer.spec.ts
@@ -9,9 +9,8 @@ beforeEach(() => {
 })
 
 describe('when reducing the successful action of setting the wearable preview', () => {
-  const controller = {} as IPreviewController
-
   it('should return a state with the created wearable preview', () => {
+    const controller = { scene: {}, emote: {} } as IPreviewController
     expect(
       previewReducer(state, setWearablePreviewController(controller))
     ).toEqual({
@@ -29,14 +28,14 @@ describe('when reducing the successful action of setting the wearable preview', 
 })
 
 describe('when reducing the successful action of setting the playing emote state', () => {
-  it('should return a state with the setting the playing emote state play', () => {
+  it('should return a state with the playing emote state true', () => {
     expect(previewReducer(state, setEmotePlaying(true))).toEqual({
       ...INITIAL_STATE,
       isPlayingEmote: true
     })
   })
 
-  it('should return a state with the setting the playing emote state stop', () => {
+  it('should return a state with the playing emote state false', () => {
     expect(previewReducer(state, setEmotePlaying(false))).toEqual({
       ...INITIAL_STATE,
       isPlayingEmote: false

--- a/webapp/src/modules/ui/preview/reducer.ts
+++ b/webapp/src/modules/ui/preview/reducer.ts
@@ -14,7 +14,7 @@ export type PreviewState = {
   isPlayingEmote?: boolean
 }
 
-const INITIAL_STATE: PreviewState = {
+export const INITIAL_STATE: PreviewState = {
   isTryingOn: false
 }
 

--- a/webapp/src/modules/ui/preview/reducer.ts
+++ b/webapp/src/modules/ui/preview/reducer.ts
@@ -2,6 +2,7 @@ import { SetIsTryingOnAction, SET_IS_TRYING_ON } from './actions'
 
 export type PreviewState = {
   isTryingOn: boolean
+  isPlayingEmote?: boolean
 }
 
 const INITIAL_STATE: PreviewState = {

--- a/webapp/src/modules/ui/preview/reducer.ts
+++ b/webapp/src/modules/ui/preview/reducer.ts
@@ -1,7 +1,16 @@
-import { SetIsTryingOnAction, SET_IS_TRYING_ON } from './actions'
+import { IPreviewController } from '@dcl/schemas'
+import {
+  SetIsTryingOnAction,
+  SetEmotePlayingAction,
+  SET_EMOTE_PLAYING,
+  SET_IS_TRYING_ON,
+  SET_WEARABLE_PREVIEW_CONTROLLER,
+  SetWearablePreviewControllerAction
+} from './actions'
 
 export type PreviewState = {
   isTryingOn: boolean
+  wearablePreviewController?: IPreviewController | null
   isPlayingEmote?: boolean
 }
 
@@ -9,7 +18,10 @@ const INITIAL_STATE: PreviewState = {
   isTryingOn: false
 }
 
-type PreviewReducerAction = SetIsTryingOnAction
+type PreviewReducerAction =
+  | SetIsTryingOnAction
+  | SetEmotePlayingAction
+  | SetWearablePreviewControllerAction
 
 export function previewReducer(
   state = INITIAL_STATE,
@@ -20,6 +32,18 @@ export function previewReducer(
       return {
         ...state,
         isTryingOn: action.payload.value
+      }
+    }
+    case SET_WEARABLE_PREVIEW_CONTROLLER: {
+      return {
+        ...state,
+        wearablePreviewController: action.payload.controller
+      }
+    }
+    case SET_EMOTE_PLAYING: {
+      return {
+        ...state,
+        isPlayingEmote: action.payload.isPlayingEmote
       }
     }
     default:

--- a/webapp/src/modules/ui/preview/selectors.ts
+++ b/webapp/src/modules/ui/preview/selectors.ts
@@ -2,3 +2,5 @@ import { RootState } from '../../reducer'
 
 export const getState = (state: RootState) => state.ui.preview
 export const getIsTryingOn = (state: RootState) => getState(state).isTryingOn
+export const getIsPlayingEmote = (state: RootState) =>
+  getState(state).isPlayingEmote

--- a/webapp/src/modules/ui/preview/selectors.ts
+++ b/webapp/src/modules/ui/preview/selectors.ts
@@ -4,3 +4,5 @@ export const getState = (state: RootState) => state.ui.preview
 export const getIsTryingOn = (state: RootState) => getState(state).isTryingOn
 export const getIsPlayingEmote = (state: RootState) =>
   getState(state).isPlayingEmote
+export const getWearablePreviewController = (state: RootState) =>
+  getState(state).wearablePreviewController

--- a/webapp/src/modules/ui/sagas.ts
+++ b/webapp/src/modules/ui/sagas.ts
@@ -1,18 +1,95 @@
-import { takeEvery, put, select } from 'redux-saga/effects'
+import { takeEvery, put, select, take } from 'redux-saga/effects'
+import { eventChannel } from 'redux-saga'
+import { IPreviewController, PreviewEmoteEventType } from '@dcl/schemas'
 import {
   CONNECT_WALLET_SUCCESS,
   ConnectWalletSuccessAction
 } from 'decentraland-dapps/dist/modules/wallet/actions'
 import { push, getLocation } from 'connected-react-router'
 import { locations } from '../routing/locations'
+import {
+  setEmotePlaying,
+  SetWearablePreviewControllerAction,
+  SET_WEARABLE_PREVIEW_CONTROLLER
+} from './preview/actions'
 
 export function* uiSaga() {
   yield takeEvery(CONNECT_WALLET_SUCCESS, handleConnectWalletSuccess)
+  yield takeEvery(
+    SET_WEARABLE_PREVIEW_CONTROLLER,
+    handleSetWearablePreviewController
+  )
 }
 
 function* handleConnectWalletSuccess(_action: ConnectWalletSuccessAction) {
   const location: ReturnType<typeof getLocation> = yield select(getLocation)
   if (location.pathname === locations.signIn()) {
     yield put(push(locations.defaultCurrentAccount()))
+  }
+}
+
+function createWearablePreviewChannel(controller: IPreviewController) {
+  return eventChannel(emit => {
+    const eventEmit = (type: string) => {
+      emit(type)
+    }
+
+    const handleEvent = (type: string) => {
+      return controller.emote.events.on(type, () => eventEmit(type))
+    }
+
+    handleEvent(PreviewEmoteEventType.ANIMATION_PLAY)
+    handleEvent(PreviewEmoteEventType.ANIMATION_PAUSE)
+    handleEvent(PreviewEmoteEventType.ANIMATION_END)
+
+    const unsubscribe = () => {
+      controller.emote.events.off(
+        PreviewEmoteEventType.ANIMATION_PLAY,
+        eventEmit
+      )
+      controller.emote.events.off(
+        PreviewEmoteEventType.ANIMATION_PAUSE,
+        eventEmit
+      )
+      controller.emote.events.off(
+        PreviewEmoteEventType.ANIMATION_END,
+        eventEmit
+      )
+    }
+
+    return unsubscribe
+  })
+}
+
+function* handleSetWearablePreviewController(
+  action: SetWearablePreviewControllerAction
+) {
+  const controller: IPreviewController | null = action.payload.controller
+
+  if (controller) {
+    const emotesChannel = createWearablePreviewChannel(controller)
+
+    try {
+      while (true) {
+        try {
+          const event: string = yield take(emotesChannel)
+          switch (event) {
+            case PreviewEmoteEventType.ANIMATION_PLAY:
+              yield put(setEmotePlaying(true))
+              break
+            case PreviewEmoteEventType.ANIMATION_PAUSE:
+              yield put(setEmotePlaying(false))
+              break
+            case PreviewEmoteEventType.ANIMATION_END:
+              yield put(setEmotePlaying(false))
+              break
+          }
+        } catch (error) {
+          yield put(setEmotePlaying(false))
+        }
+      }
+    } finally {
+      emotesChannel.close()
+    }
   }
 }


### PR DESCRIPTION
This PR adds zoom in/out and play/stop controls to emotes on the try-on screen.

![image](https://user-images.githubusercontent.com/3170051/190712036-2a76981a-674f-4155-a0d4-5f81e4e1a64b.png)

![image](https://user-images.githubusercontent.com/3170051/190712111-3f62a5cc-b16e-4b4c-8426-38896e6b4477.png)

https://user-images.githubusercontent.com/3170051/190712374-f24b58f3-7bf4-44b4-8103-b01ea004d6b9.mov

Closes #736