### PR TITLE
feat: Add cheapest filter for rentals

### DIFF
--- a/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.tsx
+++ b/webapp/src/components/Vendor/decentraland/NFTFilters/NFTFilters.tsx
@@ -68,7 +68,8 @@ const NFTFilters = (props: Props) => {
         text: t('filters.recently_listed_for_rent')
       },
       { value: SortBy.NAME, text: t('filters.name') },
-      { value: SortBy.NEWEST, text: t('filters.newest') }
+      { value: SortBy.NEWEST, text: t('filters.newest') },
+      { value: SortBy.MAX_RENTAL_PRICE, text: t('filters.cheapest') }
     ]
   } else {
     orderByDropdownOptions = [

--- a/webapp/src/modules/routing/search.ts
+++ b/webapp/src/modules/routing/search.ts
@@ -295,7 +295,7 @@ export function getAssetOrderBy(sortBy: SortBy) {
     }
     case SortBy.MIN_RENTAL_PRICE: {
       orderBy = NFTSortBy.MIN_RENTAL_PRICE
-      orderDirection = SortDirection.DESC
+      orderDirection = SortDirection.ASC
       break
     }
     case SortBy.RENTAL_DATE: {
@@ -332,6 +332,9 @@ export function getNFTSortBy(orderBy: NFTSortBy) {
     case NFTSortBy.PRICE: {
       sortBy = SortBy.CHEAPEST
       break
+    }
+    case NFTSortBy.MAX_RENTAL_PRICE: {
+      sortBy = SortBy.MAX_RENTAL_PRICE
     }
   }
 


### PR DESCRIPTION
This PR adds the cheapest sort under the `MAX_RENTAL_PRICE`.
As of today, the maximum value of the rental price on all periods is the same as the minimum one, but we're using the maximum value everywhere due to the chance of someone registering the values manually.