### PR TITLE
fix: Show lands as lists, center the modal and add dimming up to 50%

### DIFF
--- a/webapp/src/components/Modals/RentalsLaunchModal/RentalsLaunchModal.module.css
+++ b/webapp/src/components/Modals/RentalsLaunchModal/RentalsLaunchModal.module.css
@@ -1,12 +1,5 @@
-@media not (max-width: 767px) {
-  :global(.ui.modal).launchModal {
-    top: 15px;
-    right: 15px;
-  }
-}
-
 :global(.ui.dimmer).dimmerRemover {
-  background-color: unset;
+  background-color: rgba(0,0,0,0.60)
 }
 
 :global(.ui.medium.image).rentalImage {

--- a/webapp/src/components/Modals/RentalsLaunchModal/RentalsLaunchModal.module.css
+++ b/webapp/src/components/Modals/RentalsLaunchModal/RentalsLaunchModal.module.css
@@ -1,5 +1,5 @@
 :global(.ui.dimmer).dimmerRemover {
-  background-color: rgba(0,0,0,0.60)
+  background-color: rgba(0,0,0,0.50)
 }
 
 :global(.ui.medium.image).rentalImage {

--- a/webapp/src/components/Modals/RentalsLaunchModal/RentalsLaunchModal.tsx
+++ b/webapp/src/components/Modals/RentalsLaunchModal/RentalsLaunchModal.tsx
@@ -42,9 +42,10 @@ export const RentalsLaunchModal = ({
   const [isOpen, setIsOpen] = useState<boolean>(false)
   useEffect(() => {
     setIsOpen(
-      !localStorage.getItem(RENTAL_PROMO_POPUP_KEY) &&
+      (!localStorage.getItem(RENTAL_PROMO_POPUP_KEY) &&
         hasLoadedInitialFlags &&
-        isRentalsLaunchPopupEnabled
+        isRentalsLaunchPopupEnabled) ||
+        true
     )
   }, [hasLoadedInitialFlags, isRentalsLaunchPopupEnabled])
 
@@ -69,7 +70,11 @@ export const RentalsLaunchModal = ({
         </Button>
         <Button
           as={Link}
-          to={locations.lands({ onlyOnRent: true })}
+          to={locations.lands({
+            onlyOnRent: true,
+            isFullscreen: false,
+            isMap: false
+          })}
           onClick={onClose}
           primary
         >

--- a/webapp/src/components/Modals/RentalsLaunchModal/RentalsLaunchModal.tsx
+++ b/webapp/src/components/Modals/RentalsLaunchModal/RentalsLaunchModal.tsx
@@ -42,10 +42,9 @@ export const RentalsLaunchModal = ({
   const [isOpen, setIsOpen] = useState<boolean>(false)
   useEffect(() => {
     setIsOpen(
-      (!localStorage.getItem(RENTAL_PROMO_POPUP_KEY) &&
+      !localStorage.getItem(RENTAL_PROMO_POPUP_KEY) &&
         hasLoadedInitialFlags &&
-        isRentalsLaunchPopupEnabled) ||
-        true
+        isRentalsLaunchPopupEnabled
     )
   }, [hasLoadedInitialFlags, isRentalsLaunchPopupEnabled])
 


### PR DESCRIPTION
This PR changes the following:
- Makes the Rentals Launch Modal dim up to 50% (was not dimmed at all before).
- Center the Rentals Launch Modal.
- Makes the `browse list` button go to the rentals without having the map or the fullscreen set.