### PR TITLE
fix: Show expiration date on rentals and orders

### DIFF
--- a/webapp/src/components/ManageAssetPage/Details/Details.tsx
+++ b/webapp/src/components/ManageAssetPage/Details/Details.tsx
@@ -1,4 +1,5 @@
 import { useMemo, memo } from 'react'
+import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 import { Link } from 'react-router-dom'
 import { NFTCategory } from '@dcl/schemas'
 import classNames from 'classnames'
@@ -9,7 +10,6 @@ import { Box } from '../../AssetBrowse/Box'
 import { LinkedProfile } from '../../LinkedProfile'
 import { Props } from './Details.types'
 import styles from './Details.module.css'
-import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 
 const Info = ({
   title,

--- a/webapp/src/components/ManageAssetPage/Details/Details.tsx
+++ b/webapp/src/components/ManageAssetPage/Details/Details.tsx
@@ -9,6 +9,7 @@ import { Box } from '../../AssetBrowse/Box'
 import { LinkedProfile } from '../../LinkedProfile'
 import { Props } from './Details.types'
 import styles from './Details.module.css'
+import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 
 const Info = ({
   title,
@@ -24,7 +25,7 @@ const Info = ({
 )
 
 export const Details = (props: Props) => {
-  const { asset, rental, className } = props
+  const { asset, order, rental, className } = props
 
   const categoryName = useMemo(() => {
     switch (asset.category) {
@@ -83,6 +84,24 @@ export const Details = (props: Props) => {
         <Info title={t('manage_asset_page.details.network')}>
           <span>{asset.network}</span>
         </Info>
+        {order ? (
+          <Info title={t('manage_asset_page.details.order_expiration')}>
+            <span>
+              {formatDistanceToNow(order.expiresAt, {
+                addSuffix: true
+              })}
+            </span>
+          </Info>
+        ) : null}
+        {rental ? (
+          <Info title={t('manage_asset_page.details.rental_expiration')}>
+            <span>
+              {formatDistanceToNow(rental.expiration, {
+                addSuffix: true
+              })}
+            </span>
+          </Info>
+        ) : null}
         {owner ? (
           <Info title={t('manage_asset_page.details.owner')}>
             <LinkedProfile hasPopup={true} address={owner} />

--- a/webapp/src/components/ManageAssetPage/Details/Details.types.ts
+++ b/webapp/src/components/ManageAssetPage/Details/Details.types.ts
@@ -1,8 +1,9 @@
-import { RentalListing } from '@dcl/schemas'
+import { Order, RentalListing } from '@dcl/schemas'
 import { Asset } from '../../../modules/asset/types'
 
 export type Props = {
   asset: Asset
   rental?: RentalListing | null
+  order?: Order | null
   className?: string
 }

--- a/webapp/src/modules/features/selectors.ts
+++ b/webapp/src/modules/features/selectors.ts
@@ -26,12 +26,10 @@ export const getIsMaintenanceEnabled = (state: RootState) => {
 
 export const getIsRentalsEnabled = (state: RootState) => {
   try {
-    return (
-      getIsFeatureEnabled(
-        state,
-        ApplicationName.BUILDER,
-        FeatureName.RENTALS
-      ) || true
+    return getIsFeatureEnabled(
+      state,
+      ApplicationName.BUILDER,
+      FeatureName.RENTALS
     )
   } catch (e) {
     return false

--- a/webapp/src/modules/features/selectors.ts
+++ b/webapp/src/modules/features/selectors.ts
@@ -26,10 +26,12 @@ export const getIsMaintenanceEnabled = (state: RootState) => {
 
 export const getIsRentalsEnabled = (state: RootState) => {
   try {
-    return getIsFeatureEnabled(
-      state,
-      ApplicationName.BUILDER,
-      FeatureName.RENTALS
+    return (
+      getIsFeatureEnabled(
+        state,
+        ApplicationName.BUILDER,
+        FeatureName.RENTALS
+      ) || true
     )
   } catch (e) {
     return false

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -864,7 +864,9 @@
     "details": {
       "title": "Item details",
       "network": "Network",
-      "owner": "Owner"
+      "owner": "Owner",
+      "order_expiration": "Order expiration",
+      "rental_expiration": "Rental expiration"
     }
   },
   "claim_land_modal": {

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -857,7 +857,9 @@
     "details": {
       "title": "Detalles del item",
       "network": "Red",
-      "owner": "Dueño"
+      "owner": "Dueño",
+      "order_expiration": "Expiración de la orden",
+      "rental_expiration": "Expiración de la renta"
     }
   },
   "claim_land_modal": {

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -859,7 +859,9 @@
     "details": {
       "title": "商品详情",
       "network": "网络",
-      "owner": "所有者"
+      "owner": "所有者",
+      "order_expiration": "订单有效期至",
+      "rental_expiration": "出租清单有效期至"
     }
   },
   "claim_land_modal": {


### PR DESCRIPTION
This PR adds the missing order and rental expiration dates in the details.
Closes #1141