### PR TITLE
fix: Don't open in builder if not claimed

### DIFF
--- a/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
+++ b/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import {
   Back,
@@ -9,7 +9,9 @@ import {
   Narrow,
   NotMobile,
   Page,
-  Section
+  Popup,
+  Section,
+  useMobileMediaQuery
 } from 'decentraland-ui'
 import { NFTCategory, RentalStatus } from '@dcl/schemas'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
@@ -55,7 +57,7 @@ const Unauthorized = () => (
 export const ManageAssetPage = (props: Props) => {
   const { onBack, wallet, isConnecting } = props
 
-  const handleOpenInBuilder = (asset: NFT) => {
+  const handleOpenInBuilder = useCallback((asset: NFT) => {
     window.location.replace(
       `${builderUrl}/land/${
         asset.category === NFTCategory.ESTATE
@@ -63,12 +65,13 @@ export const ManageAssetPage = (props: Props) => {
           : `${asset.data.parcel?.x},${asset.data.parcel?.y}`
       }`
     )
-  }
+  }, [])
 
   const rentalStatus = useMemo(
     () => [RentalStatus.EXECUTED, RentalStatus.OPEN, RentalStatus.CANCELLED],
     []
   )
+  const isMobileView = useMobileMediaQuery()
 
   return (
     <>
@@ -95,13 +98,48 @@ export const ManageAssetPage = (props: Props) => {
                             {asset && !isLoading ? (
                               <>
                                 <Map asset={asset} />
-                                <Button
-                                  className={styles.builderButton}
-                                  primary
-                                  onClick={() => handleOpenInBuilder(asset)}
-                                >
-                                  {t('manage_asset_page.open_in_builder')}
-                                </Button>
+                                <Popup
+                                  content={
+                                    'This action is locked until the rent has finished and (or) the Land has been claimed back'
+                                  }
+                                  position="top left"
+                                  on={isMobileView ? 'click' : 'hover'}
+                                  disabled={
+                                    !(
+                                      rental !== null &&
+                                      isLandLocked(
+                                        wallet.address,
+                                        rental,
+                                        asset
+                                      )
+                                    )
+                                  }
+                                  trigger={
+                                    <span>
+                                      {
+                                        <Button
+                                          className={styles.builderButton}
+                                          primary
+                                          disabled={
+                                            rental !== null &&
+                                            isLandLocked(
+                                              wallet.address,
+                                              rental,
+                                              asset
+                                            )
+                                          }
+                                          onClick={() =>
+                                            handleOpenInBuilder(asset)
+                                          }
+                                        >
+                                          {t(
+                                            'manage_asset_page.open_in_builder'
+                                          )}
+                                        </Button>
+                                      }
+                                    </span>
+                                  }
+                                />
                                 <Highlights
                                   className={styles.highlights}
                                   nft={asset as NFT}

--- a/webapp/src/components/ManageAssetPage/Rent/Rent.tsx
+++ b/webapp/src/components/ManageAssetPage/Rent/Rent.tsx
@@ -4,11 +4,10 @@ import { Link } from 'react-router-dom'
 import intlFormat from 'date-fns/intlFormat'
 import formatDistance from 'date-fns/formatDistance'
 import { RentalListingPeriod } from '@dcl/schemas'
-import { Button, Popup } from 'decentraland-ui'
+import { Button, Popup, useMobileMediaQuery } from 'decentraland-ui'
 import { T, t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { getTransactionHref } from 'decentraland-dapps/dist/modules/transaction/utils'
 import { Profile } from 'decentraland-dapps/dist/containers'
-import { isMobile } from 'decentraland-dapps/dist/lib/utils'
 import { formatWeiMANA } from '../../../lib/mana'
 import { AssetType } from '../../../modules/asset/types'
 import { locations } from '../../../modules/routing/locations'
@@ -64,7 +63,7 @@ export const Rent = (props: Props) => {
     claimingBackLandTransaction,
     wallet
   } = props
-  const isMobileView = isMobile()
+  const isMobileView = useMobileMediaQuery()
 
   const wrapDisabledMobileButton = useCallback(
     trigger => {

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -818,6 +818,7 @@
   },
   "manage_asset_page": {
     "open_in_builder": "Open in builder",
+    "land_is_locked": "This action is locked until the rent has finished and the Land has been claimed back.",
     "transfer": "Transfer",
     "cant_transfer_rented_land": "Transferring is paused while the LAND is being rented or hasn't been claimed back.",
     "sell": {

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -811,6 +811,7 @@
   },
   "manage_asset_page": {
     "open_in_builder": "Abrir en el builder",
+    "land_is_locked": "Esta acción no será posible de realizar hasta que la renta haya finalizado y la tierra haya sido reclamada.",
     "transfer": "Transferir",
     "cant_transfer_rented_land": "La transferencia de tierra está en pausa mientras la tierra está siendo rentada o no se haya reclamado.",
     "sell": {

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -813,6 +813,7 @@
   },
   "manage_asset_page": {
     "open_in_builder": "在 Builder 中打开",
+    "land_is_locked": "此操作将被锁定，直到租金完成并且土地已被收回。",
     "transfer": "转移",
     "cant_transfer_rented_land": "当 LAND 正在出租或尚未收回时，转移将暂停。",
     "sell": {


### PR DESCRIPTION
This PR does two things:
- Disallows using the "open in builder" button until the Land is claimed, as the builder won't show the Land you don't currently own.
- Changes the mobile hook to `useMobileMediaQuery`.

Closes #1000