### PR TITLE
fix: Update rental price checks

### DIFF
--- a/webapp/src/components/ManageAssetPage/Rent/Rent.module.css
+++ b/webapp/src/components/ManageAssetPage/Rent/Rent.module.css
@@ -38,6 +38,10 @@
   margin-top: 30px;
 }
 
+.content:empty {
+  margin-top: 0px;
+}
+
 .summary {
   display: flex;
   flex-direction: row;

--- a/webapp/src/components/Modals/RentalListingModal/ConfirmationStep/ConfirmationStep.tsx
+++ b/webapp/src/components/Modals/RentalListingModal/ConfirmationStep/ConfirmationStep.tsx
@@ -53,7 +53,9 @@ const ConfirmationStep = (props: Props) => {
               </div>
             </div>
             <div className={styles.noticeRow}>
-              <div className={styles.noticeLabel}>Periods</div>
+              <div className={styles.noticeLabel}>
+                {t('rental_modal.confirmation_step.periods')}
+              </div>
               <div className={styles.noticeText}>
                 {periods.map(period => daysByPeriod[period]).join(' / ')}&nbsp;
                 {t('global.days')}

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -803,6 +803,7 @@
     },
     "confirmation_step": {
       "title": "Confirm Listing",
+      "periods": "Periods",
       "notice_line_one": "Review and confirm the price and rent periods you selected.",
       "notice_line_two": "Listing is free of charge, but editing or canceling a listing will require sending a transaction, and you will need to cover its cost.",
       "price_per_day": "Price per day",

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -796,6 +796,7 @@
     },
     "confirmation_step": {
       "title": "Confirm Listing",
+      "periods": "Períodos",
       "notice_line_one": "Revisa y confirma el precio y los períodos de alquiler que has seleccionado.",
       "notice_line_two": "Poner en alquiler es gratis, pero editar o cancelar el clasificado una vez hecho requerirá que envies una transacción, y deberas cubrir el costo de la misma.",
       "price_per_day": "Precio por día",

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -798,6 +798,7 @@
     },
     "confirmation_step": {
       "title": "确认上市",
+      "periods": "时期",
       "notice_line_one": "查看并确认您选择的价格和租期。",
       "notice_line_two": "列表是免费的，但编辑或取消列表将需要发送交易，您需要支付其费用。",
       "price_per_day": "每天的价格",


### PR DESCRIPTION
This PR fixes an issue where there was an error verifying the old price and re-works the way we check if the old price and the new one are the same, being as strict as possible to avoid wrongful user updates that cost gas.

Closes #1026 
Closes #1028