### PR TITLE
feat: Add rental toasts

### DIFF
--- a/webapp/src/modules/rental/sagas.spec.ts
+++ b/webapp/src/modules/rental/sagas.spec.ts
@@ -9,16 +9,13 @@ import {
 import { call, select } from '@redux-saga/core/effects'
 import { AuthIdentity } from 'decentraland-crypto-fetch'
 import { getConnectedProvider } from 'decentraland-dapps/dist/lib/eth'
-import { showToast } from 'decentraland-dapps/dist/modules/toast/actions'
 import { waitForTx } from 'decentraland-dapps/dist/modules/transaction/utils'
-import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { sendTransaction } from 'decentraland-dapps/dist/modules/wallet/utils'
 import {
   ContractData,
   ContractName,
   getContract
 } from 'decentraland-transactions'
-import { ToastType } from 'decentraland-ui/dist/components/Toast/Toast'
 import { expectSaga } from 'redux-saga-test-plan'
 import { throwError } from 'redux-saga-test-plan/providers'
 import { delay } from 'redux-saga/effects'
@@ -277,15 +274,6 @@ describe('when handling the UPSERT_RENTAL_REQUEST action', () => {
             ]
           ])
           .put(upsertRentalSuccess(nft, rental, UpsertRentalOptType.EDIT))
-          .put(
-            showToast({
-              type: ToastType.INFO,
-              title: t('toast.rent_listing_updated.title'),
-              body: t('toast.rent_listing_updated.body'),
-              timeout: 6000,
-              closable: true
-            })
-          )
           .dispatch(
             upsertRentalRequest(
               nft,

--- a/webapp/src/modules/rental/sagas.ts
+++ b/webapp/src/modules/rental/sagas.ts
@@ -5,15 +5,12 @@ import {
   RentalStatus
 } from '@dcl/schemas'
 import { AuthIdentity } from 'decentraland-crypto-fetch'
-import { ToastType } from 'decentraland-ui'
 import {
   ContractData,
   ContractName,
   getContract,
   Provider
 } from 'decentraland-transactions'
-import { showToast } from 'decentraland-dapps/dist/modules/toast/actions'
-import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { getConnectedProvider } from 'decentraland-dapps/dist/lib/eth'
 import { waitForTx } from 'decentraland-dapps/dist/modules/transaction/utils'
 import { sendTransaction } from 'decentraland-dapps/dist/modules/wallet/utils'
@@ -40,16 +37,12 @@ import {
   removeRentalFailure,
   removeRentalSuccess,
   removeRentalTransactionSubmitted,
-  REMOVE_RENTAL_REQUEST,
-  UPSERT_RENTAL_SUCCESS,
-  UpsertRentalSuccessAction
+  REMOVE_RENTAL_REQUEST
 } from './actions'
 import { daysByPeriod, getNonces, getSignature } from './utils'
-import { UpsertRentalOptType } from './types'
 
 export function* rentalSaga() {
   yield takeEvery(UPSERT_RENTAL_REQUEST, handleCreateOrEditRentalRequest)
-  yield takeEvery(UPSERT_RENTAL_SUCCESS, handleUpsertRentalSuccess)
   yield takeEvery(CLAIM_LAND_REQUEST, handleClaimLandRequest)
   yield takeEvery(CLOSE_MODAL, handleModalClose)
   yield takeEvery(REMOVE_RENTAL_REQUEST, handleRemoveRentalRequest)
@@ -231,20 +224,5 @@ function* handleRemoveRentalRequest(action: RemoveRentalRequestAction) {
     yield put(removeRentalSuccess(nft))
   } catch (error) {
     yield put(removeRentalFailure((error as Error).message))
-  }
-}
-
-function* handleUpsertRentalSuccess(action: UpsertRentalSuccessAction) {
-  const { operationType } = action.payload
-  if (operationType === UpsertRentalOptType.EDIT) {
-    yield put(
-      showToast({
-        type: ToastType.INFO,
-        title: t('toast.rent_listing_updated.title'),
-        body: t('toast.rent_listing_updated.body'),
-        timeout: 6000,
-        closable: true
-      })
-    )
   }
 }

--- a/webapp/src/modules/toast/sagas.spec.ts
+++ b/webapp/src/modules/toast/sagas.spec.ts
@@ -1,20 +1,90 @@
+import { RentalListing } from '@dcl/schemas'
 import { showToast } from 'decentraland-dapps/dist/modules/toast/actions'
 import { getState } from 'decentraland-dapps/dist/modules/toast/selectors'
 import { expectSaga } from 'redux-saga-test-plan'
 import { select } from 'redux-saga/effects'
+import { NFT } from '../nft/types'
+import {
+  claimLandSuccess,
+  removeRentalSuccess,
+  upsertRentalSuccess
+} from '../rental/actions'
+import { UpsertRentalOptType } from '../rental/types'
 import { updateStoreSuccess } from '../store/actions'
 import { getEmptyStore } from '../store/utils'
-import { getStoreUpdateSucessToast } from '../toast/toasts'
-
+import {
+  getLandClaimedBackSuccessToast,
+  getListingRemoveSuccessToast,
+  getStoreUpdateSuccessToast,
+  getUpsertRentalSuccessToast
+} from '../toast/toasts'
 import { toastSaga } from './sagas'
+
+let nft: NFT
+let rental: RentalListing
+
+beforeEach(() => {
+  nft = {
+    contractAddress: 'aContractAddress',
+    tokenId: 'aTokenId'
+  } as NFT
+
+  rental = {
+    id: 'aRentalId'
+  } as RentalListing
+})
 
 describe('when updating the store settings', () => {
   it('should show an info toast if the update is successful', () => {
-    const MOCKED_TOAST_MESSAGE = getStoreUpdateSucessToast()
+    const MOCKED_TOAST_MESSAGE = getStoreUpdateSuccessToast()
     return expectSaga(toastSaga)
       .provide([[select(getState), []]])
       .dispatch(updateStoreSuccess(getEmptyStore()))
       .put(showToast(MOCKED_TOAST_MESSAGE))
+      .silentRun()
+  })
+})
+
+describe('when handling the success of a LAND claimed back', () => {
+  it('should show a toast signaling the user that the land has been claimed back successfully', () => {
+    return expectSaga(toastSaga)
+      .provide([[select(getState), []]])
+      .put(showToast(getLandClaimedBackSuccessToast()))
+      .dispatch(claimLandSuccess(nft, rental))
+      .silentRun()
+  })
+})
+
+describe('when handling the success of a rental listing removal', () => {
+  it('should show a toast signaling the success of a rental listing being removed', () => {
+    return expectSaga(toastSaga)
+      .provide([[select(getState), []]])
+      .put(showToast(getListingRemoveSuccessToast()))
+      .dispatch(removeRentalSuccess(nft))
+      .silentRun()
+  })
+})
+
+describe('when handling the success of a rental listing update', () => {
+  it('should show a toast signaling the success of a rental listing update', () => {
+    return expectSaga(toastSaga)
+      .provide([[select(getState), []]])
+      .put(
+        showToast(getUpsertRentalSuccessToast(nft, UpsertRentalOptType.EDIT))
+      )
+      .dispatch(upsertRentalSuccess(nft, rental, UpsertRentalOptType.EDIT))
+      .silentRun()
+  })
+})
+
+describe('when handling the success of a rental listing creation', () => {
+  it('should show a toast signaling the success of a rental listing creation', () => {
+    return expectSaga(toastSaga)
+      .provide([[select(getState), []]])
+      .put(
+        showToast(getUpsertRentalSuccessToast(nft, UpsertRentalOptType.INSERT))
+      )
+      .dispatch(upsertRentalSuccess(nft, rental, UpsertRentalOptType.INSERT))
       .silentRun()
   })
 })

--- a/webapp/src/modules/toast/sagas.ts
+++ b/webapp/src/modules/toast/sagas.ts
@@ -1,8 +1,19 @@
 import { all, takeEvery, put } from 'redux-saga/effects'
 import { toastSaga as baseToastSaga } from 'decentraland-dapps/dist/modules/toast/sagas'
 import { showToast } from 'decentraland-dapps/dist/modules/toast/actions'
-import { getStoreUpdateSucessToast } from './toasts'
 import { UPDATE_STORE_SUCCESS } from '../store/actions'
+import {
+  CLAIM_LAND_SUCCESS,
+  REMOVE_RENTAL_SUCCESS,
+  UpsertRentalSuccessAction,
+  UPSERT_RENTAL_SUCCESS
+} from '../rental/actions'
+import {
+  getLandClaimedBackSuccessToast,
+  getListingRemoveSuccessToast,
+  getStoreUpdateSuccessToast,
+  getUpsertRentalSuccessToast
+} from './toasts'
 
 export function* toastSaga() {
   yield all([baseToastSaga(), customToastSaga()])
@@ -14,8 +25,30 @@ function* customToastSaga() {
 
 function* successToastSagas() {
   yield takeEvery(UPDATE_STORE_SUCCESS, handleStoreUpdateSuccess)
+  yield takeEvery(REMOVE_RENTAL_SUCCESS, handleRemoveRentalSuccess)
+  yield takeEvery(CLAIM_LAND_SUCCESS, handleClaimLandBackSuccess)
+  yield takeEvery(UPSERT_RENTAL_SUCCESS, handleUpsertRentalSuccess)
 }
 
 function* handleStoreUpdateSuccess() {
-  yield put(showToast(getStoreUpdateSucessToast()))
+  yield put(showToast(getStoreUpdateSuccessToast()))
+}
+
+function* handleRemoveRentalSuccess() {
+  yield put(showToast(getListingRemoveSuccessToast()))
+}
+
+function* handleClaimLandBackSuccess() {
+  yield put(showToast(getLandClaimedBackSuccessToast()))
+}
+
+function* handleUpsertRentalSuccess(action: UpsertRentalSuccessAction) {
+  yield put(
+    showToast(
+      getUpsertRentalSuccessToast(
+        action.payload.nft,
+        action.payload.operationType
+      )
+    )
+  )
 }

--- a/webapp/src/modules/toast/toasts.tsx
+++ b/webapp/src/modules/toast/toasts.tsx
@@ -1,11 +1,62 @@
-import { ToastType } from 'decentraland-ui'
+import { Button, ToastType } from 'decentraland-ui'
+import { Toast } from 'decentraland-dapps/dist/modules/toast/types'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import { UpsertRentalOptType } from '../rental/types'
+import { locations } from '../routing/locations'
+import { NFT } from '../nft/types'
 
-export function getStoreUpdateSucessToast() {
+export function getStoreUpdateSuccessToast(): Omit<Toast, 'id'> {
   return {
     type: ToastType.INFO,
     title: t('toast.store_update_success.title'),
     body: t('toast.store_update_success.body'),
+    timeout: 6000,
+    closable: true
+  }
+}
+
+export function getLandClaimedBackSuccessToast(): Omit<Toast, 'id'> {
+  return {
+    type: ToastType.INFO,
+    title: t('toast.claim_land_success.title'),
+    body: t('toast.claim_land_success.body'),
+    timeout: 6000,
+    closable: true
+  }
+}
+
+export function getListingRemoveSuccessToast(): Omit<Toast, 'id'> {
+  return {
+    type: ToastType.INFO,
+    title: t('toast.remove_listing_success.title'),
+    body: t('toast.remove_listing_success.body'),
+    timeout: 6000,
+    closable: true
+  }
+}
+
+export function getUpsertRentalSuccessToast(
+  nft: NFT,
+  type: UpsertRentalOptType
+): Omit<Toast, 'id'> {
+  return {
+    type: ToastType.INFO,
+    title:
+      type === UpsertRentalOptType.INSERT
+        ? t('toast.create_rental_success.title')
+        : t('toast.update_rental_success.title'),
+    body: (
+      <div>
+        <p>
+          {type === UpsertRentalOptType.INSERT
+            ? t('toast.create_rental_success.body')
+            : t('toast.update_rental_success.body')}
+        </p>
+        <Button as={'a'} href={locations.nft(nft.contractAddress, nft.tokenId)}>
+          {t('toast.upsert_rental_success.show_listing')}
+        </Button>
+      </div>
+    ),
     timeout: 6000,
     closable: true
   }

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -688,9 +688,24 @@
       "title": "Success",
       "body": "Store data updated correctly"
     },
-    "rent_listing_updated": {
-      "title": "Rent Listing Updated",
-      "body": "The listing has been successfully updated."
+    "remove_listing_success": {
+      "title": "Listing removed",
+      "body": "Your LAND is not available for rent anymore."
+    },
+    "claim_land_success": {
+      "title": "LAND claimed back",
+      "body": "You successfully claimed back your LAND."
+    },
+    "create_rental_success": {
+      "title": "Rental listing created",
+      "body": "Your LAND has been successfully listed for rent."
+    },
+    "update_rental_success": {
+      "title": "Rental listing update",
+      "body": "Your listing has been updated."
+    },
+    "upsert_rental_success": {
+      "show_listing": "Show listing"
     }
   },
   "maintainance": {

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -681,9 +681,24 @@
       "title": "Éxito",
       "body": "Configuración de tienda actualizada correctamente"
     },
-    "rent_listing_updated": {
+    "remove_listing_success": {
+      "title": "Listado de alquiler removido",
+      "body": "Tu tierra no está más disponbile para la renta."
+    },
+    "claim_land_success": {
+      "title": "Haz reclamado tu tierra",
+      "body": "Tu tierra ha sido reclamada correctamente."
+    },
+    "create_rental_success": {
+      "title": "Listado de alquiler creado",
+      "body": "Tu tierra ha sido listada para la renta con éxito."
+    },
+    "update_rental_success": {
       "title": "Listado de alquiler actualizado",
       "body": "El listado ha sido actualizado con éxito."
+    },
+    "upsert_rental_success": {
+      "show_listing": "Mostrar listado"
     }
   },
   "maintainance": {

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -682,6 +682,25 @@
     "store_update_success": {
       "title": "成功",
       "body": "存储数据正确更新"
+    },
+    "remove_listing_success": {
+      "title": "已移除出租列表",
+      "body": "您的 LAND 不再可供出租。"
+    },
+    "claim_land_success": {
+      "title": "您的 LAND 已被收回",
+      "body": "您已成功收回您的 LAND。"
+    },
+    "create_rental_success": {
+      "title": "已创建出租列表",
+      "body": "您的 LAND 已成功挂牌出租。"
+    },
+    "update_rental_success": {
+      "title": "出租清单更新",
+      "body": "您的列表已更新。"
+    },
+    "upsert_rental_success": {
+      "show_listing": "显示出租清单"
     }
   },
   "maintainance": {


### PR DESCRIPTION
This PR adds toasts to the following rental actions:
- Claiming back a land
- Updating or creating a new rental listing
- Removing a rental listing

It also moves the upsert toast into the toasts file.

![Screen Shot 2022-10-17 at 14 13 16](https://user-images.githubusercontent.com/1120791/196262868-2e2340c8-e36e-4ef6-af34-851f7cae13ce.png)
![Screen Shot 2022-10-17 at 16 17 22](https://user-images.githubusercontent.com/1120791/196263470-c4f56e0d-452f-4ede-89bd-df4179fa7219.png)
![Screen Shot 2022-10-17 at 14 19 25](https://user-images.githubusercontent.com/1120791/196262872-561d2e31-e094-420e-9f55-49d3a2244645.png)



Closes #831 
