### PR TITLE
fix: Various rentals fixes

### DIFF
--- a/webapp/src/components/AssetCard/AssetCard.container.ts
+++ b/webapp/src/components/AssetCard/AssetCard.container.ts
@@ -1,12 +1,10 @@
 import { connect } from 'react-redux'
 import { getLocation } from 'connected-react-router'
+import { RentalStatus } from '@dcl/schemas'
 import { RootState } from '../../modules/reducer'
 import { getData } from '../../modules/order/selectors'
-import { isLand } from '../../modules/nft/utils'
 import { getActiveOrder } from '../../modules/order/utils'
 import { isClaimingBackLandTransactionPending } from '../../modules/ui/browse/selectors'
-import { MapStateProps, OwnProps, MapDispatchProps } from './AssetCard.types'
-import AssetCard from './AssetCard'
 import { getView } from '../../modules/ui/browse/selectors'
 import { getAssetPrice, isNFT } from '../../modules/asset/utils'
 import { locations } from '../../modules/routing/locations'
@@ -16,6 +14,8 @@ import {
   getOpenRentalId
 } from '../../modules/rental/utils'
 import { getRentalById } from '../../modules/rental/selectors'
+import { MapStateProps, OwnProps, MapDispatchProps } from './AssetCard.types'
+import AssetCard from './AssetCard'
 
 const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
   const { order, asset, rental } = ownProps
@@ -27,14 +27,15 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
     price = getAssetPrice(asset, getActiveOrder(asset, orders) || undefined)
   }
 
-  let rentalPricePerDay: string | null = null
   const openRentalId = getOpenRentalId(asset)
-
-  if (!rental && openRentalId && isLand(asset)) {
-    // The price per day is the same in this version of rentals
-    rentalPricePerDay = getMaxPriceOfPeriods(
-      getRentalById(state, openRentalId)!
-    )
+  let rentalPricePerDay: string | null = null
+  if (rental && rental.status === RentalStatus.OPEN) {
+    rentalPricePerDay = getMaxPriceOfPeriods(rental)
+  } else if (!rental && openRentalId) {
+    const rentalOfNFT = getRentalById(state, openRentalId)
+    if (rentalOfNFT && rentalOfNFT.status === RentalStatus.OPEN) {
+      rentalPricePerDay = getMaxPriceOfPeriods(rentalOfNFT)
+    }
   }
 
   return {

--- a/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.container.ts
+++ b/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.container.ts
@@ -15,13 +15,18 @@ import SaleRentActionBox from './SaleRentActionBox'
 
 const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
   const wallet = getWallet(state)
+  const ownedBy = isOwnedBy(
+    ownProps.nft,
+    wallet,
+    ownProps.rental ? ownProps.rental : undefined
+  )
   return {
     wallet,
     authorizations: getAuthorizations(state),
     userHasAlreadyBidsOnNft: wallet
       ? getNFTBids(state).some(bid => bid.bidder === wallet.address)
       : false,
-    isOwner: isOwnedBy(ownProps.nft, wallet)
+    isOwner: ownedBy
   }
 }
 
@@ -29,12 +34,6 @@ const mapDispatch = (
   dispatch: MapDispatch,
   ownProps: OwnProps
 ): MapDispatchProps => ({
-  // TODO: Open the corresponding modals
-  onBid: () => dispatch(openModal('BidModal', { nft: ownProps.nft })),
-  onSell: () =>
-    dispatch(
-      openModal('SellModal', { nft: ownProps.nft, order: ownProps.order })
-    ),
   onRent: (selectedPeriodIndex: number) =>
     dispatch(
       openModal('ConfirmRentModal', {

--- a/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.container.ts
+++ b/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.container.ts
@@ -15,18 +15,17 @@ import SaleRentActionBox from './SaleRentActionBox'
 
 const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
   const wallet = getWallet(state)
-  const ownedBy = isOwnedBy(
-    ownProps.nft,
-    wallet,
-    ownProps.rental ? ownProps.rental : undefined
-  )
   return {
     wallet,
     authorizations: getAuthorizations(state),
     userHasAlreadyBidsOnNft: wallet
       ? getNFTBids(state).some(bid => bid.bidder === wallet.address)
       : false,
-    isOwner: ownedBy
+    isOwner: isOwnedBy(
+      ownProps.nft,
+      wallet,
+      ownProps.rental ? ownProps.rental : undefined
+    )
   }
 }
 

--- a/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.container.ts
+++ b/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.container.ts
@@ -4,7 +4,6 @@ import { getData as getAuthorizations } from 'decentraland-dapps/dist/modules/au
 import { RootState } from '../../../modules/reducer'
 import { getWallet } from '../../../modules/wallet/selectors'
 import { getNFTBids } from '../../../modules/ui/nft/bid/selectors'
-import { isOwnedBy } from '../../../modules/asset/utils'
 import {
   OwnProps,
   MapStateProps,
@@ -13,19 +12,14 @@ import {
 } from './SaleRentActionBox.types'
 import SaleRentActionBox from './SaleRentActionBox'
 
-const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
+const mapState = (state: RootState): MapStateProps => {
   const wallet = getWallet(state)
   return {
     wallet,
     authorizations: getAuthorizations(state),
     userHasAlreadyBidsOnNft: wallet
       ? getNFTBids(state).some(bid => bid.bidder === wallet.address)
-      : false,
-    isOwner: isOwnedBy(
-      ownProps.nft,
-      wallet,
-      ownProps.rental ? ownProps.rental : undefined
-    )
+      : false
   }
 }
 

--- a/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
+++ b/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
@@ -90,7 +90,6 @@ const SaleRentActionBox = ({
     ? getRentalEndDate(rental!)!.getTime()
     : 0
   const rentalHasEnded = isCurrentlyRented && hasRentalEnded(rental!)
-
   return (
     <div className={styles.main}>
       <div className={styles.actions}>
@@ -161,7 +160,9 @@ const SaleRentActionBox = ({
                   <div className={styles.fullWidth}>
                     <Button
                       primary
-                      disabled={isMobileView || isNFTPartOfAState}
+                      disabled={
+                        isMobileView || isNFTPartOfAState || rental !== null
+                      }
                       onClick={handleOnRent}
                       className={styles.rent}
                     >

--- a/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
+++ b/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
@@ -19,6 +19,7 @@ import { getContract } from '../../../modules/contract/utils'
 import { locations } from '../../../modules/routing/locations'
 import { isPartOfEstate } from '../../../modules/nft/utils'
 import { AssetType } from '../../../modules/asset/types'
+import { isOwnedBy } from '../../../modules/asset/utils'
 import { Mana } from '../../Mana'
 import { ManaToFiat } from '../../ManaToFiat'
 import { AuthorizationModal } from '../../AuthorizationModal'
@@ -37,7 +38,6 @@ const SaleRentActionBox = ({
   authorizations,
   order,
   rental,
-  isOwner,
   userHasAlreadyBidsOnNft,
   isRentalsEnabled,
   onRent
@@ -47,6 +47,7 @@ const SaleRentActionBox = ({
     name: getContractNames().RENTALS,
     network: nft.network
   })
+  const isOwner = isOwnedBy(nft, wallet, rental ? rental : undefined)
 
   const [selectedRentalPeriodIndex, setSelectedRentalPeriodIndex] = useState<
     number

--- a/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.types.ts
+++ b/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.types.ts
@@ -2,10 +2,7 @@ import { Dispatch } from 'redux'
 import { Order, RentalListing } from '@dcl/schemas'
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { Authorization } from 'decentraland-dapps/dist/modules/authorization/types'
-import {
-  openModal,
-  OpenModalAction
-} from 'decentraland-dapps/dist/modules/modal/actions'
+import { OpenModalAction } from 'decentraland-dapps/dist/modules/modal/actions'
 import { NFT } from '../../../modules/nft/types'
 
 export type Props = {
@@ -17,8 +14,6 @@ export type Props = {
   userHasAlreadyBidsOnNft: boolean
   isRentalsEnabled: boolean
   isOwner: boolean
-  onBid: typeof openModal
-  onSell: typeof openModal
   onRent: (selectedPeriodIndex: number) => void
 }
 
@@ -27,5 +22,5 @@ export type MapStateProps = Pick<
   Props,
   'wallet' | 'authorizations' | 'userHasAlreadyBidsOnNft' | 'isOwner'
 >
-export type MapDispatchProps = Pick<Props, 'onBid' | 'onSell' | 'onRent'>
+export type MapDispatchProps = Pick<Props, 'onRent'>
 export type MapDispatch = Dispatch<OpenModalAction>

--- a/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.types.ts
+++ b/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.types.ts
@@ -13,14 +13,13 @@ export type Props = {
   order: Order | null
   userHasAlreadyBidsOnNft: boolean
   isRentalsEnabled: boolean
-  isOwner: boolean
   onRent: (selectedPeriodIndex: number) => void
 }
 
 export type OwnProps = Pick<Props, 'nft' | 'rental' | 'order'>
 export type MapStateProps = Pick<
   Props,
-  'wallet' | 'authorizations' | 'userHasAlreadyBidsOnNft' | 'isOwner'
+  'wallet' | 'authorizations' | 'userHasAlreadyBidsOnNft'
 >
 export type MapDispatchProps = Pick<Props, 'onRent'>
 export type MapDispatch = Dispatch<OpenModalAction>

--- a/webapp/src/components/AssetProviderPage/AssetProviderPage.tsx
+++ b/webapp/src/components/AssetProviderPage/AssetProviderPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { RentalStatus } from '@dcl/schemas'
 import { Loader } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
@@ -22,15 +22,16 @@ export const NotFound = () => (
 
 const AssetProviderPage = (props: Props) => {
   const { type, isConnecting, children } = props
+  const rentalStatuses: RentalStatus[] | undefined = useMemo(
+    () =>
+      type === AssetType.NFT
+        ? [RentalStatus.OPEN, RentalStatus.EXECUTED, RentalStatus.CANCELLED]
+        : undefined,
+    [type]
+  )
+
   return (
-    <AssetProvider
-      type={type}
-      rentalStatus={
-        type === AssetType.NFT
-          ? [RentalStatus.OPEN, RentalStatus.EXECUTED, RentalStatus.CANCELLED]
-          : undefined
-      }
-    >
+    <AssetProvider type={type} rentalStatus={rentalStatuses}>
       {(asset, order, rental, isAssetLoading) => {
         const isLoading = isConnecting || isAssetLoading
 

--- a/webapp/src/components/ManageAssetPage/ManageAssetPage.container.ts
+++ b/webapp/src/components/ManageAssetPage/ManageAssetPage.container.ts
@@ -2,12 +2,12 @@ import { Dispatch } from 'redux'
 import { connect } from 'react-redux'
 import { goBack } from '../../modules/routing/actions'
 import { RootState } from '../../modules/reducer'
+import { getWallet, isConnecting } from '../../modules/wallet/selectors'
 import { MapDispatchProps, MapStateProps } from './ManageAssetPage.types'
 import { ManageAssetPage } from './ManageAssetPage'
-import { getAddress, isConnecting } from '../../modules/wallet/selectors'
 
 const mapState = (state: RootState): MapStateProps => ({
-  userAddress: getAddress(state),
+  wallet: getWallet(state),
   isConnecting: isConnecting(state)
 })
 

--- a/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
+++ b/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
@@ -18,6 +18,7 @@ import { builderUrl } from '../../lib/environment'
 import { NFT } from '../../modules/nft/types'
 import { locations } from '../../modules/routing/locations'
 import { isBeingRented } from '../../modules/rental/utils'
+import { isOwnedBy } from '../../modules/asset/utils'
 import { Navbar } from '../Navbar'
 import { ErrorBoundary } from '../AssetPage/ErrorBoundary'
 import { AssetProvider } from '../AssetProvider'
@@ -31,7 +32,6 @@ import { Details } from './Details'
 import { Sell } from './Sell'
 import { Rent } from './Rent'
 import { Map } from './Map'
-import { isOwnedBy } from '../../modules/asset/utils'
 
 const Loading = () => (
   <div className={styles.center}>

--- a/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
+++ b/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
@@ -31,6 +31,7 @@ import { Details } from './Details'
 import { Sell } from './Sell'
 import { Rent } from './Rent'
 import { Map } from './Map'
+import { isOwnedBy } from '../../modules/asset/utils'
 
 const Loading = () => (
   <div className={styles.center}>
@@ -52,7 +53,7 @@ const Unauthorized = () => (
 )
 
 export const ManageAssetPage = (props: Props) => {
-  const { onBack, userAddress, isConnecting } = props
+  const { onBack, wallet, isConnecting } = props
 
   const handleOpenInBuilder = (asset: NFT) => {
     window.location.replace(
@@ -82,11 +83,11 @@ export const ManageAssetPage = (props: Props) => {
                   <Back className="back" absolute onClick={onBack} />
                   {isLoading || isConnecting ? <Loading /> : null}
                   {!isLoading && !asset ? <NotFound /> : null}
-                  {userAddress &&
-                  !isConnecting &&
+                  {!isConnecting &&
                   !isLoading &&
-                  ((!!rental && rental.lessor === userAddress) ||
-                    userAddress === asset?.owner) ? (
+                  asset &&
+                  wallet &&
+                  isOwnedBy(asset, wallet, rental ?? undefined) ? (
                     <>
                       <Narrow className={styles.mainRow}>
                         <NotMobile>

--- a/webapp/src/components/ManageAssetPage/ManageAssetPage.types.ts
+++ b/webapp/src/components/ManageAssetPage/ManageAssetPage.types.ts
@@ -1,8 +1,11 @@
+import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
+
 export type Props = {
   userAddress?: string
+  wallet: Wallet | null
   isConnecting: boolean
   onBack: (location?: string) => void
 }
 
-export type MapStateProps = Pick<Props, 'userAddress' | 'isConnecting'>
+export type MapStateProps = Pick<Props, 'wallet' | 'isConnecting'>
 export type MapDispatchProps = Pick<Props, 'onBack'>

--- a/webapp/src/components/ManageAssetPage/ManageAssetPage.types.ts
+++ b/webapp/src/components/ManageAssetPage/ManageAssetPage.types.ts
@@ -1,7 +1,6 @@
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 
 export type Props = {
-  userAddress?: string
   wallet: Wallet | null
   isConnecting: boolean
   onBack: (location?: string) => void

--- a/webapp/src/components/ManageAssetPage/Rent/Rent.container.ts
+++ b/webapp/src/components/ManageAssetPage/Rent/Rent.container.ts
@@ -3,7 +3,10 @@ import { Dispatch } from 'redux'
 import { RentalListing } from '@dcl/schemas'
 import { openModal } from 'decentraland-dapps/dist/modules/modal/actions'
 import { RootState } from '../../../modules/reducer'
-import { isClaimingBackLandTransactionPending, getLastTransactionForClaimingBackLand} from '../../../modules/ui/browse/selectors'
+import {
+  isClaimingBackLandTransactionPending,
+  getLastTransactionForClaimingBackLand
+} from '../../../modules/ui/browse/selectors'
 import { MapStateProps, MapDispatchProps, OwnProps } from './Rent.types'
 import { RentalModalMetadata } from '../../Modals/RentalListingModal/RentalListingModal.types'
 import { VendorName } from '../../../modules/vendor'
@@ -11,8 +14,14 @@ import { NFT } from '../../../modules/nft/types'
 import { Rent } from './Rent'
 
 const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => ({
-  isClaimingBackLandTransactionPending: isClaimingBackLandTransactionPending(state, ownProps.nft),
-  claimingBackLandTransaction: getLastTransactionForClaimingBackLand(state, ownProps.nft)
+  isClaimingBackLandTransactionPending: isClaimingBackLandTransactionPending(
+    state,
+    ownProps.nft
+  ),
+  claimingBackLandTransaction: getLastTransactionForClaimingBackLand(
+    state,
+    ownProps.nft
+  )
 })
 
 const mapDispatch = (

--- a/webapp/src/components/ManageAssetPage/Rent/Rent.module.css
+++ b/webapp/src/components/ManageAssetPage/Rent/Rent.module.css
@@ -20,6 +20,11 @@
   text-transform: uppercase;
 }
 
+.price {
+  font-size: 16px !important;
+  line-height: 24px !important;
+}
+
 .header {
   display: flex;
   flex-direction: row;
@@ -46,6 +51,7 @@
   font-weight: 400;
   font-size: 15px;
   padding: 12px;
+  margin-bottom: 24px;
 }
 
 .rentMessage {
@@ -73,7 +79,7 @@
 .columnContent {
   font-style: normal;
   font-weight: 600;
-  font-size: 21px;
+  font-size: 16px;
   color: var(--primary-text);
   width: 100%;
   display: flex;
@@ -83,7 +89,7 @@
 .date {
   margin-top: 5px;
   color: #736e7d;
-  font-size: 18px;
+  font-size: 15px;
 }
 
 .actionButtonBasicPadding{
@@ -125,6 +131,9 @@
     flex-direction: column;
     margin-top: 0;
   }
+  .column {
+    margin-top: 20px;
+  }  
   .box {
     margin-top: 12px;
   }

--- a/webapp/src/components/ManageAssetPage/Rent/Rent.tsx
+++ b/webapp/src/components/ManageAssetPage/Rent/Rent.tsx
@@ -15,7 +15,7 @@ import { locations } from '../../../modules/routing/locations'
 import { VendorName } from '../../../modules/vendor'
 import { Section } from '../../../modules/vendor/decentraland'
 import {
-  getRentalChosenPeriod,
+  getMaxPriceOfPeriods,
   getRentalEndDate,
   hasRentalEnded
 } from '../../../modules/rental/utils'
@@ -92,13 +92,6 @@ export const Rent = (props: Props) => {
         claimingBackLandTransaction.chainId
       )
     : ''
-  const chosenPeriodPrice: string | null = useMemo(
-    () =>
-      rental && rental.startedAt
-        ? getRentalChosenPeriod(rental).pricePerDay
-        : null,
-    [rental]
-  )
   const rentalEndDate: Date | null = useMemo(
     () => (rental && rental.startedAt ? getRentalEndDate(rental) : null),
     [rental]
@@ -228,8 +221,13 @@ export const Rent = (props: Props) => {
                   {t('manage_asset_page.rent.price')}
                 </div>
                 <div className={styles.columnContent}>
-                  <Mana withTooltip size={'medium'} network={rental.network}>
-                    {formatWeiMANA(chosenPeriodPrice!)}
+                  <Mana
+                    withTooltip
+                    size={'medium'}
+                    className={styles.price}
+                    network={rental.network}
+                  >
+                    {formatWeiMANA(getMaxPriceOfPeriods(rental))}
                   </Mana>
                   <span>/{t('global.day')}</span>
                 </div>
@@ -283,7 +281,7 @@ export const Rent = (props: Props) => {
                       {t('manage_asset_page.rent.end_date')}
                     </div>
                     <div className={styles.columnContent}>
-                      {formatDistance(new Date(), rentalEndDate!, {
+                      {formatDistance(rentalEndDate!, new Date(), {
                         addSuffix: true
                       })}
                     </div>

--- a/webapp/src/modules/asset/utils.ts
+++ b/webapp/src/modules/asset/utils.ts
@@ -1,4 +1,4 @@
-import { NFTCategory, Order } from '@dcl/schemas'
+import { NFTCategory, Order, RentalListing } from '@dcl/schemas'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { NFT } from '../nft/types'
@@ -65,9 +65,16 @@ export function getAssetPrice(asset: Asset, order?: Order) {
     : null
 }
 
-export function isOwnedBy(asset: Asset, wallet: Wallet | null) {
+export function isOwnedBy(
+  asset: Asset,
+  wallet: Wallet | null,
+  rental?: RentalListing
+) {
   const assetAddress = 'owner' in asset ? asset.owner : asset.creator
-  return addressEquals(wallet?.address, assetAddress)
+  return (
+    addressEquals(wallet?.address, assetAddress) ||
+    addressEquals(wallet?.address, rental?.lessor ?? undefined)
+  )
 }
 
 export function isNFT(asset: Asset): asset is NFT {


### PR DESCRIPTION
This PR does the following:
- In `AssetCard.container.ts` we weren't considering when the rental is not null. This was changed to consider it.
- Changed `ownedBy` to receive a rental in order to check for the lessor to ensure that the user is the owner of the asset.
- Fixes the owner check in the `SaleRentActionBox.tsx` so it considers the owner as the lessor.
- Blocks the `Rent` button when the asset is on rent (when a rental exists).
- Changes the `AssetProviderPage` to have a memoized version of the status array to prevent multiple requests.
- Fixes the styling between the message and the rental data in the `Rent.tsx` component.