### PR TITLE
fix: Order tag unalined

### DIFF
--- a/webapp/src/components/AssetCard/AssetCard.css
+++ b/webapp/src/components/AssetCard/AssetCard.css
@@ -59,12 +59,6 @@ a.ui.card.link:hover .meta {
   margin-top: 0px;
 }
 
-.AssetCard .listed-badge {
-  position: absolute;
-  top: 197px;
-  right: 16px;
-}
-
 .AssetCard .sub-header {
   display: flex;
   flex-direction: row;

--- a/webapp/src/components/AssetCard/AssetCard.tsx
+++ b/webapp/src/components/AssetCard/AssetCard.tsx
@@ -17,7 +17,6 @@ import {
 } from '../../modules/rental/utils'
 import { Mana } from '../Mana'
 import { AssetImage } from '../AssetImage'
-import ListedBadge from '../ListedBadge'
 import { ParcelTags } from './ParcelTags'
 import { EstateTags } from './EstateTags'
 import { WearableTags } from './WearableTags'
@@ -108,7 +107,11 @@ const AssetCard = (props: Props) => {
       to={getAssetUrl(asset, isManager && isLand(asset))}
       onClick={onClick}
     >
-      <AssetImage asset={asset} showMonospace />
+      <AssetImage
+        asset={asset}
+        showOrderListedTag={showListedTag}
+        showMonospace
+      />
       {showRentalBubble ? (
         <RentalChip
           asset={asset}
@@ -118,7 +121,6 @@ const AssetCard = (props: Props) => {
           rental={rental}
         />
       ) : null}
-      {showListedTag ? <ListedBadge className="listed-badge" /> : null}
       <Card.Content>
         <Card.Header>
           <div className="title">{title}</div>

--- a/webapp/src/components/AssetImage/AssetImage.container.ts
+++ b/webapp/src/components/AssetImage/AssetImage.container.ts
@@ -9,15 +9,15 @@ import {
   getWearablePreviewController
 } from '../../modules/ui/preview/selectors'
 import {
+  setIsTryingOn,
+  setWearablePreviewController
+} from '../../modules/ui/preview/actions'
+import {
   MapStateProps,
   MapDispatchProps,
   MapDispatch
 } from './AssetImage.types'
 import AssetImage from './AssetImage'
-import {
-  setIsTryingOn,
-  setWearablePreviewController
-} from '../../modules/ui/preview/actions'
 
 const mapState = (state: RootState): MapStateProps => {
   const profiles = getProfiles(state)

--- a/webapp/src/components/AssetImage/AssetImage.css
+++ b/webapp/src/components/AssetImage/AssetImage.css
@@ -184,3 +184,10 @@
   bottom: 12px;
   right: 12px;
 }
+
+.AssetImage .listed-badge {
+  z-index: 10;
+  position: absolute;
+  bottom: 11px;
+  right: 11px;
+}

--- a/webapp/src/components/AssetImage/AssetImage.tsx
+++ b/webapp/src/components/AssetImage/AssetImage.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { LazyLoadImage } from 'react-lazy-load-image-component'
 import classNames from 'classnames'
+import { Env } from '@dcl/ui-env'
 import { BodyShape, NFTCategory, PreviewEmote, Rarity } from '@dcl/schemas'
 import { T, t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
@@ -16,10 +17,10 @@ import {
 import { getAssetImage, getAssetName } from '../../modules/asset/utils'
 import { getSelection, getCenter } from '../../modules/nft/estate/utils'
 import { Atlas } from '../Atlas'
+import ListedBadge from '../ListedBadge'
+import { config } from '../../config'
 import { ControlOptionAction, Props } from './AssetImage.types'
 import './AssetImage.css'
-import { config } from '../../config'
-import { Env } from '@dcl/ui-env'
 
 // 1x1 transparent pixel
 const PIXEL =
@@ -487,7 +488,7 @@ const AssetImage = (props: Props) => {
 
 // the purpose of this wrapper is to make the div always be square, by using a 1x1 transparent pixel
 const AssetImageWrapper = (props: Props) => {
-  const { asset, className, ...rest } = props
+  const { asset, className, showOrderListedTag, ...rest } = props
 
   let classes = 'AssetImage'
   if (className) {
@@ -498,6 +499,7 @@ const AssetImageWrapper = (props: Props) => {
     <div className={classes}>
       <img src={PIXEL} alt="pixel" className="pixel" />
       <div className="image-wrapper">
+        {showOrderListedTag ? <ListedBadge className="listed-badge" /> : null}
         <AssetImage asset={asset} {...rest} />
       </div>
     </div>

--- a/webapp/src/components/AssetImage/AssetImage.types.ts
+++ b/webapp/src/components/AssetImage/AssetImage.types.ts
@@ -22,9 +22,12 @@ export type Props = {
   wearableController?: IPreviewController | null
   isTryingOn: boolean
   isPlayingEmote?: boolean
+  showOrderListedTag?: boolean
   onSetIsTryingOn: typeof setIsTryingOn
   onSetWearablePreviewController: typeof setWearablePreviewController
 }
+
+export type OwnProps = Pick<Props, 'showOrderListedTag'>
 
 export enum ControlOptionAction {
   ZOOM_IN,


### PR DESCRIPTION
This PR fixes the order tag that was unaligned when showing assets in different screens.
The PR changes where the order listing tag is shown so it gets rendered alongside the `AssetImage`, grabbing its parent height and using the `bottom` property to position it at the bottom.

Closes #1196