### PR TITLE
feat: Add wearables and emotes tabs for newest and listing sliders on homepage

### DIFF
--- a/webapp/src/components/HomePage/HomePage.css
+++ b/webapp/src/components/HomePage/HomePage.css
@@ -37,26 +37,6 @@
   color: #a09ba8;
 }
 
-.HomePage .items-section .tabs {
-  display: flex;
-  align-items: center;
-  margin-bottom: 0;
-}
-
-.HomePage .items-section .tab div {
-  margin-right: 12px;
-  display: flex;
-  align-items: center;
-}
-
-.HomePage .items-section .view-all-button {
-  float: right;
-}
-
-.HomePage .items-section .view-all-button .tab {
-  margin-right: 0;
-}
-
 @media (max-width: 768px) {
   .HomePage .Slideshow .dcl.header-menu .dcl.header-menu-left {
     max-width: 268px;

--- a/webapp/src/components/HomePage/HomePage.css
+++ b/webapp/src/components/HomePage/HomePage.css
@@ -37,6 +37,26 @@
   color: #a09ba8;
 }
 
+.HomePage .items-section .tabs {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0;
+}
+
+.HomePage .items-section .tab div {
+  margin-right: 12px;
+  display: flex;
+  align-items: center;
+}
+
+.HomePage .items-section .view-all-button {
+  float: right;
+}
+
+.HomePage .items-section .view-all-button .tab {
+  margin-right: 0;
+}
+
 @media (max-width: 768px) {
   .HomePage .Slideshow .dcl.header-menu .dcl.header-menu-left {
     max-width: 268px;

--- a/webapp/src/components/HomePage/HomePage.tsx
+++ b/webapp/src/components/HomePage/HomePage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { Page, Tabs } from 'decentraland-ui'
+import { Button, EmoteIcon, Page, Tabs, WearableIcon } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
 import { locations } from '../../modules/routing/locations'
@@ -156,22 +156,38 @@ const HomePage = (props: Props) => {
   }, [onFetchAssetsFromRoute])
 
   const itemsSections = (view: HomepageView) => (
-    <Tabs isFullscreen>
-      <Tabs.Left>
+    <div className="items-section">
+      <Tabs>
         <Tabs.Tab
           active={currentItemSection[view] === Section.WEARABLES}
           onClick={() => handleOnChangeItemSection(view, Section.WEARABLES)}
         >
-          <div id={Section.WEARABLES}>{t(`menu.${Section.WEARABLES}`)}</div>
+          <div id={Section.WEARABLES}>
+            <WearableIcon />
+            {t(`menu.${Section.WEARABLES}`)}
+          </div>
         </Tabs.Tab>
         <Tabs.Tab
           active={currentItemSection[view] === Section.EMOTES}
           onClick={() => handleOnChangeItemSection(view, Section.EMOTES)}
         >
-          <div id={Section.EMOTES}>{t(`menu.${Section.EMOTES}`)}</div>
+          <div id={Section.EMOTES}>
+            <EmoteIcon />
+            {t(`menu.${Section.EMOTES}`)}
+          </div>
         </Tabs.Tab>
-      </Tabs.Left>
-    </Tabs>
+        <div className="view-all-button">
+          <Tabs.Tab>
+            <Button basic onClick={() => handleViewAll(view)}>
+              {sectionsViewAllTitle[view]
+                ? sectionsViewAllTitle[view]
+                : t('slideshow.view_all')}
+              <i className="caret" />
+            </Button>
+          </Tabs.Tab>
+        </div>
+      </Tabs>
+    </div>
   )
 
   const renderSlideshow = (view: HomepageView) => {

--- a/webapp/src/components/HomePage/Slideshow/ItemsSection.tsx
+++ b/webapp/src/components/HomePage/Slideshow/ItemsSection.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react'
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import {
+  Dropdown,
+  DropdownProps,
+  EmoteIcon,
+  Mobile,
+  NotMobile,
+  Tabs,
+  WearableIcon
+} from 'decentraland-ui'
+import { HomepageView } from '../../../modules/ui/asset/homepage/types'
+import { Section } from '../../../modules/vendor/decentraland/routing/types'
+
+const ItemsSection = (props: {
+  view: HomepageView
+  viewAllButton: React.ReactNode
+  onChangeItemSection: (view: HomepageView, section: Section) => void
+}) => {
+  const { view, viewAllButton, onChangeItemSection } = props
+  const [currentItemSection, setCurrentItemSection] = useState<Section>(
+    Section.WEARABLES
+  )
+
+  const handleOnChangeItemSection = (view: HomepageView, section: Section) => {
+    setCurrentItemSection(section)
+    onChangeItemSection(view, section)
+  }
+
+  const renderTabs = () => (
+    <Tabs>
+      <Tabs.Tab
+        active={currentItemSection === Section.WEARABLES}
+        onClick={() => handleOnChangeItemSection(view, Section.WEARABLES)}
+      >
+        <div id={Section.WEARABLES}>
+          <WearableIcon />
+          {t(`menu.${Section.WEARABLES}`)}
+        </div>
+      </Tabs.Tab>
+      <Tabs.Tab
+        active={currentItemSection === Section.EMOTES}
+        onClick={() => handleOnChangeItemSection(view, Section.EMOTES)}
+      >
+        <div id={Section.EMOTES}>
+          <EmoteIcon />
+          {t(`menu.${Section.EMOTES}`)}
+        </div>
+      </Tabs.Tab>
+      <div className="view-all-button">
+        <Tabs.Tab>{viewAllButton}</Tabs.Tab>
+      </div>
+    </Tabs>
+  )
+
+  const renderDropdown = () => (
+    <Dropdown
+      defaultValue={currentItemSection}
+      value={currentItemSection}
+      direction="right"
+      options={[Section.WEARABLES, Section.EMOTES].map(section => ({
+        value: section,
+        text: t(`menu.${section}`)
+      }))}
+      onChange={(
+        _event: React.SyntheticEvent<HTMLElement, Event>,
+        { value }: DropdownProps
+      ) => handleOnChangeItemSection(view, value as Section)}
+    />
+  )
+
+  return (
+    <div className="ItemsSection">
+      <NotMobile>{renderTabs()}</NotMobile>
+      <Mobile>
+        {renderDropdown()}
+        {viewAllButton}
+      </Mobile>
+    </div>
+  )
+}
+
+export default React.memo(ItemsSection)

--- a/webapp/src/components/HomePage/Slideshow/Slideshow.css
+++ b/webapp/src/components/HomePage/Slideshow/Slideshow.css
@@ -126,3 +126,48 @@
     overflow: hidden;
   }
 }
+
+.Slideshow .ItemsSection .tabs {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0;
+}
+
+.Slideshow .ItemsSection .tab div {
+  margin-right: 12px;
+  display: flex;
+  align-items: center;
+}
+
+.Slideshow .ItemsSection .view-all-button {
+  float: right;
+}
+
+.Slideshow .ItemsSection .view-all-button .tab {
+  margin-right: 0;
+}
+
+@media (max-width: 768px) {
+  .Slideshow .ItemsSection {
+    display: flex;
+    align-items: center;
+    margin-top: 12px;
+  }
+
+  .Slideshow .ItemsSection .button {
+    position: absolute;
+    right: 0;
+  }
+
+  .Slideshow .ItemsSection .ui.dropdown {
+    display: flex;
+    align-self: stretch;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    border: 1px solid rgba(115, 110, 125, 0.4);
+    border-radius: 5px;
+    padding: 6px 16px;
+    margin-right: 12px;
+  }
+}

--- a/webapp/src/components/HomePage/Slideshow/Slideshow.tsx
+++ b/webapp/src/components/HomePage/Slideshow/Slideshow.tsx
@@ -5,6 +5,7 @@ import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
 import { Asset } from '../../../modules/asset/types'
 import { AssetCard } from '../../AssetCard'
 import { Props } from './Slideshow.types'
+import ItemsSection from './ItemsSection'
 import './Slideshow.css'
 
 const PAGE_SIZE = 4
@@ -13,14 +14,16 @@ const INITIAL_PAGE = 1
 const Slideshow = (props: Props) => {
   const slideRef = useRef<HTMLDivElement>(null)
   const {
+    view,
     title,
     subtitle,
     viewAllTitle,
     assets,
-    sections,
     isSubHeader,
     isLoading,
-    onViewAll
+    hasItemsSection,
+    onViewAll,
+    onChangeItemSection
   } = props
   const [showArrows, setShowArrows] = useState(false)
   const [currentPage, setCurrentPage] = useState(INITIAL_PAGE)
@@ -83,6 +86,13 @@ const Slideshow = (props: Props) => {
     []
   )
 
+  const viewAllButton = () => (
+    <Button basic onClick={onViewAll}>
+      {viewAllTitle ? viewAllTitle : t('slideshow.view_all')}
+      <i className="caret" />
+    </Button>
+  )
+
   const showArrowsHandlers = { onMouseEnter, onMouseLeave }
 
   return (
@@ -92,16 +102,17 @@ const Slideshow = (props: Props) => {
           <div>
             <Header sub={isSubHeader}>{title}</Header>
             <Header sub>{subtitle}</Header>
-            {sections}
+            {hasItemsSection ? (
+              <ItemsSection
+                view={view}
+                viewAllButton={viewAllButton()}
+                onChangeItemSection={onChangeItemSection!}
+              />
+            ) : null}
           </div>
         </HeaderMenu.Left>
-        {!sections ? (
-          <HeaderMenu.Right>
-            <Button basic onClick={onViewAll}>
-              {viewAllTitle ? viewAllTitle : t('slideshow.view_all')}
-              <i className="caret" />
-            </Button>
-          </HeaderMenu.Right>
+        {!hasItemsSection ? (
+          <HeaderMenu.Right>{viewAllButton()}</HeaderMenu.Right>
         ) : null}
       </HeaderMenu>
       <div className="assets">

--- a/webapp/src/components/HomePage/Slideshow/Slideshow.tsx
+++ b/webapp/src/components/HomePage/Slideshow/Slideshow.tsx
@@ -17,6 +17,7 @@ const Slideshow = (props: Props) => {
     subtitle,
     viewAllTitle,
     assets,
+    sections,
     isSubHeader,
     isLoading,
     onViewAll
@@ -100,6 +101,7 @@ const Slideshow = (props: Props) => {
           </Button>
         </HeaderMenu.Right>
       </HeaderMenu>
+      {sections ?? null}
       <div className="assets">
         {isLoading ? (
           assets.length === 0 ? (

--- a/webapp/src/components/HomePage/Slideshow/Slideshow.tsx
+++ b/webapp/src/components/HomePage/Slideshow/Slideshow.tsx
@@ -92,16 +92,18 @@ const Slideshow = (props: Props) => {
           <div>
             <Header sub={isSubHeader}>{title}</Header>
             <Header sub>{subtitle}</Header>
+            {sections}
           </div>
         </HeaderMenu.Left>
-        <HeaderMenu.Right>
-          <Button basic onClick={onViewAll}>
-            {viewAllTitle ? viewAllTitle : t('slideshow.view_all')}
-            <i className="caret" />
-          </Button>
-        </HeaderMenu.Right>
+        {!sections ? (
+          <HeaderMenu.Right>
+            <Button basic onClick={onViewAll}>
+              {viewAllTitle ? viewAllTitle : t('slideshow.view_all')}
+              <i className="caret" />
+            </Button>
+          </HeaderMenu.Right>
+        ) : null}
       </HeaderMenu>
-      {sections ?? null}
       <div className="assets">
         {isLoading ? (
           assets.length === 0 ? (

--- a/webapp/src/components/HomePage/Slideshow/Slideshow.types.ts
+++ b/webapp/src/components/HomePage/Slideshow/Slideshow.types.ts
@@ -1,13 +1,16 @@
-import React from 'react'
 import { Asset } from '../../../modules/asset/types'
+import { HomepageView } from '../../../modules/ui/asset/homepage/types'
+import { Section } from '../../../modules/vendor/routing/types'
 
 export type Props = {
   title: string
   subtitle?: string
   viewAllTitle?: string
   assets: Asset[]
-  sections?: React.ReactNode
+  view: HomepageView
   isSubHeader?: boolean
   isLoading: boolean
+  hasItemsSection?: boolean
   onViewAll: () => void
+  onChangeItemSection?: (view: HomepageView, section: Section) => void
 }

--- a/webapp/src/components/HomePage/Slideshow/Slideshow.types.ts
+++ b/webapp/src/components/HomePage/Slideshow/Slideshow.types.ts
@@ -1,3 +1,4 @@
+import React from 'react'
 import { Asset } from '../../../modules/asset/types'
 
 export type Props = {
@@ -5,6 +6,7 @@ export type Props = {
   subtitle?: string
   viewAllTitle?: string
   assets: Asset[]
+  sections?: React.ReactNode
   isSubHeader?: boolean
   isLoading: boolean
   onViewAll: () => void


### PR DESCRIPTION
This PR adds the wearables and emotes tabs for the newest and listing sliders on the homepage.

Newest Slider:
- Desktop: 
![image](https://user-images.githubusercontent.com/3170051/195872401-f85e5de2-507b-4ea7-b6fc-2d61f8ffe419.png)

- Mobile:
![image](https://user-images.githubusercontent.com/3170051/195931272-f784c906-5a4a-49b6-930c-ad3e637c81f1.png)


Listing Slider:
- Desktop: 
![image](https://user-images.githubusercontent.com/3170051/195872436-3629ec3f-b51d-4987-909c-fb6370b0e723.png)

- Mobile: 
![image](https://user-images.githubusercontent.com/3170051/195931327-62fb5c96-6a2a-4287-b913-6efa00692ba6.png)


Closes #852