### PR TITLE
fix: Emote authorization for selling was not working on meta transactions

### DIFF
--- a/webapp/src/components/SellPage/SellModal/SellModal.tsx
+++ b/webapp/src/components/SellPage/SellModal/SellModal.tsx
@@ -79,7 +79,9 @@ const SellModal = (props: Props) => {
     authorizedAddress: marketplace.address,
     contractAddress: nft.contractAddress,
     contractName:
-      nft.category === NFTCategory.WEARABLE && nft.network === Network.MATIC
+      (nft.category === NFTCategory.WEARABLE ||
+        nft.category === NFTCategory.EMOTE) &&
+      nft.network === Network.MATIC
         ? ContractName.ERC721CollectionV2
         : ContractName.ERC721,
     chainId: nft.chainId,


### PR DESCRIPTION
Was being signed as an erc721 instead of a decentraland collection