### PR TITLE
feat: Render empty state component in home page section slideshows

### DIFF
--- a/webapp/src/components/HomePage/Slideshow/Slideshow.css
+++ b/webapp/src/components/HomePage/Slideshow/Slideshow.css
@@ -147,6 +147,18 @@
   margin-right: 0;
 }
 
+.Slideshow .assets .empty-state-container {
+  text-align: center;
+  flex-direction: column;
+  row-gap: 10px;
+}
+
+.Slideshow .assets .empty-state-container .empty-state-action-button {
+  color: var(--primary);
+  cursor: pointer;
+  display: inline-flex;
+}
+
 @media (max-width: 768px) {
   .Slideshow .ItemsSection {
     display: flex;

--- a/webapp/src/components/HomePage/Slideshow/Slideshow.tsx
+++ b/webapp/src/components/HomePage/Slideshow/Slideshow.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react'
-import { HeaderMenu, Header, Button, Loader } from 'decentraland-ui'
+import { HeaderMenu, Header, Button, Loader, Empty } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
 import { Asset } from '../../../modules/asset/types'
@@ -18,6 +18,7 @@ const Slideshow = (props: Props) => {
     title,
     subtitle,
     viewAllTitle,
+    emptyMessage,
     assets,
     isSubHeader,
     isLoading,
@@ -61,6 +62,12 @@ const Slideshow = (props: Props) => {
         />
       )),
     [assetsToRender, handleOnAssetCardClick]
+  )
+
+  const renderEmptyState = () => (
+    <Empty height={186} expand className="empty-state-container">
+      <span>{emptyMessage ? emptyMessage : t('slideshow.empty_message')}</span>
+    </Empty>
   )
 
   const handleOnNextPage = () => {
@@ -124,7 +131,9 @@ const Slideshow = (props: Props) => {
           )
         ) : assets.length > 0 ? (
           renderNfts()
-        ) : null}
+        ) : (
+          renderEmptyState()
+        )}
       </div>
       <>
         <div

--- a/webapp/src/components/HomePage/Slideshow/Slideshow.types.ts
+++ b/webapp/src/components/HomePage/Slideshow/Slideshow.types.ts
@@ -6,6 +6,7 @@ export type Props = {
   title: string
   subtitle?: string
   viewAllTitle?: string
+  emptyMessage?: string
   assets: Asset[]
   view: HomepageView
   isSubHeader?: boolean

--- a/webapp/src/components/RankingsTable/RankingsTable.container.ts
+++ b/webapp/src/components/RankingsTable/RankingsTable.container.ts
@@ -11,7 +11,7 @@ import {
   fetchRankingsRequest,
   FETCH_RANKINGS_REQUEST
 } from '../../modules/analytics/actions'
-import AnalyticsVolumeDayData from './RankingsTable'
+import RankingsTable from './RankingsTable'
 
 const mapState = (state: RootState): MapStateProps => {
   const data = getRankingsData(state)
@@ -26,4 +26,4 @@ const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
     dispatch(fetchRankingsRequest(entity, timeframe, filters))
 })
 
-export default connect(mapState, mapDispatch)(AnalyticsVolumeDayData)
+export default connect(mapState, mapDispatch)(RankingsTable)

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -249,6 +249,9 @@
     "home_trending_items": "Trending items",
     "home_trending_items_subtitle": "Bestselling Items over the last 24hs 🔥",
     "home_trending_items_explore_all": "Explore all",
+    "home_trending_items_empty_message": "We are having troubles fetching the latest trending wearables.{br}{try_again_link} or {explore_all_link}",
+    "home_trending_items_try_again": "Try again",
+    "home_trending_items_explore_all_wearables": "Explore all wearables",
     "home_recently_listed_items_subtitle": "Items being resold",
     "home_latest_sales_items_subtitle": "Items being minted",
     "home_new_items": "Newest items",
@@ -666,7 +669,8 @@
     "sign_in": "Sign In"
   },
   "slideshow": {
-    "view_all": "View All"
+    "view_all": "View All",
+    "empty_message": "There was an error loading these items."
   },
   "highlights": {
     "title": "Highlights"

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -244,6 +244,9 @@
     "home_trending_items": "Items de tendencia",
     "home_trending_items_subtitle": "Items más vendidos en las últimas 24hs 🔥",
     "home_trending_items_explore_all": "Explorar todos",
+    "home_trending_items_empty_message": "Tenemos problemas para obtener los últimos items.{br}{try_again_link} o {explore_all_link}",
+    "home_trending_items_try_again": "Intentar de nuevo",
+    "home_trending_items_explore_all_wearables": "Explorar todos los items",
     "home_recently_listed_items_subtitle": "Items que se revenden",
     "home_latest_sales_items_subtitle": "Items siendo acuñados",
     "home_items": "Últimos items",
@@ -659,7 +662,8 @@
     "sign_in": "iniciar sesión"
   },
   "slideshow": {
-    "view_all": "Ver Todo"
+    "view_all": "Ver Todo",
+    "empty_message": "Hubo un error al cargar los elementos."
   },
   "highlights": {
     "title": "Destacados"

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -245,6 +245,9 @@
     "home_trending_items": "热门商品",
     "home_trending_items_subtitle": "过去 24 小时内的畅销商品 🔥",
     "home_trending_items_explore_all": "探索所有",
+    "home_trending_items_empty_message": "我们无法获取最新流行的可穿戴设备。{br}{try_again_link} 或 {explore_all_link}",
+    "home_trending_items_try_again": "再试一次",
+    "home_trending_items_explore_all_wearables": "探索所有可穿戴设备",
     "home_recently_listed_items_subtitle": "被转售的物品",
     "home_latest_sales_items_subtitle": "正在铸造的物品",
     "home_new_items": "最新商品",
@@ -661,7 +664,8 @@
     "sign_in": "登入"
   },
   "slideshow": {
-    "view_all": "查看全部"
+    "view_all": "查看全部",
+    "empty_message": "加载这些项目时出错。"
   },
   "highlights": {
     "title": "亮点"


### PR DESCRIPTION
Closes #742 

For Trending Wearables:
<img width="1141" alt="image" src="https://user-images.githubusercontent.com/31735779/201126026-29c46bd7-a8f0-44fc-a565-32d3765465ef.png">

For the rest of the sections (the message is configurable):
<img width="1141" alt="image" src="https://user-images.githubusercontent.com/31735779/201126298-8a385b73-460c-4c57-a9ae-1334310a7791.png">

