### PR TITLE
fix: Wrong owner for rented LAND in the SalesAndRentBox

### DIFF
--- a/webapp/src/components/AssetPage/BaseDetail/BaseDetail.tsx
+++ b/webapp/src/components/AssetPage/BaseDetail/BaseDetail.tsx
@@ -11,6 +11,7 @@ import './BaseDetail.css'
 
 const BaseDetail = ({
   asset,
+  rental,
   assetImage,
   badges,
   left,
@@ -37,7 +38,7 @@ const BaseDetail = ({
               <div className="action-box">{actions}</div>
             ) : null}
             {showDetails ? (
-              <Details asset={asset} />
+              <Details rental={rental} asset={asset} />
             ) : (
               <Box className="box" childrenClassName="box-children">
                 {box}

--- a/webapp/src/components/AssetPage/BaseDetail/BaseDetail.types.ts
+++ b/webapp/src/components/AssetPage/BaseDetail/BaseDetail.types.ts
@@ -1,8 +1,10 @@
+import { RentalListing } from '@dcl/schemas'
 import { ReactNode } from 'react'
 import { Asset } from '../../../modules/asset/types'
 
 export type Props = {
   asset: Asset
+  rental?: RentalListing
   assetImage: ReactNode
   isOnSale: boolean
   badges: ReactNode

--- a/webapp/src/components/AssetPage/EstateDetail/EstateDetail.tsx
+++ b/webapp/src/components/AssetPage/EstateDetail/EstateDetail.tsx
@@ -35,6 +35,7 @@ const EstateDetail = ({ nft, order, rental, isRentalsEnabled }: Props) => {
     <BaseDetail
       className="EstateDetail"
       asset={nft}
+      rental={rental ?? undefined}
       showDetails={isRentalsEnabled && isLand(nft)}
       assetImage={
         <>

--- a/webapp/src/components/AssetPage/ParcelDetail/ParcelDetail.tsx
+++ b/webapp/src/components/AssetPage/ParcelDetail/ParcelDetail.tsx
@@ -30,6 +30,7 @@ const ParcelDetail = ({ nft, order, rental, isRentalsEnabled }: Props) => {
   return (
     <BaseDetail
       asset={nft}
+      rental={rental ?? undefined}
       assetImage={
         <AssetImage asset={nft} isDraggable withNavigation hasPopup />
       }

--- a/webapp/src/components/AssetPage/RentalHistory/RentalHistory.tsx
+++ b/webapp/src/components/AssetPage/RentalHistory/RentalHistory.tsx
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom'
 import React, { useState, useEffect } from 'react'
 import { RentalListing, RentalStatus } from '@dcl/schemas'
 import {
@@ -11,11 +10,9 @@ import {
   Row
 } from 'decentraland-ui'
 import { T, t } from 'decentraland-dapps/dist/modules/translation/utils'
-import { Profile } from 'decentraland-dapps/dist/containers'
 import dateFnsFormat from 'date-fns/format'
 
 import { capitalize } from '../../../lib/text'
-import { locations } from '../../../modules/routing/locations'
 import { rentalsAPI } from '../../../modules/vendor/decentraland/rentals/api'
 import { formatDistanceToNow } from '../../../lib/date'
 import { formatWeiMANA } from '../../../lib/mana'
@@ -23,6 +20,7 @@ import { getRentalChosenPeriod } from '../../../modules/rental/utils'
 import { Mana } from '../../Mana'
 import { Props } from './RentalHistory.types'
 import styles from './RentalHistory.module.css'
+import { LinkedProfile } from '../../LinkedProfile'
 
 const INPUT_FORMAT = 'PPP'
 const WEEK_IN_MILLISECONDS = 7 * 24 * 60 * 60 * 1000
@@ -101,14 +99,10 @@ const RentalHistory = (props: Props) => {
                 {rentals.map(rental => (
                   <Table.Row key={rental.id}>
                     <Table.Cell>
-                      <Link to={locations.account(rental.lessor!)}>
-                        <Profile address={rental.lessor ?? '0x0'} />
-                      </Link>
+                      <LinkedProfile address={rental.lessor ?? '0x0'} />
                     </Table.Cell>
                     <Table.Cell>
-                      <Link to={locations.account(rental.tenant!)}>
-                        <Profile address={rental.tenant ?? '0x1'} />
-                      </Link>
+                      <LinkedProfile address={rental.tenant ?? '0x1'} />
                     </Table.Cell>
                     <Table.Cell title={formatDateTitle(rental.startedAt!)}>
                       {formatEventDate(rental.startedAt ?? 0)}

--- a/webapp/src/components/AssetPage/RentalHistory/RentalHistory.tsx
+++ b/webapp/src/components/AssetPage/RentalHistory/RentalHistory.tsx
@@ -18,9 +18,9 @@ import { formatDistanceToNow } from '../../../lib/date'
 import { formatWeiMANA } from '../../../lib/mana'
 import { getRentalChosenPeriod } from '../../../modules/rental/utils'
 import { Mana } from '../../Mana'
+import { LinkedProfile } from '../../LinkedProfile'
 import { Props } from './RentalHistory.types'
 import styles from './RentalHistory.module.css'
-import { LinkedProfile } from '../../LinkedProfile'
 
 const INPUT_FORMAT = 'PPP'
 const WEEK_IN_MILLISECONDS = 7 * 24 * 60 * 60 * 1000
@@ -99,10 +99,10 @@ const RentalHistory = (props: Props) => {
                 {rentals.map(rental => (
                   <Table.Row key={rental.id}>
                     <Table.Cell>
-                      <LinkedProfile address={rental.lessor ?? '0x0'} />
+                      <LinkedProfile address={rental.lessor!} />
                     </Table.Cell>
                     <Table.Cell>
-                      <LinkedProfile address={rental.tenant ?? '0x1'} />
+                      <LinkedProfile address={rental.tenant!} />
                     </Table.Cell>
                     <Table.Cell title={formatDateTitle(rental.startedAt!)}>
                       {formatEventDate(rental.startedAt ?? 0)}

--- a/webapp/src/components/AssetPage/TransactionHistory/TransactionHistory.tsx
+++ b/webapp/src/components/AssetPage/TransactionHistory/TransactionHistory.tsx
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom'
 import React, { useState, useEffect } from 'react'
 import { Sale } from '@dcl/schemas'
 import {
@@ -11,14 +10,13 @@ import {
   Row
 } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
-import { Profile } from 'decentraland-dapps/dist/containers'
 import dateFnsFormat from 'date-fns/format'
 
 import { Mana } from '../../Mana'
-import { locations } from '../../../modules/routing/locations'
 import { saleAPI } from '../../../modules/vendor/decentraland'
 import { formatDistanceToNow } from '../../../lib/date'
 import { formatWeiMANA } from '../../../lib/mana'
+import { LinkedProfile } from '../../LinkedProfile'
 import { Props } from './TransactionHistory.types'
 import './TransactionHistory.css'
 
@@ -105,14 +103,10 @@ const TransactionHistory = (props: Props) => {
                 {sales.map(sale => (
                   <Table.Row key={sale.id}>
                     <Table.Cell>
-                      <Link to={locations.account(sale.seller)}>
-                        <Profile address={sale.seller} />
-                      </Link>
+                      <LinkedProfile address={sale.seller} />
                     </Table.Cell>
                     <Table.Cell>
-                      <Link to={locations.account(sale.buyer)}>
-                        <Profile address={sale.buyer} />
-                      </Link>
+                      <LinkedProfile address={sale.buyer} />
                     </Table.Cell>
                     <Table.Cell>{t(`global.${sale.type}`)}</Table.Cell>
                     <Table.Cell title={formatDateTitle(sale.timestamp)}>

--- a/webapp/src/components/Bid/Bid.tsx
+++ b/webapp/src/components/Bid/Bid.tsx
@@ -2,12 +2,12 @@ import React, { useCallback, useState } from 'react'
 import { ethers } from 'ethers'
 import { Link } from 'react-router-dom'
 import { Loader, Stats, Button } from 'decentraland-ui'
-import { Profile } from 'decentraland-dapps/dist/containers'
 import { T, t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { locations } from '../../modules/routing/locations'
 import { addressEquals } from '../../modules/wallet/utils'
 import { AssetType } from '../../modules/asset/types'
 import { AssetProvider } from '../AssetProvider'
+import { LinkedProfile } from '../LinkedProfile'
 import { AssetImage } from '../AssetImage'
 import { Mana } from '../Mana'
 import { AcceptButton } from './AcceptButton'
@@ -71,9 +71,7 @@ const Bid = (props: Props) => {
           <div className="wrapper">
             <div className="info">
               <Stats className="from" title={t('bid.from')}>
-                <Link to={locations.account(bid.bidder)}>
-                  <Profile address={bid.bidder} />
-                </Link>
+                <LinkedProfile address={bid.bidder} />
               </Stats>
               <Stats className="price" title={t('bid.price')}>
                 <Mana network={bid.network}>{formatWeiMANA(bid.price)}</Mana>

--- a/webapp/src/components/LinkedProfile/LinkedProfile.tsx
+++ b/webapp/src/components/LinkedProfile/LinkedProfile.tsx
@@ -1,23 +1,13 @@
 import { Link } from 'react-router-dom'
 import { Profile } from 'decentraland-dapps/dist/containers'
 import { locations } from '../../modules/routing/locations'
-import { AssetType } from '../../modules/asset/types'
-import { VendorName } from '../../modules/vendor'
-import { Section } from '../../modules/vendor/decentraland'
 import { Props } from './LinkedProfile.types'
 
 export const LinkedProfile = (props: Props) => {
-  const { address, className } = props
+  const { address, className, browseOptions } = props
 
   return (
-    <Link
-      className={className}
-      to={locations.account(address, {
-        assetType: AssetType.NFT,
-        vendor: VendorName.DECENTRALAND,
-        section: Section.ALL
-      })}
-    >
+    <Link className={className} to={locations.account(address, browseOptions)}>
       <Profile {...props} />
     </Link>
   )

--- a/webapp/src/components/LinkedProfile/LinkedProfile.tsx
+++ b/webapp/src/components/LinkedProfile/LinkedProfile.tsx
@@ -1,0 +1,24 @@
+import { Link } from 'react-router-dom'
+import { Profile } from 'decentraland-dapps/dist/containers'
+import { locations } from '../../modules/routing/locations'
+import { AssetType } from '../../modules/asset/types'
+import { VendorName } from '../../modules/vendor'
+import { Section } from '../../modules/vendor/decentraland'
+import { Props } from './LinkedProfile.types'
+
+export const LinkedProfile = (props: Props) => {
+  const { address, className } = props
+
+  return (
+    <Link
+      className={className}
+      to={locations.account(address, {
+        assetType: AssetType.NFT,
+        vendor: VendorName.DECENTRALAND,
+        section: Section.ALL
+      })}
+    >
+      <Profile {...props} />
+    </Link>
+  )
+}

--- a/webapp/src/components/LinkedProfile/LinkedProfile.types.ts
+++ b/webapp/src/components/LinkedProfile/LinkedProfile.types.ts
@@ -1,0 +1,7 @@
+import { ProfileProps } from 'decentraland-ui/dist/components/Profile/Profile'
+import { BrowseOptions } from '../../modules/routing/types'
+
+export type Props = ProfileProps & {
+  className?: string
+  browseOptions?: BrowseOptions
+}

--- a/webapp/src/components/LinkedProfile/index.ts
+++ b/webapp/src/components/LinkedProfile/index.ts
@@ -1,0 +1,1 @@
+export { LinkedProfile } from './LinkedProfile'

--- a/webapp/src/components/ManageAssetPage/Details/Details.tsx
+++ b/webapp/src/components/ManageAssetPage/Details/Details.tsx
@@ -2,13 +2,13 @@ import { useMemo, memo } from 'react'
 import { Link } from 'react-router-dom'
 import { NFTCategory } from '@dcl/schemas'
 import classNames from 'classnames'
-import { Profile } from 'decentraland-dapps/dist/containers'
 import { T, t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { NFT } from '../../../modules/nft/types'
 import { locations } from '../../../modules/routing/locations'
 import { Box } from '../../AssetBrowse/Box'
 import { Props } from './Details.types'
 import styles from './Details.module.css'
+import { LinkedProfile } from '../../LinkedProfile'
 
 const Info = ({
   title,
@@ -38,6 +38,10 @@ export const Details = (props: Props) => {
   }, [asset])
 
   const owner = rental && rental.lessor ? rental.lessor : (asset as NFT).owner!
+  console.log('Owner', owner)
+  console.log('NFT owner', (asset as NFT).owner)
+  console.log('NFT', asset)
+  console.log('Rental', rental)
 
   return (
     <Box
@@ -85,7 +89,7 @@ export const Details = (props: Props) => {
         </Info>
         {owner ? (
           <Info title={t('manage_asset_page.details.owner')}>
-            <Profile hasPopup={true} address={owner} />
+            <LinkedProfile hasPopup={true} address={owner} />
           </Info>
         ) : null}
       </div>

--- a/webapp/src/components/ManageAssetPage/Details/Details.tsx
+++ b/webapp/src/components/ManageAssetPage/Details/Details.tsx
@@ -6,9 +6,9 @@ import { T, t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { NFT } from '../../../modules/nft/types'
 import { locations } from '../../../modules/routing/locations'
 import { Box } from '../../AssetBrowse/Box'
+import { LinkedProfile } from '../../LinkedProfile'
 import { Props } from './Details.types'
 import styles from './Details.module.css'
-import { LinkedProfile } from '../../LinkedProfile'
 
 const Info = ({
   title,

--- a/webapp/src/components/ManageAssetPage/Details/Details.tsx
+++ b/webapp/src/components/ManageAssetPage/Details/Details.tsx
@@ -38,10 +38,6 @@ export const Details = (props: Props) => {
   }, [asset])
 
   const owner = rental && rental.lessor ? rental.lessor : (asset as NFT).owner!
-  console.log('Owner', owner)
-  console.log('NFT owner', (asset as NFT).owner)
-  console.log('NFT', asset)
-  console.log('Rental', rental)
 
   return (
     <Box

--- a/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
+++ b/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
@@ -219,6 +219,7 @@ export const ManageAssetPage = (props: Props) => {
                                 />
                                 <Details
                                   asset={asset as NFT}
+                                  rental={rental}
                                   className={styles.details}
                                 />
                               </>

--- a/webapp/src/components/ManageAssetPage/Rent/Rent.tsx
+++ b/webapp/src/components/ManageAssetPage/Rent/Rent.tsx
@@ -7,12 +7,8 @@ import { RentalListingPeriod } from '@dcl/schemas'
 import { Button, Popup, useMobileMediaQuery } from 'decentraland-ui'
 import { T, t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { getTransactionHref } from 'decentraland-dapps/dist/modules/transaction/utils'
-import { Profile } from 'decentraland-dapps/dist/containers'
 import { formatWeiMANA } from '../../../lib/mana'
-import { AssetType } from '../../../modules/asset/types'
 import { locations } from '../../../modules/routing/locations'
-import { VendorName } from '../../../modules/vendor'
-import { Section } from '../../../modules/vendor/decentraland'
 import {
   canBeClaimed,
   canCreateANewRental,
@@ -24,6 +20,7 @@ import {
   isRentalListingOpen
 } from '../../../modules/rental/utils'
 import { isLand, isParcel } from '../../../modules/nft/utils'
+import { LinkedProfile } from '../../LinkedProfile'
 import { Mana } from '../../Mana'
 import { IconButton } from '../IconButton'
 import styles from './Rent.module.css'
@@ -37,22 +34,6 @@ const sortPeriods = (a: RentalListingPeriod, b: RentalListingPeriod) => {
   } else {
     return -1
   }
-}
-
-const LinkedProfile = ({ address }: { address: string }) => {
-  return (
-    <Link
-      to={locations.account(address, {
-        assetType: AssetType.NFT,
-        vendor: VendorName.DECENTRALAND,
-        section: Section.ALL
-      })}
-    >
-      <span className={styles.profile}>
-        <Profile hasPopup={true} address={address} />
-      </span>
-    </Link>
-  )
 }
 
 export const Rent = (props: Props) => {

--- a/webapp/src/components/RankingsTable/RankingCollectorRow/RankingCollectorRow.tsx
+++ b/webapp/src/components/RankingsTable/RankingCollectorRow/RankingCollectorRow.tsx
@@ -89,13 +89,11 @@ const RankingCollectorRow = ({ entity }: Props) => {
           <>
             <Table.Cell width={4}>
               <div className="rankings-collector-cell">
-                <Link to={locations.account(collectorAddress)}>
-                  <LinkedProfile
-                    address={collectorAddress}
-                    inline={false}
-                    size="large"
-                  />
-                </Link>
+                <LinkedProfile
+                  address={collectorAddress}
+                  inline={false}
+                  size="large"
+                />
               </div>
             </Table.Cell>
             <Table.Cell width={2}>{entity.purchases}</Table.Cell>

--- a/webapp/src/components/RankingsTable/RankingCollectorRow/RankingCollectorRow.tsx
+++ b/webapp/src/components/RankingsTable/RankingCollectorRow/RankingCollectorRow.tsx
@@ -3,10 +3,10 @@ import { Link } from 'react-router-dom'
 import { Loader, Mana, Mobile, NotMobile, Table } from 'decentraland-ui'
 import { Network } from '@dcl/schemas'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
-import { Profile } from 'decentraland-dapps/dist/containers'
 import { formatWeiMANA } from '../../../lib/mana'
 import { locations } from '../../../modules/routing/locations'
 import { ManaToFiat } from '../../ManaToFiat'
+import { LinkedProfile } from '../../LinkedProfile'
 import { Props } from './RankingCollectorRow.types'
 import './RankingCollectorRow.css'
 
@@ -19,7 +19,11 @@ const RankingCollectorRow = ({ entity }: Props) => {
         <div>
           <div className="rankings-collector-data">
             <Link to={locations.account(collectorAddress)}>
-              <Profile address={collectorAddress} inline={false} size="large" />
+              <LinkedProfile
+                address={collectorAddress}
+                inline={false}
+                size="large"
+              />
             </Link>
             <span className="rankings-collector-items-collected">
               {t('home_page.analytics.rankings.collectors.collected_items', {
@@ -86,7 +90,7 @@ const RankingCollectorRow = ({ entity }: Props) => {
             <Table.Cell width={4}>
               <div className="rankings-collector-cell">
                 <Link to={locations.account(collectorAddress)}>
-                  <Profile
+                  <LinkedProfile
                     address={collectorAddress}
                     inline={false}
                     size="large"

--- a/webapp/src/components/RankingsTable/RankingCreatorRow/RankingCreatorRow.tsx
+++ b/webapp/src/components/RankingsTable/RankingCreatorRow/RankingCreatorRow.tsx
@@ -1,11 +1,9 @@
 import React, { useState } from 'react'
-import { Link } from 'react-router-dom'
 import { Network } from '@dcl/schemas'
 import { Loader, Mana, Mobile, NotMobile, Table } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
-import { Profile } from 'decentraland-dapps/dist/containers'
+import { LinkedProfile } from '../../LinkedProfile'
 import { formatWeiMANA } from '../../../lib/mana'
-import { locations } from '../../../modules/routing/locations'
 import { ManaToFiat } from '../../ManaToFiat'
 import { AssetType } from '../../../modules/asset/types'
 import { Section } from '../../../modules/vendor/decentraland'
@@ -20,14 +18,15 @@ const RankingCreatorRow = ({ entity }: Props) => {
       <div className="RankingCreatorRow rankings-creator-cell">
         <div>
           <div className="rankings-creator-data">
-            <Link
-              to={locations.account(creatorAddress, {
+            <LinkedProfile
+              address={creatorAddress}
+              inline={false}
+              size="large"
+              browseOptions={{
                 assetType: AssetType.ITEM,
                 section: Section.WEARABLES
-              })}
-            >
-              <Profile address={creatorAddress} inline={false} size="large" />
-            </Link>
+              }}
+            />
             <span className="rankings-creator-collections-created">
               {t('home_page.analytics.rankings.creators.collections_created', {
                 collections: entity.collections
@@ -88,18 +87,15 @@ const RankingCreatorRow = ({ entity }: Props) => {
           <>
             <Table.Cell width={5}>
               <div className="rankings-creator-cell">
-                <Link
-                  to={locations.account(creatorAddress, {
+                <LinkedProfile
+                  address={creatorAddress}
+                  inline={false}
+                  size="large"
+                  browseOptions={{
                     assetType: AssetType.ITEM,
                     section: Section.WEARABLES
-                  })}
-                >
-                  <Profile
-                    address={creatorAddress}
-                    inline={false}
-                    size="large"
-                  />
-                </Link>
+                  }}
+                />
               </div>
             </Table.Cell>
             <Table.Cell width={3}>{entity.collections}</Table.Cell>

--- a/webapp/src/components/RankingsTable/RankingItemRow/RankingItemRow.tsx
+++ b/webapp/src/components/RankingsTable/RankingItemRow/RankingItemRow.tsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom'
 import { Loader, Mana, Mobile, NotMobile, Table } from 'decentraland-ui'
 import { Item, NFTCategory } from '@dcl/schemas'
 import { t, T } from 'decentraland-dapps/dist/modules/translation/utils'
-import { Profile } from 'decentraland-dapps/dist/containers'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
 import { formatWeiMANA } from '../../../lib/mana'
 import { AssetType } from '../../../modules/asset/types'
@@ -14,6 +13,7 @@ import { AssetProvider } from '../../AssetProvider'
 import { ManaToFiat } from '../../ManaToFiat'
 import RarityBadge from '../../RarityBadge'
 import { AssetImage } from '../../AssetImage'
+import { LinkedProfile } from '../../LinkedProfile'
 import { Props } from './RankingItemRow.types'
 import './RankingItemRow.css'
 
@@ -59,13 +59,11 @@ const RankingItemRow = ({ entity }: Props) => {
                       values={{
                         creator: (
                           <span className="rankings-item-data-creator">
-                            <Link to={locations.account(item.creator)}>
-                              <Profile
-                                address={item.creator}
-                                textOnly
-                                inline={false}
-                              />
-                            </Link>
+                            <LinkedProfile
+                              address={item.creator}
+                              textOnly
+                              inline={false}
+                            />
                           </span>
                         )
                       }}
@@ -168,13 +166,11 @@ const RankingItemRow = ({ entity }: Props) => {
                   values={{
                     creator: (
                       <span className="rankings-item-data-creator">
-                        <Link to={locations.account(item.creator)}>
-                          <Profile
-                            address={item.creator}
-                            textOnly
-                            inline={false}
-                          />
-                        </Link>
+                        <LinkedProfile
+                          address={item.creator}
+                          textOnly
+                          inline={false}
+                        />
                       </span>
                     )
                   }}

--- a/webapp/src/components/RecentlySoldTable/RecentlySoldTable.tsx
+++ b/webapp/src/components/RecentlySoldTable/RecentlySoldTable.tsx
@@ -15,15 +15,14 @@ import {
 import { Item, NFTCategory, Sale, SaleSortBy } from '@dcl/schemas'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
 import { T, t } from 'decentraland-dapps/dist/modules/translation/utils'
-import { Profile } from 'decentraland-dapps/dist/containers'
 import { useScrollSectionIntoView } from '../../modules/ui/utils'
 import { AssetProvider } from '../AssetProvider'
 import { AssetType } from '../../modules/asset/types'
 import { formatWeiMANA } from '../../lib/mana'
-import { locations } from '../../modules/routing/locations'
 import { ManaToFiat } from '../ManaToFiat'
 import { VendorName } from '../../modules/vendor/types'
 import { NFT } from '../../modules/nft/types'
+import { LinkedProfile } from '../LinkedProfile'
 import { AssetImage } from '../AssetImage'
 import { formatDistanceToNow } from '../../lib/date'
 import { Props } from './RecentlySoldTable.types'
@@ -279,31 +278,23 @@ const RecentlySoldTable = (props: Props) => {
                           <span>
                             {t('home_page.recently_sold.wearables.seller')}
                           </span>
-                          <Link
-                            to={locations.account(sale.seller)}
+                          <LinkedProfile
                             className="account-link"
-                          >
-                            <Profile
-                              address={sale.seller}
-                              textOnly
-                              inline={false}
-                            />
-                          </Link>
+                            address={sale.seller}
+                            textOnly
+                            inline={false}
+                          />
                         </div>
                         <div>
                           <span>
                             {t('home_page.recently_sold.wearables.buyer')}
                           </span>
-                          <Link
-                            to={locations.account(sale.seller)}
+                          <LinkedProfile
                             className="account-link"
-                          >
-                            <Profile
-                              address={sale.buyer}
-                              textOnly
-                              inline={false}
-                            />
-                          </Link>
+                            address={sale.buyer}
+                            textOnly
+                            inline={false}
+                          />
                         </div>
                       </>
                     ) : null}
@@ -340,13 +331,11 @@ const RecentlySoldTable = (props: Props) => {
                         values={{
                           creator: (
                             <span className="rankings-item-data-creator">
-                              <Link to={locations.account(item.creator)}>
-                                <Profile
-                                  address={item.creator}
-                                  textOnly
-                                  inline={false}
-                                />
-                              </Link>
+                              <LinkedProfile
+                                address={item.creator}
+                                textOnly
+                                inline={false}
+                              />
                             </span>
                           )
                         }}
@@ -359,17 +348,20 @@ const RecentlySoldTable = (props: Props) => {
               ) : null}
             </Table.Cell>
             <Table.Cell width={2}>
-              <Link
-                to={locations.account(sale.seller)}
+              <LinkedProfile
                 className="account-link"
-              >
-                <Profile address={sale.seller} textOnly inline={false} />
-              </Link>
+                address={sale.seller}
+                textOnly
+                inline={false}
+              />
             </Table.Cell>
             <Table.Cell width={2}>
-              <Link to={locations.account(sale.buyer)} className="account-link">
-                <Profile address={sale.buyer} textOnly inline={false} />
-              </Link>
+              <LinkedProfile
+                className="account-link"
+                address={sale.buyer}
+                textOnly
+                inline={false}
+              />
             </Table.Cell>
             <Table.Cell width={1}>{t(`global.${sale.type}`)}</Table.Cell>
             <Table.Cell width={2}>
@@ -454,31 +446,23 @@ const RecentlySoldTable = (props: Props) => {
                           <span>
                             {t('home_page.recently_sold.wearables.seller')}
                           </span>
-                          <Link
-                            to={locations.account(sale.seller)}
+                          <LinkedProfile
                             className="account-link"
-                          >
-                            <Profile
-                              address={sale.seller}
-                              textOnly
-                              inline={false}
-                            />
-                          </Link>
+                            address={sale.seller}
+                            textOnly
+                            inline={false}
+                          />
                         </div>
                         <div>
                           <span>
                             {t('home_page.recently_sold.wearables.buyer')}
                           </span>
-                          <Link
-                            to={locations.account(sale.seller)}
+                          <LinkedProfile
                             className="account-link"
-                          >
-                            <Profile
-                              address={sale.buyer}
-                              textOnly
-                              inline={false}
-                            />
-                          </Link>
+                            address={sale.buyer}
+                            textOnly
+                            inline={false}
+                          />
                         </div>
                       </>
                     ) : null}
@@ -514,17 +498,20 @@ const RecentlySoldTable = (props: Props) => {
               ) : null}
             </Table.Cell>
             <Table.Cell width={2}>
-              <Link
-                to={locations.account(sale.seller)}
+              <LinkedProfile
                 className="account-link"
-              >
-                <Profile address={sale.seller} textOnly inline={false} />
-              </Link>
+                address={sale.seller}
+                textOnly
+                inline={false}
+              />
             </Table.Cell>
             <Table.Cell width={2}>
-              <Link to={locations.account(sale.buyer)} className="account-link">
-                <Profile address={sale.buyer} textOnly inline={false} />
-              </Link>
+              <LinkedProfile
+                className="account-link"
+                address={sale.buyer}
+                textOnly
+                inline={false}
+              />
             </Table.Cell>
             <Table.Cell width={1}>{t(`global.${sale.type}`)}</Table.Cell>
             <Table.Cell width={2}>

--- a/webapp/src/components/Sales/Activity/Activity.tsx
+++ b/webapp/src/components/Sales/Activity/Activity.tsx
@@ -9,14 +9,12 @@ import {
   Pagination,
   Table
 } from 'decentraland-ui'
-import { Profile } from 'decentraland-dapps/dist/containers'
-import { Link } from 'react-router-dom'
 import { SALES_PER_PAGE } from '../../../modules/routing/utils'
-import AssetCell from '../../OnSaleOrRentList/AssetCell'
-import { Props } from './Activity.types'
-import { Mana } from '../../Mana'
 import { formatWeiMANA } from '../../../lib/mana'
-import { locations } from '../../../modules/routing/locations'
+import AssetCell from '../../OnSaleOrRentList/AssetCell'
+import { LinkedProfile } from '../../LinkedProfile'
+import { Mana } from '../../Mana'
+import { Props } from './Activity.types'
 import './Activity.css'
 
 const Activity = ({
@@ -83,9 +81,7 @@ const Activity = ({
                           })}
                         </Table.Cell>
                         <Table.Cell>
-                          <Link to={locations.account(sale.buyer)}>
-                            <Profile address={sale.buyer} inline />
-                          </Link>
+                          <LinkedProfile address={sale.buyer} inline />
                         </Table.Cell>
                         <Table.Cell>{t(`global.${sale.type}`)}</Table.Cell>
                         <Table.Cell>


### PR DESCRIPTION
This PR fixes the owner label in the `SalesAndRentBox` and adds a `LinkedProfile` component that is used all through the application.
The issue was caused because we weren't giving the rental to the BaseDetail component.

Closes #1068