### PR TITLE
fix: View the LAND available to buy as default

### DIFF
--- a/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.tsx
+++ b/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.tsx
@@ -69,7 +69,15 @@ const NFTFilters = (props: Props) => {
     ]
   } else {
     orderByDropdownOptions = [
+      {
+        value: SortBy.RECENTLY_LISTED,
+        text: t('filters.recently_listed')
+      },
       { value: SortBy.RECENTLY_SOLD, text: t('filters.recently_sold') },
+      {
+        value: SortBy.CHEAPEST,
+        text: t('filters.cheapest')
+      },
       { value: SortBy.NEWEST, text: t('filters.newest') },
       { value: SortBy.NAME, text: t('filters.name') }
     ]
@@ -95,17 +103,6 @@ const NFTFilters = (props: Props) => {
   const shouldShowOnSaleFilter =
     (isRentalsEnabled && ((section && !isLandSection(section!)) || !section)) ||
     !isRentalsEnabled
-
-  if (onlyOnSale) {
-    orderByDropdownOptions.unshift({
-      value: SortBy.RECENTLY_LISTED,
-      text: t('filters.recently_listed')
-    })
-    orderByDropdownOptions.unshift({
-      value: SortBy.CHEAPEST,
-      text: t('filters.cheapest')
-    })
-  }
 
   const sortBy = orderByDropdownOptions.find(
     option => option.value === props.sortBy

--- a/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.tsx
+++ b/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.tsx
@@ -69,15 +69,6 @@ const NFTFilters = (props: Props) => {
     ]
   } else {
     orderByDropdownOptions = [
-      {
-        value: SortBy.RECENTLY_LISTED,
-        text: t('filters.recently_listed')
-      },
-      { value: SortBy.RECENTLY_SOLD, text: t('filters.recently_sold') },
-      {
-        value: SortBy.CHEAPEST,
-        text: t('filters.cheapest')
-      },
       { value: SortBy.NEWEST, text: t('filters.newest') },
       { value: SortBy.NAME, text: t('filters.name') }
     ]
@@ -103,6 +94,21 @@ const NFTFilters = (props: Props) => {
   const shouldShowOnSaleFilter =
     (isRentalsEnabled && ((section && !isLandSection(section!)) || !section)) ||
     !isRentalsEnabled
+
+  if (onlyOnSale) {
+    orderByDropdownOptions.unshift({
+      value: SortBy.RECENTLY_LISTED,
+      text: t('filters.recently_listed')
+    })
+    orderByDropdownOptions.unshift({
+      value: SortBy.RECENTLY_SOLD,
+      text: t('filters.recently_sold')
+    })
+    orderByDropdownOptions.unshift({
+      value: SortBy.CHEAPEST,
+      text: t('filters.cheapest')
+    })
+  }
 
   const sortBy = orderByDropdownOptions.find(
     option => option.value === props.sortBy
@@ -144,9 +150,14 @@ const NFTFilters = (props: Props) => {
 
   const handleIsMapChange = useCallback(
     (isMap: boolean) => {
-      onBrowse({ isMap, isFullscreen: isMap, search: '' })
+      onBrowse({
+        isMap,
+        isFullscreen: isMap,
+        search: '',
+        onlyOnSale: (!onlyOnSale && !onlyOnRent) || onlyOnSale
+      })
     },
-    [onBrowse]
+    [onBrowse, onlyOnSale, onlyOnRent]
   )
 
   const handleOrderByDropdownChange = useCallback(


### PR DESCRIPTION
When getting for the first time into the LAND section of the Marketplace, the user has to unselect the map to go to the list view. Clicking the list button makes the user use a not available filter for `All Land`, so now whenever a user comes in for the first time, they'll load the `Available to buy` land first.
Closes #993 