### PR TITLE
fix: TransactionHistory pagination

### DIFF
--- a/webapp/src/components/AssetPage/TransactionHistory/TransactionHistory.tsx
+++ b/webapp/src/components/AssetPage/TransactionHistory/TransactionHistory.tsx
@@ -63,7 +63,7 @@ const TransactionHistory = (props: Props) => {
         .fetch(params)
         .then(response => {
           setSales(response.data)
-          setTotalPages((response.total / ROWS_PER_PAGE) | 0)
+          setTotalPages(Math.ceil(response.total / ROWS_PER_PAGE) | 0)
         })
         .finally(() => setIsLoading(false))
         .catch(error => {


### PR DESCRIPTION
This PR fixes the `TransactionHistory` component total pages computing.

![image](https://user-images.githubusercontent.com/3170051/199803978-a3539898-a4c4-48af-a9e4-9819f226207a.png)

Closes #935