### PR TITLE
feat: Add rentalStatus params to nfts requests

### DIFF
--- a/webapp/src/components/AssetProviderPage/AssetProviderPage.tsx
+++ b/webapp/src/components/AssetProviderPage/AssetProviderPage.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
+import { RentalStatus } from '@dcl/schemas'
 import { Loader } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import { AssetType } from '../../modules/asset/types'
 import { AssetProvider } from '../AssetProvider'
 import { Props } from './AssetProviderPage.types'
 import styles from './AssetProviderPage.module.css'
@@ -21,7 +23,14 @@ export const NotFound = () => (
 const AssetProviderPage = (props: Props) => {
   const { type, isConnecting, children } = props
   return (
-    <AssetProvider type={type}>
+    <AssetProvider
+      type={type}
+      rentalStatus={
+        type === AssetType.NFT
+          ? [RentalStatus.OPEN, RentalStatus.EXECUTED, RentalStatus.CANCELLED]
+          : undefined
+      }
+    >
       {(asset, order, rental, isAssetLoading) => {
         const isLoading = isConnecting || isAssetLoading
 

--- a/webapp/src/components/ManageAssetPage/Details/Details.tsx
+++ b/webapp/src/components/ManageAssetPage/Details/Details.tsx
@@ -24,7 +24,7 @@ const Info = ({
 )
 
 export const Details = (props: Props) => {
-  const { asset, className } = props
+  const { asset, rental, className } = props
 
   const categoryName = useMemo(() => {
     switch (asset.category) {
@@ -36,6 +36,8 @@ export const Details = (props: Props) => {
         return t('global.nft')
     }
   }, [asset])
+
+  const owner = rental && rental.lessor ? rental.lessor : (asset as NFT).owner!
 
   return (
     <Box
@@ -60,7 +62,7 @@ export const Details = (props: Props) => {
                           t('global.estate')
                         }
                         to={locations.nft(
-                          (asset as NFT).owner!,
+                          owner,
                           asset.data.parcel?.estate!.tokenId
                         )}
                       >
@@ -81,9 +83,9 @@ export const Details = (props: Props) => {
         <Info title={t('manage_asset_page.details.network')}>
           <span>{asset.network}</span>
         </Info>
-        {(asset as NFT).owner ? (
+        {owner ? (
           <Info title={t('manage_asset_page.details.owner')}>
-            <Profile hasPopup={true} address={(asset as NFT).owner} />
+            <Profile hasPopup={true} address={owner} />
           </Info>
         ) : null}
       </div>

--- a/webapp/src/components/ManageAssetPage/Details/Details.types.ts
+++ b/webapp/src/components/ManageAssetPage/Details/Details.types.ts
@@ -1,6 +1,8 @@
+import { RentalListing } from '@dcl/schemas'
 import { Asset } from '../../../modules/asset/types'
 
 export type Props = {
   asset: Asset
+  rental?: RentalListing | null
   className?: string
 }

--- a/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
+++ b/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
@@ -78,172 +78,186 @@ export const ManageAssetPage = (props: Props) => {
           <Section className={styles.main}>
             <AssetProvider
               type={AssetType.NFT}
-              rentalStatus={[RentalStatus.EXECUTED, RentalStatus.OPEN]}
+              rentalStatus={[RentalStatus.EXECUTED, RentalStatus.OPEN, RentalStatus.CANCELLED]}
             >
-              {(asset, order, rental, isLoading) => (
-                <>
-                  <Back className="back" absolute onClick={onBack} />
-                  {isLoading || isConnecting ? <Loading /> : null}
-                  {!isLoading && !asset ? <NotFound /> : null}
-                  {userAddress &&
-                  !isConnecting &&
-                  !isLoading &&
-                  userAddress === asset?.owner ? (
-                    <>
-                      <Narrow className={styles.mainRow}>
-                        <NotMobile>
-                          <Column className={styles.leftMenu}>
-                            {asset && !isLoading ? (
-                              <>
-                                <Map asset={asset} />
-                                <Button
-                                  className={styles.builderButton}
-                                  primary
-                                  onClick={() => handleOpenInBuilder(asset)}
-                                >
-                                  {t('manage_asset_page.open_in_builder')}
-                                </Button>
-                                <Highlights
-                                  className={styles.highlights}
-                                  nft={asset as NFT}
-                                />
-                                <Details
-                                  asset={asset as NFT}
-                                  className={styles.details}
-                                />
-                              </>
-                            ) : null}
-                          </Column>
-                          <Column className={styles.content}>
-                            {asset && !isLoading ? (
-                              <>
-                                <section className={styles.assetDescription}>
-                                  <div
-                                    className={styles.assetDescriptionHeader}
+              {(asset, order, rental, isLoading) => {
+                console.log('asset: ', asset)
+                console.log('rental: ', rental)
+                return (
+                  <>
+                    <Back className="back" absolute onClick={onBack} />
+                    {isLoading || isConnecting ? <Loading /> : null}
+                    {!isLoading && !asset ? <NotFound /> : null}
+                    {userAddress &&
+                    !isConnecting &&
+                    !isLoading &&
+                    ((!!rental && rental.lessor === userAddress) ||
+                      userAddress === asset?.owner) ? (
+                      <>
+                        <Narrow className={styles.mainRow}>
+                          <NotMobile>
+                            <Column className={styles.leftMenu}>
+                              {asset && !isLoading ? (
+                                <>
+                                  <Map asset={asset} />
+                                  <Button
+                                    className={styles.builderButton}
+                                    primary
+                                    onClick={() => handleOpenInBuilder(asset)}
                                   >
-                                    <h1
-                                      className={styles.assetDescriptionTitle}
-                                    >
-                                      {asset?.name}
-                                    </h1>
+                                    {t('manage_asset_page.open_in_builder')}
+                                  </Button>
+                                  <Highlights
+                                    className={styles.highlights}
+                                    nft={asset as NFT}
+                                  />
+                                  <Details
+                                    asset={asset as NFT}
+                                    rental={rental}
+                                    className={styles.details}
+                                  />
+                                </>
+                              ) : null}
+                            </Column>
+                            <Column className={styles.content}>
+                              {asset && !isLoading ? (
+                                <>
+                                  <section className={styles.assetDescription}>
                                     <div
-                                      className={styles.assetDescriptionOptions}
+                                      className={styles.assetDescriptionHeader}
                                     >
-                                      <Button
-                                        className={styles.transfer}
-                                        as={Link}
-                                        disabled={isBeingRented(rental)}
-                                        to={locations.transfer(
-                                          asset.contractAddress,
-                                          asset.tokenId
-                                        )}
-                                        fluid
+                                      <h1
+                                        className={styles.assetDescriptionTitle}
                                       >
-                                        {t('manage_asset_page.transfer')}
-                                      </Button>
+                                        {asset?.name}
+                                      </h1>
+                                      <div
+                                        className={
+                                          styles.assetDescriptionOptions
+                                        }
+                                      >
+                                        <Button
+                                          className={styles.transfer}
+                                          as={Link}
+                                          disabled={isBeingRented(rental)}
+                                          to={locations.transfer(
+                                            asset.contractAddress,
+                                            asset.tokenId
+                                          )}
+                                          fluid
+                                        >
+                                          {t('manage_asset_page.transfer')}
+                                        </Button>
+                                      </div>
                                     </div>
-                                  </div>
-                                  <p className={styles.assetDescriptionContent}>
-                                    {asset?.data.estate?.description ||
-                                      asset?.data.parcel?.description}
-                                  </p>
-                                  {isBeingRented(rental) ? (
-                                    <div className={styles.rentedMessage}>
-                                      {t(
-                                        'manage_asset_page.cant_transfer_rented_land'
-                                      )}
-                                    </div>
-                                  ) : null}
-                                </section>
-                                <Sell
-                                  nft={asset}
-                                  isBeingRented={isBeingRented(rental)}
-                                  order={order}
-                                />
-                                <Rent nft={asset} rental={rental} />
-                              </>
-                            ) : null}
-                          </Column>
-                        </NotMobile>
-                        <Mobile>
-                          <Column className={styles.columnMobile}>
-                            {asset && !isLoading ? (
-                              <>
-                                <Map asset={asset} />
-                                <Button
-                                  className={styles.builderButton}
-                                  primary
-                                  onClick={() => handleOpenInBuilder(asset)}
-                                >
-                                  {t('manage_asset_page.open_in_builder')}
-                                </Button>
-                                <Highlights
-                                  className={styles.highlights}
-                                  nft={asset as NFT}
-                                />
-                                <Details
-                                  asset={asset as NFT}
-                                  className={styles.details}
-                                />
-                              </>
-                            ) : null}
-                            {asset && !isLoading ? (
-                              <>
-                                <section className={styles.assetDescription}>
-                                  <div
-                                    className={styles.assetDescriptionHeader}
+                                    <p
+                                      className={styles.assetDescriptionContent}
+                                    >
+                                      {asset?.data.estate?.description ||
+                                        asset?.data.parcel?.description}
+                                    </p>
+                                    {isBeingRented(rental) ? (
+                                      <div className={styles.rentedMessage}>
+                                        {t(
+                                          'manage_asset_page.cant_transfer_rented_land'
+                                        )}
+                                      </div>
+                                    ) : null}
+                                  </section>
+                                  <Sell
+                                    nft={asset}
+                                    isBeingRented={isBeingRented(rental)}
+                                    order={order}
+                                  />
+                                  <Rent nft={asset} rental={rental} />
+                                </>
+                              ) : null}
+                            </Column>
+                          </NotMobile>
+                          <Mobile>
+                            <Column className={styles.columnMobile}>
+                              {asset && !isLoading ? (
+                                <>
+                                  <Map asset={asset} />
+                                  <Button
+                                    className={styles.builderButton}
+                                    primary
+                                    onClick={() => handleOpenInBuilder(asset)}
                                   >
-                                    <h1
-                                      className={styles.assetDescriptionTitle}
-                                    >
-                                      {asset?.name}
-                                    </h1>
+                                    {t('manage_asset_page.open_in_builder')}
+                                  </Button>
+                                  <Highlights
+                                    className={styles.highlights}
+                                    nft={asset as NFT}
+                                  />
+                                  <Details
+                                    asset={asset as NFT}
+                                    className={styles.details}
+                                  />
+                                </>
+                              ) : null}
+                              {asset && !isLoading ? (
+                                <>
+                                  <section className={styles.assetDescription}>
                                     <div
-                                      className={styles.assetDescriptionOptions}
+                                      className={styles.assetDescriptionHeader}
                                     >
-                                      <Button
-                                        className={styles.transfer}
-                                        as={Link}
-                                        disabled={isBeingRented(rental)}
-                                        to={locations.transfer(
-                                          asset.contractAddress,
-                                          asset.tokenId
-                                        )}
-                                        fluid
+                                      <h1
+                                        className={styles.assetDescriptionTitle}
                                       >
-                                        {t('manage_asset_page.transfer')}
-                                      </Button>
+                                        {asset?.name}
+                                      </h1>
+                                      <div
+                                        className={
+                                          styles.assetDescriptionOptions
+                                        }
+                                      >
+                                        <Button
+                                          className={styles.transfer}
+                                          as={Link}
+                                          disabled={isBeingRented(rental)}
+                                          to={locations.transfer(
+                                            asset.contractAddress,
+                                            asset.tokenId
+                                          )}
+                                          fluid
+                                        >
+                                          {t('manage_asset_page.transfer')}
+                                        </Button>
+                                      </div>
                                     </div>
-                                  </div>
-                                  <p className={styles.assetDescriptionContent}>
-                                    {asset?.data.estate?.description ||
-                                      asset?.data.parcel?.description}
-                                  </p>
-                                  {isBeingRented(rental) ? (
-                                    <div className={styles.rentedMessage}>
-                                      {t(
-                                        'manage_asset_page.cant_transfer_rented_land'
-                                      )}
-                                    </div>
-                                  ) : null}
-                                </section>
-                                <Sell
-                                  nft={asset}
-                                  isBeingRented={isBeingRented(rental)}
-                                  order={order}
-                                />
-                                <Rent nft={asset} rental={rental} />
-                              </>
-                            ) : null}
-                          </Column>
-                        </Mobile>
-                      </Narrow>
-                    </>
-                  ) : (
-                    <Unauthorized />
-                  )}
-                </>
-              )}
+                                    <p
+                                      className={styles.assetDescriptionContent}
+                                    >
+                                      {asset?.data.estate?.description ||
+                                        asset?.data.parcel?.description}
+                                    </p>
+                                    {isBeingRented(rental) ? (
+                                      <div className={styles.rentedMessage}>
+                                        {t(
+                                          'manage_asset_page.cant_transfer_rented_land'
+                                        )}
+                                      </div>
+                                    ) : null}
+                                  </section>
+                                  <Sell
+                                    nft={asset}
+                                    isBeingRented={isBeingRented(rental)}
+                                    order={order}
+                                  />
+                                  <Rent nft={asset} rental={rental} />
+                                </>
+                              ) : null}
+                            </Column>
+                          </Mobile>
+                        </Narrow>
+                      </>
+                    ) : (
+                      <Unauthorized />
+                    )}
+                  </>
+                )
+              }}
             </AssetProvider>
           </Section>
         </ErrorBoundary>

--- a/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
+++ b/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
@@ -78,186 +78,178 @@ export const ManageAssetPage = (props: Props) => {
           <Section className={styles.main}>
             <AssetProvider
               type={AssetType.NFT}
-              rentalStatus={[RentalStatus.EXECUTED, RentalStatus.OPEN, RentalStatus.CANCELLED]}
+              rentalStatus={[
+                RentalStatus.EXECUTED,
+                RentalStatus.OPEN,
+                RentalStatus.CANCELLED
+              ]}
             >
-              {(asset, order, rental, isLoading) => {
-                console.log('asset: ', asset)
-                console.log('rental: ', rental)
-                return (
-                  <>
-                    <Back className="back" absolute onClick={onBack} />
-                    {isLoading || isConnecting ? <Loading /> : null}
-                    {!isLoading && !asset ? <NotFound /> : null}
-                    {userAddress &&
-                    !isConnecting &&
-                    !isLoading &&
-                    ((!!rental && rental.lessor === userAddress) ||
-                      userAddress === asset?.owner) ? (
-                      <>
-                        <Narrow className={styles.mainRow}>
-                          <NotMobile>
-                            <Column className={styles.leftMenu}>
-                              {asset && !isLoading ? (
-                                <>
-                                  <Map asset={asset} />
-                                  <Button
-                                    className={styles.builderButton}
-                                    primary
-                                    onClick={() => handleOpenInBuilder(asset)}
+              {(asset, order, rental, isLoading) => (
+                <>
+                  <Back className="back" absolute onClick={onBack} />
+                  {isLoading || isConnecting ? <Loading /> : null}
+                  {!isLoading && !asset ? <NotFound /> : null}
+                  {userAddress &&
+                  !isConnecting &&
+                  !isLoading &&
+                  ((!!rental && rental.lessor === userAddress) ||
+                    userAddress === asset?.owner) ? (
+                    <>
+                      <Narrow className={styles.mainRow}>
+                        <NotMobile>
+                          <Column className={styles.leftMenu}>
+                            {asset && !isLoading ? (
+                              <>
+                                <Map asset={asset} />
+                                <Button
+                                  className={styles.builderButton}
+                                  primary
+                                  onClick={() => handleOpenInBuilder(asset)}
+                                >
+                                  {t('manage_asset_page.open_in_builder')}
+                                </Button>
+                                <Highlights
+                                  className={styles.highlights}
+                                  nft={asset as NFT}
+                                />
+                                <Details
+                                  asset={asset as NFT}
+                                  rental={rental}
+                                  className={styles.details}
+                                />
+                              </>
+                            ) : null}
+                          </Column>
+                          <Column className={styles.content}>
+                            {asset && !isLoading ? (
+                              <>
+                                <section className={styles.assetDescription}>
+                                  <div
+                                    className={styles.assetDescriptionHeader}
                                   >
-                                    {t('manage_asset_page.open_in_builder')}
-                                  </Button>
-                                  <Highlights
-                                    className={styles.highlights}
-                                    nft={asset as NFT}
-                                  />
-                                  <Details
-                                    asset={asset as NFT}
-                                    rental={rental}
-                                    className={styles.details}
-                                  />
-                                </>
-                              ) : null}
-                            </Column>
-                            <Column className={styles.content}>
-                              {asset && !isLoading ? (
-                                <>
-                                  <section className={styles.assetDescription}>
+                                    <h1
+                                      className={styles.assetDescriptionTitle}
+                                    >
+                                      {asset?.name}
+                                    </h1>
                                     <div
-                                      className={styles.assetDescriptionHeader}
+                                      className={styles.assetDescriptionOptions}
                                     >
-                                      <h1
-                                        className={styles.assetDescriptionTitle}
-                                      >
-                                        {asset?.name}
-                                      </h1>
-                                      <div
-                                        className={
-                                          styles.assetDescriptionOptions
-                                        }
-                                      >
-                                        <Button
-                                          className={styles.transfer}
-                                          as={Link}
-                                          disabled={isBeingRented(rental)}
-                                          to={locations.transfer(
-                                            asset.contractAddress,
-                                            asset.tokenId
-                                          )}
-                                          fluid
-                                        >
-                                          {t('manage_asset_page.transfer')}
-                                        </Button>
-                                      </div>
-                                    </div>
-                                    <p
-                                      className={styles.assetDescriptionContent}
-                                    >
-                                      {asset?.data.estate?.description ||
-                                        asset?.data.parcel?.description}
-                                    </p>
-                                    {isBeingRented(rental) ? (
-                                      <div className={styles.rentedMessage}>
-                                        {t(
-                                          'manage_asset_page.cant_transfer_rented_land'
+                                      <Button
+                                        className={styles.transfer}
+                                        as={Link}
+                                        disabled={isBeingRented(rental)}
+                                        to={locations.transfer(
+                                          asset.contractAddress,
+                                          asset.tokenId
                                         )}
-                                      </div>
-                                    ) : null}
-                                  </section>
-                                  <Sell
-                                    nft={asset}
-                                    isBeingRented={isBeingRented(rental)}
-                                    order={order}
-                                  />
-                                  <Rent nft={asset} rental={rental} />
-                                </>
-                              ) : null}
-                            </Column>
-                          </NotMobile>
-                          <Mobile>
-                            <Column className={styles.columnMobile}>
-                              {asset && !isLoading ? (
-                                <>
-                                  <Map asset={asset} />
-                                  <Button
-                                    className={styles.builderButton}
-                                    primary
-                                    onClick={() => handleOpenInBuilder(asset)}
+                                        fluid
+                                      >
+                                        {t('manage_asset_page.transfer')}
+                                      </Button>
+                                    </div>
+                                  </div>
+                                  <p className={styles.assetDescriptionContent}>
+                                    {asset?.data.estate?.description ||
+                                      asset?.data.parcel?.description}
+                                  </p>
+                                  {isBeingRented(rental) ? (
+                                    <div className={styles.rentedMessage}>
+                                      {t(
+                                        'manage_asset_page.cant_transfer_rented_land'
+                                      )}
+                                    </div>
+                                  ) : null}
+                                </section>
+                                <Sell
+                                  nft={asset}
+                                  isBeingRented={isBeingRented(rental)}
+                                  order={order}
+                                />
+                                <Rent nft={asset} rental={rental} />
+                              </>
+                            ) : null}
+                          </Column>
+                        </NotMobile>
+                        <Mobile>
+                          <Column className={styles.columnMobile}>
+                            {asset && !isLoading ? (
+                              <>
+                                <Map asset={asset} />
+                                <Button
+                                  className={styles.builderButton}
+                                  primary
+                                  onClick={() => handleOpenInBuilder(asset)}
+                                >
+                                  {t('manage_asset_page.open_in_builder')}
+                                </Button>
+                                <Highlights
+                                  className={styles.highlights}
+                                  nft={asset as NFT}
+                                />
+                                <Details
+                                  asset={asset as NFT}
+                                  className={styles.details}
+                                />
+                              </>
+                            ) : null}
+                            {asset && !isLoading ? (
+                              <>
+                                <section className={styles.assetDescription}>
+                                  <div
+                                    className={styles.assetDescriptionHeader}
                                   >
-                                    {t('manage_asset_page.open_in_builder')}
-                                  </Button>
-                                  <Highlights
-                                    className={styles.highlights}
-                                    nft={asset as NFT}
-                                  />
-                                  <Details
-                                    asset={asset as NFT}
-                                    className={styles.details}
-                                  />
-                                </>
-                              ) : null}
-                              {asset && !isLoading ? (
-                                <>
-                                  <section className={styles.assetDescription}>
+                                    <h1
+                                      className={styles.assetDescriptionTitle}
+                                    >
+                                      {asset?.name}
+                                    </h1>
                                     <div
-                                      className={styles.assetDescriptionHeader}
+                                      className={styles.assetDescriptionOptions}
                                     >
-                                      <h1
-                                        className={styles.assetDescriptionTitle}
-                                      >
-                                        {asset?.name}
-                                      </h1>
-                                      <div
-                                        className={
-                                          styles.assetDescriptionOptions
-                                        }
-                                      >
-                                        <Button
-                                          className={styles.transfer}
-                                          as={Link}
-                                          disabled={isBeingRented(rental)}
-                                          to={locations.transfer(
-                                            asset.contractAddress,
-                                            asset.tokenId
-                                          )}
-                                          fluid
-                                        >
-                                          {t('manage_asset_page.transfer')}
-                                        </Button>
-                                      </div>
-                                    </div>
-                                    <p
-                                      className={styles.assetDescriptionContent}
-                                    >
-                                      {asset?.data.estate?.description ||
-                                        asset?.data.parcel?.description}
-                                    </p>
-                                    {isBeingRented(rental) ? (
-                                      <div className={styles.rentedMessage}>
-                                        {t(
-                                          'manage_asset_page.cant_transfer_rented_land'
+                                      <Button
+                                        className={styles.transfer}
+                                        as={Link}
+                                        disabled={isBeingRented(rental)}
+                                        to={locations.transfer(
+                                          asset.contractAddress,
+                                          asset.tokenId
                                         )}
-                                      </div>
-                                    ) : null}
-                                  </section>
-                                  <Sell
-                                    nft={asset}
-                                    isBeingRented={isBeingRented(rental)}
-                                    order={order}
-                                  />
-                                  <Rent nft={asset} rental={rental} />
-                                </>
-                              ) : null}
-                            </Column>
-                          </Mobile>
-                        </Narrow>
-                      </>
-                    ) : (
-                      <Unauthorized />
-                    )}
-                  </>
-                )
-              }}
+                                        fluid
+                                      >
+                                        {t('manage_asset_page.transfer')}
+                                      </Button>
+                                    </div>
+                                  </div>
+                                  <p className={styles.assetDescriptionContent}>
+                                    {asset?.data.estate?.description ||
+                                      asset?.data.parcel?.description}
+                                  </p>
+                                  {isBeingRented(rental) ? (
+                                    <div className={styles.rentedMessage}>
+                                      {t(
+                                        'manage_asset_page.cant_transfer_rented_land'
+                                      )}
+                                    </div>
+                                  ) : null}
+                                </section>
+                                <Sell
+                                  nft={asset}
+                                  isBeingRented={isBeingRented(rental)}
+                                  order={order}
+                                />
+                                <Rent nft={asset} rental={rental} />
+                              </>
+                            ) : null}
+                          </Column>
+                        </Mobile>
+                      </Narrow>
+                    </>
+                  ) : (
+                    <Unauthorized />
+                  )}
+                </>
+              )}
             </AssetProvider>
           </Section>
         </ErrorBoundary>

--- a/webapp/src/modules/vendor/utils.ts
+++ b/webapp/src/modules/vendor/utils.ts
@@ -1,4 +1,4 @@
-import { NFTCategory } from '@dcl/schemas'
+import { NFTCategory, RentalStatus } from '@dcl/schemas'
 import {
   getCategoryFromSection,
   getSearchEmoteCategory,
@@ -13,7 +13,7 @@ export function getFilters(
   vendor: VendorName,
   options: BrowseOptions
 ): NFTsFetchFilters {
-  const { section } = options
+  const { section, address } = options
 
   switch (vendor) {
     case VendorName.DECENTRALAND: {
@@ -55,7 +55,11 @@ export function getFilters(
         wearableGenders,
         contracts,
         network,
-        emotePlayMode
+        emotePlayMode,
+        rentalStatus:
+          isLand && address
+            ? [RentalStatus.OPEN, RentalStatus.EXECUTED]
+            : undefined
       } as NFTsFetchFilters<VendorName.DECENTRALAND>
     }
     default:


### PR DESCRIPTION
Closes #970
Closes #964

- Parcel details: `/v1/nfts?contractAddress=0x25b6b4bac4adb582a0abd475439da6730777fbf7&tokenId=115792089237316195423570985008687907841019819456486779354776098140369474027560&rentalStatus[]=executed&rentalStatus[]=open&rentalStatus[]=cancelled`
- Manage Aset page: `/v1/nfts?contractAddress=0x25b6b4bac4adb582a0abd475439da6730777fbf7&tokenId=115792089237316195423570985008687907841019819456486779354776098140369474027560&rentalStatus[]=executed&rentalStatus[]=open&rentalStatus[]=cancelled`

- My assets
    - On Rent: `/v1/nfts?first=1000&skip=0&sortBy=newest&owner=0x747c6f502272129bf1ba872a1903045b837ee86c&isOnRent=true&isLand=true&rentalStatus=open&rentalStatus=executed`
    - Lands: 
```v1/nfts?first=24&skip=0&sortBy=newest&owner=0x747c6f502272129bf1ba872a1903045b837ee86c&isLand=true&rentalStatus=open&rentalStatus=executed```

- 