### PR TITLE
fix: Prevent cancelling transfer or bidding

### DIFF
--- a/webapp/src/components/BidPage/BidModal/BidModal.tsx
+++ b/webapp/src/components/BidPage/BidModal/BidModal.tsx
@@ -152,6 +152,7 @@ const BidModal = (props: Props) => {
         <div className="buttons">
           <Button
             as="div"
+            disabled={isLoading || isPlacingBid}
             onClick={() =>
               onNavigate(locations.nft(nft.contractAddress, nft.tokenId))
             }

--- a/webapp/src/components/TransferPage/TransferPage.container.ts
+++ b/webapp/src/components/TransferPage/TransferPage.container.ts
@@ -15,7 +15,7 @@ import {
 import TransferPage from './TransferPage'
 
 const mapState = (state: RootState): MapStateProps => ({
-  isTransfering: isLoadingType(getLoading(state), TRANSFER_NFT_REQUEST)
+  isTransferring: isLoadingType(getLoading(state), TRANSFER_NFT_REQUEST)
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({

--- a/webapp/src/components/TransferPage/TransferPage.tsx
+++ b/webapp/src/components/TransferPage/TransferPage.tsx
@@ -14,7 +14,7 @@ import { Props } from './TransferPage.types'
 import './TransferPage.css'
 
 const TransferPage = (props: Props) => {
-  const { onNavigate, onTransfer, isTransfering } = props
+  const { onNavigate, onTransfer, isTransferring } = props
 
   const [address, setAddress] = useState('')
   const [isInvalidAddress, setIsInvalidAddress] = useState(false)
@@ -28,7 +28,7 @@ const TransferPage = (props: Props) => {
             <AssetProviderPage type={AssetType.NFT}>
               {(nft, order) => {
                 let subtitle
-                let isDisabled = !address || isInvalidAddress || isTransfering
+                let isDisabled = !address || isInvalidAddress || isTransferring
                 let canTransfer = true
                 const subtitleClasses = ['subtitle']
                 const name = getAssetName(nft)
@@ -102,6 +102,7 @@ const TransferPage = (props: Props) => {
                       <div className="buttons">
                         <Button
                           as="div"
+                          disabled={isTransferring}
                           onClick={() =>
                             onNavigate(
                               locations.nft(nft.contractAddress, nft.tokenId)
@@ -113,7 +114,7 @@ const TransferPage = (props: Props) => {
                         <ChainButton
                           type="submit"
                           primary
-                          loading={isTransfering}
+                          loading={isTransferring}
                           disabled={isDisabled}
                           chainId={nft.chainId}
                         >

--- a/webapp/src/components/TransferPage/TransferPage.types.ts
+++ b/webapp/src/components/TransferPage/TransferPage.types.ts
@@ -7,11 +7,11 @@ import {
 
 export type Props = {
   onTransfer: typeof transferNFTRequest
-  isTransfering: boolean
+  isTransferring: boolean
   onNavigate: (path: string) => void
 }
 
-export type MapStateProps = Pick<Props, 'isTransfering'>
+export type MapStateProps = Pick<Props, 'isTransferring'>
 export type MapDispatchProps = Pick<Props, 'onNavigate' | 'onTransfer'>
 export type MapDispatch = Dispatch<
   CallHistoryMethodAction | TransferNFTRequestAction


### PR DESCRIPTION
This PR disables the `Cancel` button in the Transferring and Bid pages.