### PR TITLE
fix: zoom button style

### DIFF
--- a/webapp/src/components/AssetImage/AssetImage.css
+++ b/webapp/src/components/AssetImage/AssetImage.css
@@ -167,13 +167,16 @@
 
 .AssetImage .zoom-controls > .ui.button.zoom-control i.icon {
   margin: 0 !important;
+  width: 16px;
+  height: 16px;
 }
 
 .AssetImage .zoom-controls > .ui.button.zoom-in-control {
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  min-width: unset;
+  border-radius: 6px 6px 0px 0px;
+}
+
+.AssetImage .zoom-controls > .ui.button.zoom-out-control {
+  border-radius: 0px 0px 6px 6px;
 }
 
 .AssetImage .play-emote-control {


### PR DESCRIPTION
This PR centers the icons of the zoom buttons in the emote preview, and also makes the corners round as the rest of the buttons.

Before:
<img width="212" alt="Screen Shot 2022-10-14 at 13 04 55" src="https://user-images.githubusercontent.com/2781777/195892486-7ce86335-3f33-4c7e-be50-b34d24fb91f0.png">

After:
<img width="232" alt="Screen Shot 2022-10-14 at 13 08 58" src="https://user-images.githubusercontent.com/2781777/195892509-2a732d2c-99a3-4ac2-b3d7-5008b9e07d40.png">
