### PR TITLE
feat: Only fetch contracts on same session

### DIFF
--- a/webapp/src/components/SettingsPage/SettingsPage.container.ts
+++ b/webapp/src/components/SettingsPage/SettingsPage.container.ts
@@ -17,6 +17,7 @@ import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors
 import { getWallet, isConnecting } from '../../modules/wallet/selectors'
 import {
   getContract,
+  getHasFetched,
   getLoading as getContractLoading
 } from '../../modules/contract/selectors'
 import { Contract } from '../../modules/vendor/services'
@@ -51,6 +52,7 @@ const mapState = (state: RootState): MapStateProps => {
       isLoadingType(getContractLoading(state), FETCH_CONTRACTS_REQUEST),
     isConnecting: isConnecting(state),
     hasError,
+    hasFetchedContracts: getHasFetched(state),
     getContract: (query: Partial<Contract>) => getContract(state, query)
   }
 }

--- a/webapp/src/components/SettingsPage/SettingsPage.types.ts
+++ b/webapp/src/components/SettingsPage/SettingsPage.types.ts
@@ -15,6 +15,7 @@ export type Props = {
   isLoading: boolean
   hasError: boolean
   isConnecting: boolean
+  hasFetchedContracts: boolean
   getContract: (query: Partial<Contract>) => ReturnType<typeof getContract>
   onNavigate: (path: string) => void
   onFetchContracts: typeof fetchContractsRequest
@@ -28,6 +29,7 @@ export type MapStateProps = Pick<
   | 'isConnecting'
   | 'hasError'
   | 'getContract'
+  | 'hasFetchedContracts'
 >
 export type MapDispatchProps = Pick<Props, 'onNavigate' | 'onFetchContracts'>
 export type MapDispatch = Dispatch<

--- a/webapp/src/modules/contract/actions.ts
+++ b/webapp/src/modules/contract/actions.ts
@@ -33,3 +33,11 @@ export const upsertContracts = (contracts: Contract[]) =>
   action(UPSERT_CONTRACTS, { contracts })
 
 export type UpsertContractsAction = ReturnType<typeof upsertContracts>
+
+// RESET HAS FETCHED
+
+export const RESET_HAS_FETCHED = 'Reset has fetched'
+
+export const resetHasFetched = () => action(RESET_HAS_FETCHED, {})
+
+export type ResetHasFetchedAction = ReturnType<typeof resetHasFetched>

--- a/webapp/src/modules/contract/reducer.spec.ts
+++ b/webapp/src/modules/contract/reducer.spec.ts
@@ -5,6 +5,7 @@ import {
   fetchContractsRequest,
   fetchContractsSuccess,
   FETCH_CONTRACTS_REQUEST,
+  resetHasFetched,
   upsertContracts
 } from './actions'
 import { contractReducer } from './reducer'
@@ -33,13 +34,15 @@ describe('when fetch contract success action is received', () => {
       {
         loading: [{ type: FETCH_CONTRACTS_REQUEST }],
         error: 'some error',
-        data: []
+        data: [],
+        hasFetched: false
       },
       fetchContractsSuccess([contractSample] as Contract[])
     )
     expect(newState.loading.length).toBe(0)
     expect(newState.data).toStrictEqual([contractSample])
     expect(newState.error).toBeNull()
+    expect(newState.hasFetched).toBeTruthy()
   })
 })
 
@@ -49,7 +52,8 @@ describe('when fetch contract failure action is received', () => {
       {
         loading: [{ type: FETCH_CONTRACTS_REQUEST }],
         error: 'some error',
-        data: []
+        data: [],
+        hasFetched: false
       },
       fetchContractsFailure('some other error')
     )
@@ -76,7 +80,8 @@ describe('when upsert contracts action is received', () => {
         {
           loading: [],
           error: null,
-          data: [contract]
+          data: [contract],
+          hasFetched: false
         },
         upsertContracts([newContract])
       )
@@ -97,12 +102,61 @@ describe('when upsert contracts action is received', () => {
         {
           loading: [],
           error: null,
-          data: []
+          data: [],
+          hasFetched: false
         },
         upsertContracts([newContract])
       )
 
       expect(newState.data).toEqual([newContract])
+    })
+  })
+})
+
+describe('when the reset of the the has fetched flag is received', () => {
+  let hasFetched = false
+
+  describe('when has fetched was true', () => {
+    beforeEach(() => {
+      hasFetched = true
+    })
+
+    it('should set has fetched to false', () => {
+      const newState = contractReducer(
+        {
+          loading: [],
+          error: null,
+          data: [],
+          hasFetched: true
+        },
+        resetHasFetched()
+      )
+
+      expect(newState).toStrictEqual({
+        loading: [],
+        error: null,
+        data: [],
+        hasFetched: false
+      })
+    })
+  })
+
+  describe('when has fetched was false', () => {
+    beforeEach(() => {
+      hasFetched = false
+    })
+
+    it('should keep has fetched as false', () => {
+      const state = {
+        loading: [],
+        error: null,
+        data: [],
+        hasFetched: false
+      }
+
+      const newState = contractReducer(state, resetHasFetched())
+
+      expect(newState).toStrictEqual(state)
     })
   })
 })

--- a/webapp/src/modules/contract/reducer.ts
+++ b/webapp/src/modules/contract/reducer.ts
@@ -12,6 +12,8 @@ import {
   FETCH_CONTRACTS_FAILURE,
   FETCH_CONTRACTS_REQUEST,
   FETCH_CONTRACTS_SUCCESS,
+  ResetHasFetchedAction,
+  RESET_HAS_FETCHED,
   UpsertContractsAction,
   UPSERT_CONTRACTS
 } from './actions'
@@ -22,6 +24,7 @@ export type ContractState = {
   data: Contract[]
   loading: LoadingState
   error: string | null
+  hasFetched: boolean
 }
 
 const network = config.get('NETWORK') as Network
@@ -33,7 +36,8 @@ const networkContracts = contracts[network].map(contract => ({
 export const INITIAL_STATE: ContractState = {
   data: networkContracts as Contract[],
   loading: [],
-  error: null
+  error: null,
+  hasFetched: false
 }
 
 type ContractReducerAction =
@@ -41,6 +45,7 @@ type ContractReducerAction =
   | FetchContractsSuccessAction
   | FetchContractsFailureAction
   | UpsertContractsAction
+  | ResetHasFetchedAction
 
 export function contractReducer(
   state = INITIAL_STATE,
@@ -61,7 +66,8 @@ export function contractReducer(
         ...state,
         loading: loadingReducer(state.loading, action),
         error: null,
-        data: upsertContracts(state.data, contracts)
+        data: upsertContracts(state.data, contracts),
+        hasFetched: true
       }
     }
 
@@ -81,6 +87,13 @@ export function contractReducer(
       return {
         ...state,
         data: upsertContracts(state.data, contracts)
+      }
+    }
+
+    case RESET_HAS_FETCHED: {
+      return {
+        ...state,
+        hasFetched: false
       }
     }
 

--- a/webapp/src/modules/contract/selectors.ts
+++ b/webapp/src/modules/contract/selectors.ts
@@ -7,6 +7,7 @@ export const getState = (state: RootState) => state.contract
 export const getContracts = (state: RootState) => getState(state).data
 export const getError = (state: RootState) => getState(state).error
 export const getLoading = (state: RootState) => getState(state).loading
+export const getHasFetched = (state: RootState) => getState(state).hasFetched
 
 export const getContract = createSelectorCreator(defaultMemoize, isEqual)<
   RootState,


### PR DESCRIPTION
Closes #1167 

- Fetched contracts only once per session, meaning that as long as you are navigating with the same account contracts will be fetched once no matter how many times you enter the settings page.
- Fixed issue were disconnecting while inside the settings page broke everything 🚀 