### PR TITLE
fix: Change sale rent box styles

### DIFF
--- a/webapp/src/components/AssetPage/SaleRentActionBox/PeriodsDropdown/PeriodsDropdown.tsx
+++ b/webapp/src/components/AssetPage/SaleRentActionBox/PeriodsDropdown/PeriodsDropdown.tsx
@@ -77,7 +77,6 @@ const PeriodsDropdown = ({ value, periods, className, onChange }: Props) => {
       value={value}
       options={options}
       onChange={handleOnChange}
-      defaultValue={0}
     />
   )
 }

--- a/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.module.css
+++ b/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.module.css
@@ -1,7 +1,7 @@
 .main {
   border-radius: 12px;
   margin-bottom: 12px;
-  background: #242129;
+  background: rgba(42, 38, 47);
 }
 
 .actions {
@@ -59,15 +59,16 @@
   display: flex;
   flex-direction: row;
   width: 100%;
-  border: 2px solid rgba(115, 110, 125, 0.24);
-  border-radius: 6px;
+  overflow: hidden;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
   justify-content: space-between;
 }
 
 .viewOption {
   flex: 1 1 auto;
   width: 100%;
-  background: rgba(115, 110, 125, 0.24);
+  background: rgba(31, 27, 35);
   text-align: center;
   padding-top: 9px;
   padding-bottom: 9px;
@@ -80,15 +81,13 @@
 	border: none;
   font-weight: 500;
   font-size: 17px;
+  padding-top: 15px;
+  padding-bottom: 15px;
 }
 
 .selectedViewOption {
-  background: #242129;
+  background: rgba(42, 38, 47);
   cursor: auto;
-}
-
-.viewSelector {
-  margin-bottom: 24px;
 }
 
 .notForSale {

--- a/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
+++ b/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
@@ -131,29 +131,29 @@ const SaleRentActionBox = ({
 
   return (
     <div className={styles.main}>
+      {isRentalOpen && maxPriceOfPeriods && isRentalsEnabled ? (
+        <div className={styles.viewSelector}>
+          <button
+            onClick={toggleView}
+            disabled={view === View.SALE}
+            className={classNames(styles.viewOption, {
+              [styles.selectedViewOption]: view === View.SALE
+            })}
+          >
+            {t('global.sale')}
+          </button>
+          <button
+            onClick={toggleView}
+            disabled={view === View.RENT}
+            className={classNames(styles.viewOption, {
+              [styles.selectedViewOption]: view === View.RENT
+            })}
+          >
+            {t('global.rent')}
+          </button>
+        </div>
+      ) : null}
       <div className={styles.actions}>
-        {isRentalOpen && maxPriceOfPeriods && isRentalsEnabled ? (
-          <div className={styles.viewSelector}>
-            <button
-              onClick={toggleView}
-              disabled={view === View.SALE}
-              className={classNames(styles.viewOption, {
-                [styles.selectedViewOption]: view === View.SALE
-              })}
-            >
-              {t('global.sale')}
-            </button>
-            <button
-              onClick={toggleView}
-              disabled={view === View.RENT}
-              className={classNames(styles.viewOption, {
-                [styles.selectedViewOption]: view === View.RENT
-              })}
-            >
-              {t('global.rent')}
-            </button>
-          </div>
-        ) : null}
         {view === View.RENT &&
         isRentalOpen &&
         maxPriceOfPeriods &&


### PR DESCRIPTION
This PR changes the sale rent box styles to match the new styles.
It also removes a default value on a dropdown that shouldn't be there and was causing some warnings to pop up.

![Screen Shot 2022-12-08 at 12 31 30](https://user-images.githubusercontent.com/1120791/206488714-8e2be010-1ea8-4ab5-a2ad-eedff631fc61.png)

![Screen Shot 2022-12-08 at 12 33 47](https://user-images.githubusercontent.com/1120791/206488721-3b374b33-0d7d-48c5-a75f-859120936d45.png)

![Screen Shot 2022-12-08 at 12 33 58](https://user-images.githubusercontent.com/1120791/206488728-867ce24d-c815-4627-b999-fa689054d9b4.png)

Closes #1120