### PR TITLE
fix: LAND filters in collectibles

### DIFF
--- a/webapp/src/components/Vendor/NFTFilters/NFTFilters.css
+++ b/webapp/src/components/Vendor/NFTFilters/NFTFilters.css
@@ -80,6 +80,11 @@
   margin-left: 20px;
 }
 
+.NFTFilters .ui.toggle.checkbox {
+  display: flex;
+  align-items: center;
+}
+
 .NFTFilters .ui.toggle.checkbox input.hidden:focus + label,
 .NFTFilters .ui.toggle.checkbox.checked input.hidden + label,
 .NFTFilters .ui.toggle.checkbox input.hidden + label,

--- a/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.container.ts
+++ b/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.container.ts
@@ -7,7 +7,7 @@ import {
   getOnlySmart,
   hasFiltersEnabled
 } from '../../../../modules/routing/selectors'
-import { getCount } from '../../../../modules/ui/browse/selectors'
+import { getCount, getView } from '../../../../modules/ui/browse/selectors'
 import { getIsRentalsEnabled } from '../../../../modules/features/selectors'
 import {
   getSection,
@@ -35,6 +35,7 @@ const mapState = (state: RootState): MapStateProps => ({
   assetType: getAssetType(state),
   count: getCount(state),
   section: getSection(state),
+  view: getView(state),
   sortBy: getSortBy(state),
   search: getSearch(state),
   onlyOnSale: getOnlyOnSale(state),

--- a/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.tsx
+++ b/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.tsx
@@ -22,15 +22,17 @@ import { NFTSidebar } from '../../NFTSidebar'
 import { Chip } from '../../../Chip'
 import { TextFilter } from '../../NFTFilters/TextFilter'
 import { FiltersMenu } from '../../NFTFilters/FiltersMenu'
-import { Props } from './NFTFilters.types'
 import { AssetType } from '../../../../modules/asset/types'
 import { isLandSection } from '../../../../modules/ui/utils'
+import { View } from '../../../../modules/ui/types'
 import { LANDFilters } from '../types'
 import { browseRentedLAND } from '../utils'
+import { Props } from './NFTFilters.types'
 
 const NFTFilters = (props: Props) => {
   const {
     section,
+    view,
     search,
     count,
     onlyOnSale,
@@ -49,7 +51,7 @@ const NFTFilters = (props: Props) => {
     isRentalsEnabled,
     availableContracts
   } = props
-
+  console.log('View', view)
   const category = section ? getCategoryFromSection(section) : undefined
 
   const [showFiltersMenu, setShowFiltersMenu] = useState(false)
@@ -292,7 +294,7 @@ const NFTFilters = (props: Props) => {
               minWidth={Responsive.onlyTablet.minWidth}
               className="topbar-filter"
             >
-              {isRentalsEnabled ? (
+              {isRentalsEnabled && view === View.CURRENT_ACCOUNT ? (
                 <Dropdown
                   direction="left"
                   className="topbar-dropdown"

--- a/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.tsx
+++ b/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.tsx
@@ -51,7 +51,6 @@ const NFTFilters = (props: Props) => {
     isRentalsEnabled,
     availableContracts
   } = props
-  console.log('View', view)
   const category = section ? getCategoryFromSection(section) : undefined
 
   const [showFiltersMenu, setShowFiltersMenu] = useState(false)

--- a/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.types.ts
+++ b/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.types.ts
@@ -9,11 +9,13 @@ import {
 import { Section } from '../../../../modules/vendor/routing/types'
 import { WearableGender } from '../../../../modules/nft/wearable/types'
 import { AssetType } from '../../../../modules/asset/types'
+import { View } from '../../../../modules/ui/types'
 
 export type Props = {
   assetType: AssetType
   count?: number
   section: Section
+  view?: View
   sortBy?: SortBy
   search: string
   onlyOnSale?: boolean
@@ -34,6 +36,7 @@ export type Props = {
 
 export type MapStateProps = Pick<
   Props,
+  | 'view'
   | 'assetType'
   | 'count'
   | 'section'


### PR DESCRIPTION
This PR fixes the following:
- The LAND filters appearing in collectibles.
- The on sale toggle being uncentered.

Before:
![Screen Shot 2022-11-02 at 14 57 32](https://user-images.githubusercontent.com/1120791/199565720-1be93361-00f1-4885-9bb8-3a401c902969.png)

After:
![Screen Shot 2022-11-02 at 14 58 02](https://user-images.githubusercontent.com/1120791/199565890-b6d8c1ab-5f9d-4232-9444-a60f599872ba.png)
