### PR TITLE
fix: Parse current mana into wei to compare prices

### DIFF
--- a/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
+++ b/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
@@ -112,22 +112,21 @@ const SaleRentActionBox = ({
     () =>
       !!rental &&
       !!currentMana &&
-      ethers.BigNumber.from(currentMana).gte(
-        ethers.utils.formatEther(
-          ethers.BigNumber.from(
-            rental.periods[selectedRentalPeriodIndex].pricePerDay
-          ).mul(rental.periods[selectedRentalPeriodIndex].maxDays)
-        )
-      ),
+      currentMana >=
+        Number(
+          ethers.utils.formatEther(
+            ethers.BigNumber.from(
+              rental.periods[selectedRentalPeriodIndex].pricePerDay
+            ).mul(rental.periods[selectedRentalPeriodIndex].maxDays)
+          )
+        ),
     [rental, currentMana, selectedRentalPeriodIndex]
   )
   const hasEnoughManaToBuy = useMemo(
     () =>
       !!order &&
       !!currentMana &&
-      ethers.BigNumber.from(currentMana).gte(
-        ethers.utils.formatEther(order.price)
-      ),
+      currentMana >= Number(ethers.utils.formatEther(order.price)),
     [order, currentMana]
   )
 
@@ -204,7 +203,7 @@ const SaleRentActionBox = ({
                   }
                   position="top center"
                   on={isMobileView ? 'click' : 'hover'}
-                  disabled={!isMobileView && !isNFTPartOfAState}
+                  disabled={!isNFTPartOfAState}
                   trigger={
                     <div className={styles.fullWidth}>
                       <Button

--- a/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
+++ b/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
@@ -112,13 +112,12 @@ const SaleRentActionBox = ({
     () =>
       !!rental &&
       !!currentMana &&
-      currentMana >=
-        Number(
-          ethers.utils.formatEther(
-            ethers.BigNumber.from(
-              rental.periods[selectedRentalPeriodIndex].pricePerDay
-            ).mul(rental.periods[selectedRentalPeriodIndex].maxDays)
-          )
+      ethers.utils
+        .parseEther(currentMana.toString())
+        .gte(
+          ethers.BigNumber.from(
+            rental.periods[selectedRentalPeriodIndex].pricePerDay
+          ).mul(rental.periods[selectedRentalPeriodIndex].maxDays)
         ),
     [rental, currentMana, selectedRentalPeriodIndex]
   )
@@ -126,7 +125,7 @@ const SaleRentActionBox = ({
     () =>
       !!order &&
       !!currentMana &&
-      currentMana >= Number(ethers.utils.formatEther(order.price)),
+      ethers.utils.parseEther(currentMana.toString()).gte(order.price),
     [order, currentMana]
   )
 


### PR DESCRIPTION
This PR changes the way we were comparing rental and order prices so the website doesn't crash when converting a floating point number into a big number.