### PR TITLE
fix: Add the LAND authorizations to array

### DIFF
--- a/webapp/src/components/SettingsPage/SettingsPage.tsx
+++ b/webapp/src/components/SettingsPage/SettingsPage.tsx
@@ -65,11 +65,7 @@ const SettingsPage = (props: Props) => {
 
   const authorizationsForSelling = authorizations.filter(authorization => {
     const contract = getContract({ address: authorization.contractAddress })
-    return (
-      contract.category != null &&
-      contract.category !== NFTCategory.PARCEL &&
-      contract.category !== NFTCategory.ESTATE
-    )
+    return contract.category != null
   })
 
   const authorizationsForRenting = authorizations.filter(authorization => {

--- a/webapp/src/components/SettingsPage/SettingsPage.tsx
+++ b/webapp/src/components/SettingsPage/SettingsPage.tsx
@@ -75,11 +75,10 @@ const SettingsPage = (props: Props) => {
 
   const authorizationsForSelling = authorizations.filter(authorization => {
     const contract = getContract({ address: authorization.contractAddress })
-    return (
-      contract.category != null &&
-      rentals &&
-      authorization.authorizedAddress !== rentals.address
-    )
+    return rentals
+      ? contract.category !== null &&
+          authorization.authorizedAddress !== rentals.address
+      : contract.category !== null
   })
 
   const authorizationsForRenting = authorizations.filter(authorization => {

--- a/webapp/src/components/SettingsPage/SettingsPage.tsx
+++ b/webapp/src/components/SettingsPage/SettingsPage.tsx
@@ -9,6 +9,7 @@ import { Page, Grid, Blockie, Loader, Form } from 'decentraland-ui'
 import { ContractName } from 'decentraland-transactions'
 
 import { locations } from '../../modules/routing/locations'
+import { Contract } from '../../modules/vendor/services'
 import { shortenAddress } from '../../modules/wallet/utils'
 import { Navbar } from '../Navbar'
 import { Navigation } from '../Navigation'
@@ -63,15 +64,20 @@ const SettingsPage = (props: Props) => {
     network: Network.MATIC
   })
 
-  const rentals = getContract({
-    name: getContractNames().RENTALS,
-    network: Network.ETHEREUM
-  })
+  let rentals: Contract | undefined
+
+  try {
+    rentals = getContract({
+      name: getContractNames().RENTALS,
+      network: Network.ETHEREUM
+    })
+  } catch (error) {}
 
   const authorizationsForSelling = authorizations.filter(authorization => {
     const contract = getContract({ address: authorization.contractAddress })
     return (
       contract.category != null &&
+      rentals &&
       authorization.authorizedAddress !== rentals.address
     )
   })
@@ -81,6 +87,7 @@ const SettingsPage = (props: Props) => {
     return (
       (contract.category === NFTCategory.PARCEL ||
         contract.category === NFTCategory.ESTATE) &&
+      rentals &&
       authorization.authorizedAddress === rentals.address
     )
   })

--- a/webapp/src/components/SettingsPage/SettingsPage.tsx
+++ b/webapp/src/components/SettingsPage/SettingsPage.tsx
@@ -63,16 +63,25 @@ const SettingsPage = (props: Props) => {
     network: Network.MATIC
   })
 
+  const rentals = getContract({
+    name: getContractNames().RENTALS,
+    network: Network.ETHEREUM
+  })
+
   const authorizationsForSelling = authorizations.filter(authorization => {
     const contract = getContract({ address: authorization.contractAddress })
-    return contract.category != null
+    return (
+      contract.category != null &&
+      authorization.authorizedAddress !== rentals.address
+    )
   })
 
   const authorizationsForRenting = authorizations.filter(authorization => {
     const contract = getContract({ address: authorization.contractAddress })
     return (
-      contract.category === NFTCategory.PARCEL ||
-      contract.category === NFTCategory.ESTATE
+      (contract.category === NFTCategory.PARCEL ||
+        contract.category === NFTCategory.ESTATE) &&
+      authorization.authorizedAddress === rentals.address
     )
   })
 

--- a/webapp/src/modules/wallet/sagas.ts
+++ b/webapp/src/modules/wallet/sagas.ts
@@ -168,12 +168,28 @@ function* handleWallet(
     })
 
     if (
-      (contract.category === NFTCategory.WEARABLE ||
-        contract.category === NFTCategory.EMOTE) &&
-      !authorizations.some(
-        authorization => authorization.contractAddress === contract.address
-      )
+      contract.category === NFTCategory.WEARABLE ||
+      contract.category === NFTCategory.EMOTE
     ) {
+      // just add the authorizations for the contracts that are not already in the array
+      if (
+        !authorizations.some(
+          authorization => authorization.contractAddress === contract.address
+        )
+      ) {
+        authorizations.push({
+          address,
+          authorizedAddress: marketplace.address,
+          contractAddress: contract.address,
+          contractName:
+            contract.network === Network.MATIC
+              ? ContractName.ERC721CollectionV2
+              : ContractName.ERC721,
+          chainId: contract.chainId,
+          type: AuthorizationType.APPROVAL
+        })
+      }
+    } else {
       authorizations.push({
         address,
         authorizedAddress: marketplace.address,


### PR DESCRIPTION
The error was introduced recently, when a change was added to filter the authorizations that were already in the array. It included a condition to check whether they were wearables/emotes so it was leaving the LANDs/Estates out. This PRs adds them back.