### PR TITLE
fix: show minimum price instead of zero

### DIFF
--- a/webapp/src/components/SellPage/SellModal/SellModal.tsx
+++ b/webapp/src/components/SellPage/SellModal/SellModal.tsx
@@ -97,7 +97,8 @@ const SellModal = (props: Props) => {
   const { orderService } = VendorFactory.build(nft.vendor)
 
   const isInvalidDate = new Date(expiresAt).getTime() < Date.now()
-  const isInvalidPrice = parseMANANumber(price) <= 0
+  const isInvalidPrice =
+    parseMANANumber(price) <= 0 || parseFloat(price) !== parseMANANumber(price)
   const isDisabled =
     !orderService.canSell() ||
     !isOwnedBy(nft, wallet) ||

--- a/webapp/src/lib/mana.ts
+++ b/webapp/src/lib/mana.ts
@@ -8,9 +8,21 @@ export function formatWeiMANA(
   wei: string,
   maximumFractionDigits: number = MAXIMUM_FRACTION_DIGITS
 ): string {
-  return Number(ethers.utils.formatEther(wei)).toLocaleString(undefined, {
+  const value = Number(ethers.utils.formatEther(wei))
+
+  if (value === 0) {
+    return '0'
+  }
+
+  const fixedValue = value.toLocaleString(undefined, {
     maximumFractionDigits
   })
+
+  if (fixedValue === '0') {
+    return getMinimumValueForFractionDigits(maximumFractionDigits).toString()
+  }
+
+  return fixedValue
 }
 
 /**
@@ -27,5 +39,20 @@ export function parseMANANumber(
     return 0
   }
 
-  return parseFloat(mana.toFixed(maximumFractionDigits))
+  const fixedValue = parseFloat(mana.toFixed(maximumFractionDigits))
+
+  if (fixedValue === 0) {
+    return getMinimumValueForFractionDigits(maximumFractionDigits)
+  }
+
+  return fixedValue
+}
+
+/**
+ * returns the minimum value that can be given the maximum fraction digits
+ */
+export function getMinimumValueForFractionDigits(
+  maximumFractionDigits: number
+) {
+  return Math.pow(10, -maximumFractionDigits)
 }


### PR DESCRIPTION
Fixes: #873

With this, the prices and sales that are smaller than 0 now show the minimum price:

<img width="1107" alt="Screen Shot 2022-10-12 at 14 38 28" src="https://user-images.githubusercontent.com/2781777/195412315-69355e54-498f-435a-a645-42866a859b0a.png">

But the items that are truly free still show 0:

<img width="1273" alt="Screen Shot 2022-10-12 at 14 38 59" src="https://user-images.githubusercontent.com/2781777/195412354-6d9a5635-4fd8-4a6a-a5e9-52cceb78f421.png">

