### PR TITLE
fix: Remove lenght check from V check

### DIFF
--- a/webapp/src/modules/rental/sagas.spec.ts
+++ b/webapp/src/modules/rental/sagas.spec.ts
@@ -237,7 +237,8 @@ describe('when handling the request action to upsert a rental listing', () => {
           }
         ]
         const expiration = 1234567
-        const signature = 'the-signature'
+        const signature =
+          '0x402a10749ebca5d35af41b5780a2667e7edbc2ec64bad157714f533c69cb694c4e4595b88dce064a92772850e903c23d0f67625aeccf9308841ad34929daf51c'
         return expectSaga(rentalSaga)
           .provide([
             [select(getAddress), signerAddress],

--- a/webapp/src/modules/rental/utils.spec.ts
+++ b/webapp/src/modules/rental/utils.spec.ts
@@ -897,24 +897,4 @@ describe('when generating an ECDSA signature with a valid V from a signature', (
       )
     })
   })
-
-  describe('and the original signature has a length greater than 65 bytes', () => {
-    it('should return the same signature', () => {
-      expect(
-        generateECDSASignatureWithValidV(
-          '0x402a10749ebca5d35af41b5780a2667e7edbc2ec64bad157714f533c69cb694c4e4595b88dce064a92772850e903c23d0f67625aeccf9308841ad34929daf51ca'
-        )
-      ).toBe(
-        '0x402a10749ebca5d35af41b5780a2667e7edbc2ec64bad157714f533c69cb694c4e4595b88dce064a92772850e903c23d0f67625aeccf9308841ad34929daf51ca'
-      )
-    })
-  })
-
-  describe('and the original signature has a length lower than 65 bytes', () => {
-    it('should return the same signature', () => {
-      expect(
-        generateECDSASignatureWithValidV('0x402a10749ebca5d35af41b5780a2667e')
-      ).toBe('0x402a10749ebca5d35af41b5780a2667e')
-    })
-  })
 })

--- a/webapp/src/modules/rental/utils.ts
+++ b/webapp/src/modules/rental/utils.ts
@@ -307,10 +307,6 @@ function getLastECDSASignatureByte(signature: string) {
  * @returns true if the v value is decimal 27 or 28 else otherwise.
  */
 function hasECDSASignatureAValidV(signature: string): boolean {
-  if (signature.length !== 130) {
-    return true
-  }
-
   const lastSignatureByte = getLastECDSASignatureByte(signature)
   return lastSignatureByte === 27 || lastSignatureByte === 28
 }


### PR DESCRIPTION
This PR removes the length check from the ECDSA V check.