### PR TITLE
fix: Reduce NFT server requests

### DIFF
--- a/webapp/src/components/AssetProvider/AssetProvider.container.ts
+++ b/webapp/src/components/AssetProvider/AssetProvider.container.ts
@@ -4,10 +4,7 @@ import { FETCH_APPLICATION_FEATURES_REQUEST } from 'decentraland-dapps/dist/modu
 import { isLoadingFeatureFlags as getIsLoadingFeatureFlags } from '../../modules/features/selectors'
 import { RootState } from '../../modules/reducer'
 import { fetchNFTRequest, FETCH_NFT_REQUEST } from '../../modules/nft/actions'
-import {
-  fetchItemRequest,
-  FETCH_ITEM_REQUEST
-} from '../../modules/item/actions'
+import { fetchItemRequest } from '../../modules/item/actions'
 import {
   getContractAddress as getNFTContractAddress,
   getTokenId as getNFTTokenId,
@@ -17,7 +14,7 @@ import {
 import {
   getContractAddress as getItemContractAddress,
   getTokenId as getItemTokenId,
-  getLoading as getItemLoading,
+  isFetchingItem,
   getData as getItems
 } from '../../modules/item/selectors'
 import { getData as getOrders } from '../../modules/order/selectors'
@@ -57,7 +54,7 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
       contractAddress = contractAddress || getItemContractAddress(state)
       tokenId = tokenId || getItemTokenId(state)
       asset = getItem(contractAddress, tokenId, items)
-      isLoading = isLoadingType(getItemLoading(state), FETCH_ITEM_REQUEST)
+      isLoading = isFetchingItem(state, contractAddress!, tokenId!)
       break
     }
     default:

--- a/webapp/src/components/AssetProvider/AssetProvider.tsx
+++ b/webapp/src/components/AssetProvider/AssetProvider.tsx
@@ -26,7 +26,7 @@ const AssetProvider = (props: Props) => {
   }, [isLoadingFeatureFlags])
 
   useEffect(() => {
-    if (contractAddress && tokenId) {
+    if (contractAddress && tokenId && asset === null && !isLoading) {
       switch (type) {
         case AssetType.NFT:
           if (hasLoadedInitialFlags) {
@@ -41,6 +41,7 @@ const AssetProvider = (props: Props) => {
       }
     }
   }, [
+    asset,
     contractAddress,
     tokenId,
     type,
@@ -48,7 +49,8 @@ const AssetProvider = (props: Props) => {
     onFetchItem,
     rentalStatus,
     isLoadingFeatureFlags,
-    hasLoadedInitialFlags
+    hasLoadedInitialFlags,
+    isLoading
   ])
 
   return (

--- a/webapp/src/components/AssetProvider/AssetProvider.tsx
+++ b/webapp/src/components/AssetProvider/AssetProvider.tsx
@@ -48,7 +48,6 @@ const AssetProvider = (props: Props) => {
     onFetchNFT,
     onFetchItem,
     rentalStatus,
-    isLoadingFeatureFlags,
     hasLoadedInitialFlags,
     isLoading
   ])

--- a/webapp/src/components/CollectionProvider/CollectionProvider.container.ts
+++ b/webapp/src/components/CollectionProvider/CollectionProvider.container.ts
@@ -1,19 +1,20 @@
+import { Collection } from '@dcl/schemas'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { connect } from 'react-redux'
 import { Dispatch } from 'redux'
 import {
   fetchSingleCollectionRequest,
-  FETCH_COLLECTIONS_REQUEST,
-  FETCH_SINGLE_COLLECTION_REQUEST
+  FETCH_COLLECTIONS_REQUEST
 } from '../../modules/collection/actions'
 import {
   getLoading,
-  getCollectionsByAddress
+  getCollectionsByAddress,
+  isFetchingCollection
 } from '../../modules/collection/selectors'
-import { FETCH_ITEMS_REQUEST } from '../../modules/item/actions'
+import { fetchItemsRequest } from '../../modules/item/actions'
 import {
   getItemsByContractAddress,
-  getLoading as getLoadingItems
+  isFetchingItemsOfCollection
 } from '../../modules/item/selectors'
 import { RootState } from '../../modules/reducer'
 import CollectionProvider from './CollectionProvider'
@@ -25,20 +26,31 @@ import {
 
 const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => ({
   collection: getCollectionsByAddress(state)[ownProps.contractAddress],
-  items: getItemsByContractAddress(state)[ownProps.contractAddress],
-  isLoading:
+  items: getItemsByContractAddress(state)[ownProps.contractAddress] ?? [],
+  isLoadingCollection:
     isLoadingType(getLoading(state), FETCH_COLLECTIONS_REQUEST) ||
-    isLoadingType(getLoading(state), FETCH_SINGLE_COLLECTION_REQUEST) ||
-    (!!ownProps.withItems &&
-      isLoadingType(getLoadingItems(state), FETCH_ITEMS_REQUEST))
+    isFetchingCollection(state, ownProps.contractAddress),
+  isLoadingCollectionItems: isFetchingItemsOfCollection(
+    state,
+    ownProps.contractAddress
+  )
 })
 
 const mapDispatch = (
   dispatch: Dispatch,
-  { contractAddress, withItems }: OwnProps
+  { contractAddress }: OwnProps
 ): MapDispatchProps => ({
   onFetchCollection: () =>
-    dispatch(fetchSingleCollectionRequest(contractAddress, withItems))
+    dispatch(fetchSingleCollectionRequest(contractAddress)),
+  onFetchCollectionItems: (collection: Collection) =>
+    dispatch(
+      fetchItemsRequest({
+        filters: {
+          first: collection.size,
+          contracts: [collection.contractAddress]
+        }
+      })
+    )
 })
 
 export default connect(mapState, mapDispatch)(CollectionProvider)

--- a/webapp/src/components/CollectionProvider/CollectionProvider.tsx
+++ b/webapp/src/components/CollectionProvider/CollectionProvider.tsx
@@ -4,25 +4,47 @@ import { Props } from './CollectionProvider.types'
 const CollectionProvider = ({
   collection,
   items,
-  isLoading,
+  isLoadingCollection,
+  isLoadingCollectionItems,
   withItems,
+  contractAddress,
   onFetchCollection,
+  onFetchCollectionItems,
   children
 }: Props) => {
   useEffect(() => {
-    if (isLoading) {
-      return
+    if (!isLoadingCollection && !collection) {
+      onFetchCollection()
     }
 
     if (
-      !collection ||
-      (withItems && (!items || items.length !== collection.size))
+      !isLoadingCollectionItems &&
+      collection &&
+      withItems &&
+      (!items || items.length !== collection.size)
     ) {
-      onFetchCollection()
+      onFetchCollectionItems(collection)
     }
-  }, [collection, items, withItems, isLoading, onFetchCollection])
+  }, [
+    collection,
+    items,
+    contractAddress,
+    withItems,
+    onFetchCollection,
+    isLoadingCollection,
+    isLoadingCollectionItems,
+    onFetchCollectionItems
+  ])
 
-  return <>{children({ collection, items, isLoading })}</>
+  return (
+    <>
+      {children({
+        collection,
+        items,
+        isLoading: isLoadingCollection || isLoadingCollectionItems
+      })}
+    </>
+  )
 }
 
 export default React.memo(CollectionProvider)

--- a/webapp/src/components/CollectionProvider/CollectionProvider.types.tsx
+++ b/webapp/src/components/CollectionProvider/CollectionProvider.types.tsx
@@ -6,13 +6,21 @@ export type Props = {
   withItems?: boolean
   collection?: Collection
   items?: Item[]
-  isLoading: boolean
+  isLoadingCollection: boolean
+  isLoadingCollectionItems: boolean
   onFetchCollection: () => void
+  onFetchCollectionItems: (collection: Collection) => void
   children: (
-    data: Pick<Props, 'collection' | 'items' | 'isLoading'>
+    data: Pick<Props, 'collection' | 'items'> & { isLoading: boolean }
   ) => ReactNode
 }
 
-export type MapStateProps = Pick<Props, 'collection' | 'items' | 'isLoading'>
-export type MapDispatchProps = Pick<Props, 'onFetchCollection'>
+export type MapStateProps = Pick<
+  Props,
+  'collection' | 'items' | 'isLoadingCollection' | 'isLoadingCollectionItems'
+>
+export type MapDispatchProps = Pick<
+  Props,
+  'onFetchCollection' | 'onFetchCollectionItems'
+>
 export type OwnProps = Pick<Props, 'contractAddress' | 'withItems'>

--- a/webapp/src/config/env/dev.json
+++ b/webapp/src/config/env/dev.json
@@ -6,6 +6,7 @@
   "ATLAS_SERVER_URL": "https://api.decentraland.zone",
   "PEER_URL": "https://peer-ap1.decentraland.zone",
   "SIGNATURES_SERVER_URL": "https://signatures-api.decentraland.zone/v1",
+  "REFRESH_SIGNATURES_DELAY": "10000",
   "TRANSACTIONS_API_URL": "https://transactions-api.decentraland.zone/v1",
   "BUILDER_URL": "https://builder.decentraland.zone",
   "COINGECKO_API_URL": "https://api.coingecko.com/api/v3",

--- a/webapp/src/config/env/prod.json
+++ b/webapp/src/config/env/prod.json
@@ -6,6 +6,7 @@
   "ATLAS_SERVER_URL": "https://api.decentraland.org",
   "PEER_URL": "https://peer.decentraland.org",
   "SIGNATURES_SERVER_URL": "https://signatures-api.decentraland.org/v1",
+  "REFRESH_SIGNATURES_DELAY": "10000",
   "TRANSACTIONS_API_URL": "https://transactions-api.decentraland.org/v1",
   "BUILDER_URL": "https://builder.decentraland.org",
   "COINGECKO_API_URL": "https://api.coingecko.com/api/v3",

--- a/webapp/src/config/env/stg.json
+++ b/webapp/src/config/env/stg.json
@@ -6,6 +6,7 @@
   "ATLAS_SERVER_URL": "https://api.decentraland.today",
   "PEER_URL": "https://peer.decentraland.org",
   "SIGNATURES_SERVER_URL": "https://signatures-api.decentraland.today/v1",
+  "REFRESH_SIGNATURES_DELAY": "10000",
   "TRANSACTIONS_API_URL": "https://transactions-api.decentraland.today/v1",
   "BUILDER_URL": "https://builder.decentraland.today",
   "COINGECKO_API_URL": "https://api.coingecko.com/api/v3",

--- a/webapp/src/modules/collection/actions.ts
+++ b/webapp/src/modules/collection/actions.ts
@@ -45,7 +45,10 @@ export const fetchSingleCollectionRequest = (
   contractAddress: string,
   shouldFetchItems?: boolean
 ) =>
-  action(FETCH_SINGLE_COLLECTION_REQUEST, { contractAddress, shouldFetchItems })
+  action(FETCH_SINGLE_COLLECTION_REQUEST, {
+    contractAddress,
+    shouldFetchItems
+  })
 export const fetchSingleCollectionSuccess = (collection: Collection) =>
   action(FETCH_SINGLE_COLLECTION_SUCCESS, {
     collection

--- a/webapp/src/modules/collection/sagas.ts
+++ b/webapp/src/modules/collection/sagas.ts
@@ -88,8 +88,6 @@ export function* handleFetchSingleCollectionRequest(
 
     const [collection] = collections
 
-    yield put(fetchSingleCollectionSuccess(collection))
-
     if (shouldFetchItems) {
       const itemsByContractAddress: ReturnType<typeof getItemsByContractAddress> = yield select(
         getItemsByContractAddress
@@ -108,6 +106,7 @@ export function* handleFetchSingleCollectionRequest(
         )
       }
     }
+    yield put(fetchSingleCollectionSuccess(collection))
   } catch (error) {
     yield put(
       fetchSingleCollectionFailure(

--- a/webapp/src/modules/collection/selectors.spec.ts
+++ b/webapp/src/modules/collection/selectors.spec.ts
@@ -1,0 +1,69 @@
+import { RootState } from '../reducer'
+import {
+  fetchCollectionsRequest,
+  fetchSingleCollectionRequest
+} from './actions'
+import { isFetchingCollection } from './selectors'
+
+let state: RootState
+let contractAddress: string
+
+beforeEach(() => {
+  contractAddress = 'aContractAddress'
+  state = {
+    collection: {
+      data: {},
+      error: null,
+      loading: [],
+      count: 0
+    }
+  } as any
+})
+
+describe('when getting if a collection is being fetched', () => {
+  describe("and there's no collection being fetched", () => {
+    beforeEach(() => {
+      state.collection.loading = []
+    })
+
+    it('should return false', () => {
+      expect(isFetchingCollection(state, contractAddress)).toBe(false)
+    })
+  })
+
+  describe("and the given collection isn't being fetched", () => {
+    beforeEach(() => {
+      state.collection.loading = [
+        fetchCollectionsRequest({ contractAddress: 'anotherContractAddress' }),
+        fetchCollectionsRequest({ first: 2 }),
+        fetchSingleCollectionRequest('anotherContractAddress')
+      ]
+    })
+
+    it('should return false', () => {
+      expect(isFetchingCollection(state, contractAddress)).toBe(false)
+    })
+  })
+
+  describe('and the given collection is being fetched in a single collection fetch', () => {
+    beforeEach(() => {
+      state.collection.loading = [fetchSingleCollectionRequest(contractAddress)]
+    })
+
+    it('should return true', () => {
+      expect(isFetchingCollection(state, contractAddress)).toBe(true)
+    })
+  })
+
+  describe('and the given collection is being fetched in a collections fetch', () => {
+    beforeEach(() => {
+      state.collection.loading = [
+        fetchCollectionsRequest({ contractAddress: contractAddress })
+      ]
+    })
+
+    it('should return true', () => {
+      expect(isFetchingCollection(state, contractAddress)).toBe(true)
+    })
+  })
+})

--- a/webapp/src/modules/collection/selectors.ts
+++ b/webapp/src/modules/collection/selectors.ts
@@ -3,12 +3,28 @@ import { createMatchSelector } from 'connected-react-router'
 import { createSelector } from 'reselect'
 import { locations } from '../routing/locations'
 import { RootState } from '../reducer'
+import {
+  FETCH_COLLECTIONS_REQUEST,
+  FETCH_SINGLE_COLLECTION_REQUEST
+} from './actions'
 
 export const getState = (state: RootState) => state.collection
 export const getCollectionsByUrn = (state: RootState) => getState(state).data
 export const getCount = (state: RootState) => getState(state).count
 export const getError = (state: RootState) => getState(state).error
 export const getLoading = (state: RootState) => getState(state).loading
+
+export const isFetchingCollection = (
+  state: RootState,
+  contractAddress: string
+) =>
+  getLoading(state).find(
+    action =>
+      (action.type === FETCH_SINGLE_COLLECTION_REQUEST &&
+        action.payload.contractAddress === contractAddress) ||
+      (action.type === FETCH_COLLECTIONS_REQUEST &&
+        action.payload.filters?.contractAddress === contractAddress)
+  ) !== undefined
 
 export const getCollections = createSelector<
   RootState,

--- a/webapp/src/modules/item/selectors.spec.ts
+++ b/webapp/src/modules/item/selectors.spec.ts
@@ -1,17 +1,30 @@
 import { Item } from '@dcl/schemas'
+import { RootState } from '../reducer'
+import { fetchItemRequest, fetchItemsRequest } from './actions'
 import { INITIAL_STATE } from './reducer'
-import { getData, getError, getLoading, getState } from './selectors'
+import {
+  getData,
+  getError,
+  getLoading,
+  getState,
+  isFetchingItem,
+  isFetchingItemsOfCollection
+} from './selectors'
 
-const state = {
-  item: {
-    ...INITIAL_STATE,
-    data: {
-      anItemId: {} as Item
-    },
-    error: 'anError',
-    loading: []
-  }
-} as any
+let state: RootState
+
+beforeEach(() => {
+  state = {
+    item: {
+      ...INITIAL_STATE,
+      data: {
+        anItemId: {} as Item
+      },
+      error: 'anError',
+      loading: []
+    }
+  } as any
+})
 
 describe("when getting the item's state", () => {
   it('should return the state', () => {
@@ -34,5 +47,91 @@ describe('when getting the error of the state', () => {
 describe('when getting the loading state of the state', () => {
   it('should return the loading state', () => {
     expect(getLoading(state)).toEqual(state.item.loading)
+  })
+})
+
+describe('when getting if an item is being fetched', () => {
+  let contractAddress: string
+  let tokenId: string
+
+  beforeEach(() => {
+    contractAddress = 'aContractAddress'
+    tokenId = 'aTokenId'
+    state.item.loading = []
+  })
+
+  describe('and no items are being fetched', () => {
+    beforeEach(() => {
+      state.item.loading = []
+    })
+
+    it('should return false', () => {
+      expect(isFetchingItem(state, contractAddress, tokenId)).toBe(false)
+    })
+  })
+
+  describe("and it isn't not being fetched", () => {
+    beforeEach(() => {
+      state.item.loading = [fetchItemRequest(contractAddress, 'anotherTokenId')]
+    })
+
+    it('should return false', () => {
+      expect(isFetchingItem(state, contractAddress, tokenId)).toBe(false)
+    })
+  })
+
+  describe('and it is being fetched', () => {
+    beforeEach(() => {
+      state.item.loading.push(fetchItemRequest(contractAddress, tokenId))
+    })
+
+    it('should return true', () => {
+      expect(isFetchingItem(state, contractAddress, tokenId)).toBe(true)
+    })
+  })
+})
+
+describe('when getting if the items of a collection are being fetched', () => {
+  let contractAddress: string
+
+  beforeEach(() => {
+    contractAddress = 'aContractAddress'
+    state.item.loading = []
+  })
+
+  describe('and there are no items being fetched', () => {
+    beforeEach(() => {
+      state.item.loading = []
+    })
+
+    it('should return false', () => {
+      expect(isFetchingItemsOfCollection(state, contractAddress)).toBe(false)
+    })
+  })
+
+  describe("and they're not being fetched", () => {
+    beforeEach(() => {
+      state.item.loading.push(
+        fetchItemsRequest({
+          filters: { contracts: ['anotherContractAddress'] }
+        })
+      )
+    })
+
+    it('should return false', () => {
+      expect(isFetchingItemsOfCollection(state, contractAddress)).toBe(false)
+    })
+  })
+
+  describe("and they're being fetched", () => {
+    beforeEach(() => {
+      state.item.loading.push(
+        fetchItemsRequest({ filters: { contracts: [contractAddress] } })
+      )
+    })
+
+    it('should return true', () => {
+      expect(isFetchingItemsOfCollection(state, contractAddress)).toBe(true)
+    })
   })
 })

--- a/webapp/src/modules/item/selectors.ts
+++ b/webapp/src/modules/item/selectors.ts
@@ -3,11 +3,34 @@ import { createMatchSelector } from 'connected-react-router'
 import { Item } from '@dcl/schemas'
 import { locations } from '../routing/locations'
 import { RootState } from '../reducer'
+import { FETCH_ITEMS_REQUEST, FETCH_ITEM_REQUEST } from './actions'
 
 export const getState = (state: RootState) => state.item
 export const getData = (state: RootState) => getState(state).data
 export const getError = (state: RootState) => getState(state).error
 export const getLoading = (state: RootState) => getState(state).loading
+
+export const isFetchingItem = (
+  state: RootState,
+  contractAddress: string,
+  tokenId: string
+) =>
+  getLoading(state).find(
+    action =>
+      action.type === FETCH_ITEM_REQUEST &&
+      action.payload.contractAddress === contractAddress &&
+      action.payload.tokenId === tokenId
+  ) !== undefined
+
+export const isFetchingItemsOfCollection = (
+  state: RootState,
+  contractAddress: string
+) =>
+  getLoading(state).find(
+    action =>
+      action.type === FETCH_ITEMS_REQUEST &&
+      action.payload.filters?.contracts?.includes(contractAddress)
+  ) !== undefined
 
 export const getItems = createSelector<
   RootState,

--- a/webapp/src/modules/rental/utils.ts
+++ b/webapp/src/modules/rental/utils.ts
@@ -14,6 +14,7 @@ import {
   ContractName,
   getContract
 } from 'decentraland-transactions'
+import { config } from '../../config'
 import { VendorName } from '../vendor'
 import { rentalsAPI } from '../vendor/decentraland/rentals/api'
 import { addressEquals } from '../wallet/utils'
@@ -284,7 +285,7 @@ export async function waitUntilRentalChangesStatus(
   let hasChanged = false
   let listing: RentalListing
   while (!hasChanged) {
-    await delay(3500)
+    await delay(Number(config.get('REFRESH_SIGNATURES_DELAY', '5000')))
     listing = await rentalsAPI.refreshRentalListing(nft.openRentalId!)
     hasChanged = listing.status === status
   }


### PR DESCRIPTION
This PR reduces the NFT server requests by:
- Increasing the delay used when waiting for a rental to be changed.
- Changes the `TransactionHistory` component so it doesn't re-trigger the request when the asset instance changes.
- Changes the `CollectionProvider` component so it fetches items and and collections separately, removing the need to fetch the collection again when fetching items.
- Changes the `AssetProvider` component so it doesn't re-fetch assets when they were already fetched.

Closes #1128 