### PR TITLE
fix: SaleRentActionBox failing to load if not logged in

### DIFF
--- a/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
+++ b/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
@@ -46,10 +46,6 @@ const SaleRentActionBox = ({
 }: Props) => {
   const isMobileView = isMobile()
   const isRentalOpen = isRentalListingOpen(rental)
-  const rentals = getContract({
-    name: getContractNames().RENTALS,
-    network: nft.network
-  })
   const isOwner = isOwnedBy(nft, wallet, rental ? rental : undefined)
 
   const [selectedRentalPeriodIndex, setSelectedRentalPeriodIndex] = useState<
@@ -74,17 +70,26 @@ const SaleRentActionBox = ({
   const canBid = !isOwner && isBiddable && !userHasAlreadyBidsOnNft
   const isCurrentlyRented = isRentalListingExecuted(rental)
   const [showAuthorizationModal, setShowAuthorizationModal] = useState(false)
-  const contractNames = getContractNames()
-  const mana = getContract({
-    name: contractNames.MANA,
-    network: nft.network
-  })
+  const authorization = useMemo(() => {
+    if (!wallet) {
+      return null
+    }
 
-  const authorization = getContractAuthorization(
-    wallet!.address,
-    rentals?.address,
-    mana ? { ...mana, name: ContractName.MANAToken } : undefined
-  )
+    const contractNames = getContractNames()
+    const mana = getContract({
+      name: contractNames.MANA,
+      network: nft.network
+    })
+    const rentals = getContract({
+      name: getContractNames().RENTALS,
+      network: nft.network
+    })
+    return getContractAuthorization(
+      wallet.address,
+      rentals?.address,
+      mana ? { ...mana, name: ContractName.MANAToken } : undefined
+    )
+  }, [wallet, getContract, nft.network])
 
   const handleOnRent = useCallback(() => {
     if (!!authorization && hasAuthorization(authorizations, authorization)) {


### PR DESCRIPTION
This PR fixes an issue which prevented users that were not logged into view the Parcel or Estate details because there was no wallet object being instantiated.
The PR also condenses all the contract gathering procedure into a `useMemo` function to perform it once.

Closes #1052 