### PR TITLE
fix: loading indicator missplaced in the asset page

### DIFF
--- a/webapp/src/components/AssetPage/AssetPage.tsx
+++ b/webapp/src/components/AssetPage/AssetPage.tsx
@@ -26,7 +26,7 @@ const AssetPage = ({ type, isRentalsEnabled, onBack }: Props) => {
         <ErrorBoundary>
           <Section>
             <Column>
-              <AssetProviderPage type={type}>
+              <AssetProviderPage type={type} fullWidth>
                 {(asset, order, rental) => (
                   <>
                     <Back

--- a/webapp/src/components/AssetProviderPage/AssetProviderPage.module.css
+++ b/webapp/src/components/AssetProviderPage/AssetProviderPage.module.css
@@ -9,3 +9,7 @@
   align-items: center;
   height: calc(100vh - 350px);
 }
+
+.fullWidth {
+  width: 100%;
+}

--- a/webapp/src/components/AssetProviderPage/AssetProviderPage.tsx
+++ b/webapp/src/components/AssetProviderPage/AssetProviderPage.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react'
+import classNames from 'classnames'
 import { RentalStatus } from '@dcl/schemas'
 import { Loader } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
@@ -7,8 +8,8 @@ import { AssetProvider } from '../AssetProvider'
 import { Props } from './AssetProviderPage.types'
 import styles from './AssetProviderPage.module.css'
 
-const Loading = () => (
-  <div className={styles.center}>
+const Loading = ({ fullWidth }: { fullWidth: boolean }) => (
+  <div className={classNames(styles.center, fullWidth && styles.fullWidth)}>
     <Loader active size="huge" />
   </div>
 )
@@ -21,7 +22,13 @@ export const NotFound = () => (
 )
 
 const AssetProviderPage = (props: Props) => {
-  const { type, isConnecting, isRentalsEnabled, children } = props
+  const {
+    type,
+    isConnecting,
+    isRentalsEnabled,
+    children,
+    fullWidth = false
+  } = props
   const rentalStatuses: RentalStatus[] | undefined = useMemo(
     () =>
       type === AssetType.NFT && isRentalsEnabled
@@ -37,7 +44,7 @@ const AssetProviderPage = (props: Props) => {
 
         return (
           <>
-            {isLoading ? <Loading /> : null}
+            {isLoading ? <Loading fullWidth={fullWidth} /> : null}
             {!isLoading && !asset ? <NotFound /> : null}
             {!isLoading && asset ? children(asset, order, rental) : null}
           </>

--- a/webapp/src/components/AssetProviderPage/AssetProviderPage.types.ts
+++ b/webapp/src/components/AssetProviderPage/AssetProviderPage.types.ts
@@ -5,6 +5,7 @@ export type Props<T extends AssetType = AssetType> = {
   type: T
   isConnecting: boolean
   isRentalsEnabled: boolean
+  fullWidth?: boolean
   children: (
     asset: Asset<T>,
     order: Order | null,
@@ -15,5 +16,5 @@ export type Props<T extends AssetType = AssetType> = {
 export type MapStateProps = Pick<Props, 'isConnecting' | 'isRentalsEnabled'>
 export type OwnProps<T extends AssetType = AssetType> = Pick<
   Props<T>,
-  'type' | 'children'
+  'type' | 'children' | 'fullWidth'
 >


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8763687/205125369-fd51ea7b-0fbf-4eee-8336-86b74a26b16f.png)

Closes #1089 
Closes #1081 