### PR TITLE
feat: Update discord prefix

### DIFF
--- a/webapp/src/components/StoreSettings/StoreSettings.tsx
+++ b/webapp/src/components/StoreSettings/StoreSettings.tsx
@@ -12,7 +12,7 @@ import { LinkType, Store } from '../../modules/store/types'
 import {
   getIsValidLink,
   getPrefixedCoverName,
-  linkStartWiths
+  linkStartsWith
 } from '../../modules/store/utils'
 import './StoreSettings.css'
 
@@ -47,7 +47,7 @@ const StoreSettings = ({
 
     if (website && !getIsValidLink(LinkType.WEBSITE, website)) {
       newErrors[LinkType.WEBSITE] = t('store_settings.link_start_with_error', {
-        value: linkStartWiths[LinkType.WEBSITE]
+        value: linkStartsWith[LinkType.WEBSITE]
       })
     }
 
@@ -75,7 +75,7 @@ const StoreSettings = ({
   )
 
   const getInputValue = useCallback(
-    (type: LinkType) => store[type].replace(linkStartWiths[type], ''),
+    (type: LinkType) => store[type].replace(linkStartsWith[type], ''),
     [store]
   )
 
@@ -83,7 +83,7 @@ const StoreSettings = ({
     (type: LinkType, value: string) =>
       onChange({
         ...store,
-        [type]: (!value ? '' : linkStartWiths[type] + value).replaceAll(' ', '')
+        [type]: (!value ? '' : linkStartsWith[type] + value).replaceAll(' ', '')
       }),
     [store, onChange]
   )

--- a/webapp/src/modules/store/utils.ts
+++ b/webapp/src/modules/store/utils.ts
@@ -158,23 +158,23 @@ export const deployStoreEntity = async (
 
 // Validations
 
-export const linkStartWiths: Record<LinkType, string> = {
+export const linkStartsWith: Record<LinkType, string> = {
   [LinkType.WEBSITE]: 'https://',
   [LinkType.FACEBOOK]: 'https://www.facebook.com/',
   [LinkType.TWITTER]: 'https://www.twitter.com/',
-  [LinkType.DISCORD]: 'https://discord.com/channels/'
+  [LinkType.DISCORD]: 'https://discord.gg/'
 }
 
 export const getIsValidLink = (type: LinkType, link: string) => {
   switch (type) {
     case LinkType.WEBSITE:
-      return link.startsWith(linkStartWiths.website)
+      return link.startsWith(linkStartsWith.website)
     case LinkType.FACEBOOK:
-      return link.startsWith(linkStartWiths.facebook)
+      return link.startsWith(linkStartsWith.facebook)
     case LinkType.TWITTER:
-      return link.startsWith(linkStartWiths.twitter)
+      return link.startsWith(linkStartsWith.twitter)
     case LinkType.DISCORD:
-      return link.startsWith(linkStartWiths.discord)
+      return link.startsWith(linkStartsWith.discord)
     default:
       throw new Error(`Invalid LinkType '${type}'`)
   }

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -282,7 +282,7 @@
     "size_error": "Maximum file size allowed is of {max}, the file you selected has {current}",
     "facebook": "Facebook Handle",
     "twitter": "Twitter Handle",
-    "discord": "Discord Channel ID",
+    "discord": "Discord Invite ID",
     "save": "Save",
     "revert": "Revert",
     "add_cover_picture": "Click here to add a cover picture",

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -277,7 +277,7 @@
     "size_error": "El tamaño máximo permitido es de {max}, el archivo seleccionado tiene {current}",
     "facebook": "Handle de Facebook",
     "twitter": "Handle de Twitter",
-    "discord": "ID del canal de Discord",
+    "discord": "ID de invitación de Discord",
     "save": "Guardar",
     "revert": "Revertir",
     "add_cover_picture": "Haga click aquí para ponerle una imagen a la tienda",

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -278,7 +278,7 @@
     "size_error": "允许的最大文件大小为 {max}，您选择的文件具有 {current}",
     "facebook": "处理 Facebook",
     "twitter": "处理 Twitter",
-    "discord": "通道编号 Discord",
+    "discord": "Discord 邀请 ID",
     "save": "救",
     "revert": "恢复",
     "add_cover_picture": "单击此处将图像放入您的商店",


### PR DESCRIPTION
Closes #1105 

Users can update the old Discord url to the new one by writing the channel id in the input field.

<img width="432" alt="Screenshot 2022-12-05 at 09 19 45" src="https://user-images.githubusercontent.com/24811313/205636202-655bc048-3ba9-48cc-a244-65fd872affb9.png">

Using the example of Uniswap https://discord.gg/FCfyBSbCU5 to the invite page.

<img width="503" alt="Screenshot 2022-12-05 at 09 20 06" src="https://user-images.githubusercontent.com/24811313/205636208-83733490-6987-47dd-bd71-a55f783af5a2.png">

Also changed the text to Invite ID instead of channel ID

![image](https://user-images.githubusercontent.com/24811313/205645658-04ea94a3-5727-493d-9ec9-83c138a5376f.png)
