### PR TITLE
fix: Fix rentals signature with V different from 27 or 28

### DIFF
--- a/webapp/src/modules/rental/sagas.ts
+++ b/webapp/src/modules/rental/sagas.ts
@@ -280,6 +280,10 @@ function* handleAcceptRentalListingRequest(
       [[], [], []] as [string[], number[], number[]]
     )
 
+    const lastSignatureByte = Number.parseInt(rental.signature.slice(-2), 16)
+    const isSignatureVValid =
+      lastSignatureByte === 27 || lastSignatureByte === 28
+
     const listing = {
       signer: rental.lessor,
       contractAddress: rental.contractAddress,
@@ -290,7 +294,9 @@ function* handleAcceptRentalListingRequest(
       maxDays,
       minDays,
       target: ethers.constants.AddressZero,
-      signature: rental.signature
+      signature: isSignatureVValid
+        ? rental.signature
+        : rental.signature.slice(0, -2) + (lastSignatureByte + 27).toString(16)
     }
 
     let fingerprint = ethers.utils.randomBytes(32).map(() => 0)
@@ -313,6 +319,8 @@ function* handleAcceptRentalListingRequest(
       rental.periods[periodIndexChosen].maxDays,
       fingerprint
     ]
+
+    console.log('Transaction params', txParams)
 
     const txHash: string = yield call(
       sendTransaction as (

--- a/webapp/src/modules/rental/sagas.ts
+++ b/webapp/src/modules/rental/sagas.ts
@@ -320,8 +320,6 @@ function* handleAcceptRentalListingRequest(
       fingerprint
     ]
 
-    console.log('Transaction params', txParams)
-
     const txHash: string = yield call(
       sendTransaction as (
         contract: ContractData,


### PR DESCRIPTION
This PR fixes the issue where rental listings couldn't be accepted by the contracts because of ending in 0 or 1, making the validation fail due to an invalid V value.