### PR TITLE
fix: Various sell component fixes

### DIFF
--- a/webapp/src/components/CancelSalePage/CancelSalePage.container.ts
+++ b/webapp/src/components/CancelSalePage/CancelSalePage.container.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import { push } from 'connected-react-router'
+import { goBack, push } from 'connected-react-router'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { RootState } from '../../modules/reducer'
 import { getLoading } from '../../modules/order/selectors'
@@ -7,6 +7,7 @@ import {
   cancelOrderRequest,
   CANCEL_ORDER_REQUEST
 } from '../../modules/order/actions'
+import { getIsRentalsEnabled } from '../../modules/features/selectors'
 import {
   MapStateProps,
   MapDispatchProps,
@@ -15,11 +16,13 @@ import {
 import CancelSalePage from './CancelSalePage'
 
 const mapState = (state: RootState): MapStateProps => ({
-  isLoading: isLoadingType(getLoading(state), CANCEL_ORDER_REQUEST)
+  isLoading: isLoadingType(getLoading(state), CANCEL_ORDER_REQUEST),
+  isRentalsEnabled: getIsRentalsEnabled(state)
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
   onNavigate: path => dispatch(push(path)),
+  onGoBack: () => dispatch(goBack()),
   onCancelOrder: (order, nft) => dispatch(cancelOrderRequest(order, nft))
 })
 

--- a/webapp/src/components/CancelSalePage/CancelSalePage.types.ts
+++ b/webapp/src/components/CancelSalePage/CancelSalePage.types.ts
@@ -7,12 +7,17 @@ import {
 
 export type Props = {
   isLoading: boolean
+  isRentalsEnabled: boolean
   onCancelOrder: typeof cancelOrderRequest
   onNavigate: (path: string) => void
+  onGoBack: (path: string) => void
 }
 
-export type MapStateProps = Pick<Props, 'isLoading'>
-export type MapDispatchProps = Pick<Props, 'onNavigate' | 'onCancelOrder'>
+export type MapStateProps = Pick<Props, 'isLoading' | 'isRentalsEnabled'>
+export type MapDispatchProps = Pick<
+  Props,
+  'onNavigate' | 'onCancelOrder' | 'onGoBack'
+>
 export type MapDispatch = Dispatch<
   CallHistoryMethodAction | CancelOrderRequestAction
 >

--- a/webapp/src/components/ManageAssetPage/Sell/Sell.container.ts
+++ b/webapp/src/components/ManageAssetPage/Sell/Sell.container.ts
@@ -16,6 +16,10 @@ const mapDispatch = (
   onEditOrder: () =>
     dispatch(
       push(locations.sell(ownProps.nft.contractAddress, ownProps.nft.tokenId))
+    ),
+  onCancelOrder: () =>
+    dispatch(
+      push(locations.cancel(ownProps.nft.contractAddress, ownProps.nft.tokenId))
     )
 })
 

--- a/webapp/src/components/ManageAssetPage/Sell/Sell.tsx
+++ b/webapp/src/components/ManageAssetPage/Sell/Sell.tsx
@@ -17,7 +17,8 @@ const Sell = (props: Props) => {
     isBeingRented,
     order,
     nft: { contractAddress, tokenId },
-    onEditOrder
+    onEditOrder,
+    onCancelOrder
   } = props
 
   return (
@@ -30,11 +31,18 @@ const Sell = (props: Props) => {
         </h1>
         <div className={styles.action}>
           {order ? (
-            <IconButton
-              iconName="pencil"
-              disabled={isBeingRented}
-              onClick={onEditOrder}
-            />
+            <>
+              <IconButton
+                iconName="pencil"
+                disabled={isBeingRented}
+                onClick={onEditOrder}
+              />
+              <IconButton
+                iconName="trash alternate"
+                disabled={isBeingRented}
+                onClick={onCancelOrder}
+              />
+            </>
           ) : (
             <Button
               className={styles.sellButton}

--- a/webapp/src/components/ManageAssetPage/Sell/Sell.types.ts
+++ b/webapp/src/components/ManageAssetPage/Sell/Sell.types.ts
@@ -7,10 +7,11 @@ export type Props = {
   order?: Order | null
   isBeingRented: boolean
   onEditOrder: () => void
+  onCancelOrder: () => void
 }
 
 export type MapStateProps = {}
-export type MapDispatchProps = Pick<Props, 'onEditOrder'>
+export type MapDispatchProps = Pick<Props, 'onEditOrder' | 'onCancelOrder'>
 
 export type OwnProps = Pick<
   Props,

--- a/webapp/src/components/SellPage/SellModal/SellModal.tsx
+++ b/webapp/src/components/SellPage/SellModal/SellModal.tsx
@@ -40,7 +40,9 @@ const SellModal = (props: Props) => {
     authorizations,
     isLoading,
     isCreatingOrder,
+    isRentalsEnabled,
     onNavigate,
+    onGoBack,
     onCreateOrder
   } = props
 
@@ -148,7 +150,9 @@ const SellModal = (props: Props) => {
           <Button
             as="div"
             onClick={() =>
-              onNavigate(locations.nft(nft.contractAddress, nft.tokenId))
+              isRentalsEnabled
+                ? onGoBack()
+                : onNavigate(locations.nft(nft.contractAddress, nft.tokenId))
             }
           >
             {t('global.cancel')}

--- a/webapp/src/components/SellPage/SellModal/SellModal.types.ts
+++ b/webapp/src/components/SellPage/SellModal/SellModal.types.ts
@@ -11,6 +11,8 @@ export type Props = {
   authorizations: Authorization[]
   isLoading: boolean
   isCreatingOrder: boolean
+  isRentalsEnabled: boolean
   onNavigate: (path: string) => void
+  onGoBack: () => void
   onCreateOrder: typeof createOrderRequest
 }

--- a/webapp/src/components/SellPage/SellPage.container.ts
+++ b/webapp/src/components/SellPage/SellPage.container.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import { push } from 'connected-react-router'
+import { goBack, push } from 'connected-react-router'
 import { FETCH_AUTHORIZATIONS_REQUEST } from 'decentraland-dapps/dist/modules/authorization/actions'
 import {
   getData as getAuthorizations,
@@ -7,19 +7,28 @@ import {
 } from 'decentraland-dapps/dist/modules/authorization/selectors'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { RootState } from '../../modules/reducer'
-import { createOrderRequest, CREATE_ORDER_REQUEST } from '../../modules/order/actions'
-import {getLoading as getLoadingOrders } from '../../modules/order/selectors'
+import {
+  createOrderRequest,
+  CREATE_ORDER_REQUEST
+} from '../../modules/order/actions'
+import { getLoading as getLoadingOrders } from '../../modules/order/selectors'
+import { getIsRentalsEnabled } from '../../modules/features/selectors'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './SellPage.types'
 import SellPage from './SellPage'
 
 const mapState = (state: RootState): MapStateProps => ({
   authorizations: getAuthorizations(state),
-  isLoading: isLoadingType(getLoadingAuthorizations(state), FETCH_AUTHORIZATIONS_REQUEST),
-  isCreatingOrder: isLoadingType(getLoadingOrders(state), CREATE_ORDER_REQUEST)
+  isLoading: isLoadingType(
+    getLoadingAuthorizations(state),
+    FETCH_AUTHORIZATIONS_REQUEST
+  ),
+  isCreatingOrder: isLoadingType(getLoadingOrders(state), CREATE_ORDER_REQUEST),
+  isRentalsEnabled: getIsRentalsEnabled(state)
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
   onNavigate: path => dispatch(push(path)),
+  onGoBack: () => dispatch(goBack()),
   onCreateOrder: (nft, price, expiresAt) =>
     dispatch(createOrderRequest(nft, price, expiresAt))
 })

--- a/webapp/src/components/SellPage/SellPage.tsx
+++ b/webapp/src/components/SellPage/SellPage.tsx
@@ -14,6 +14,8 @@ const SellPage = (props: Props) => {
     authorizations,
     isLoading,
     isCreatingOrder,
+    isRentalsEnabled,
+    onGoBack,
     onNavigate,
     onCreateOrder
   } = props
@@ -32,6 +34,8 @@ const SellPage = (props: Props) => {
                   authorizations={authorizations}
                   isLoading={isLoading}
                   isCreatingOrder={isCreatingOrder}
+                  isRentalsEnabled={isRentalsEnabled}
+                  onGoBack={onGoBack}
                   onNavigate={onNavigate}
                   onCreateOrder={onCreateOrder}
                 />

--- a/webapp/src/components/SellPage/SellPage.types.ts
+++ b/webapp/src/components/SellPage/SellPage.types.ts
@@ -10,15 +10,20 @@ export type Props = {
   authorizations: Authorization[]
   isLoading: boolean
   isCreatingOrder: boolean
+  isRentalsEnabled: boolean
   onCreateOrder: typeof createOrderRequest
   onNavigate: (path: string) => void
+  onGoBack: () => void
 }
 
 export type MapStateProps = Pick<
   Props,
-  'authorizations' | 'isLoading' | 'isCreatingOrder'
+  'authorizations' | 'isLoading' | 'isCreatingOrder' | 'isRentalsEnabled'
 >
-export type MapDispatchProps = Pick<Props, 'onNavigate' | 'onCreateOrder'>
+export type MapDispatchProps = Pick<
+  Props,
+  'onNavigate' | 'onCreateOrder' | 'onGoBack'
+>
 export type MapDispatch = Dispatch<
   CallHistoryMethodAction | CreateOrderRequestAction
 >


### PR DESCRIPTION
This PR fixes the following:
- Adds functionality to go back when clicking on cancel on the sell or cancel order page.
- Adds an icon to cancel a sell order (the functionality was missing).