### PR TITLE
fix: Add missing editing cost warning message

### DIFF
--- a/webapp/src/components/ManageAssetPage/Rent/Rent.module.css
+++ b/webapp/src/components/ManageAssetPage/Rent/Rent.module.css
@@ -37,8 +37,8 @@
   flex-direction: row;
 }
 
-.header .right .actionButton {
-  margin-right: 12px;
+.header .right .actionButton + .action {
+  margin-left: 12px;
 }
 
 .content {

--- a/webapp/src/components/Modals/RentalListingModal/CreateOrEditListingStep/CreateOrEditListingStep.module.css
+++ b/webapp/src/components/Modals/RentalListingModal/CreateOrEditListingStep/CreateOrEditListingStep.module.css
@@ -135,3 +135,11 @@
     grid-template-rows: 34px 34px 34px;
   }
 }
+
+.editingCostWarning {
+  font-size: 15px;
+  padding: 15px;
+  border-radius: 6px;
+  background-color: #37333D;
+  margin-bottom: 16px;
+}

--- a/webapp/src/components/Modals/RentalListingModal/CreateOrEditListingStep/CreateOrEditListingStep.tsx
+++ b/webapp/src/components/Modals/RentalListingModal/CreateOrEditListingStep/CreateOrEditListingStep.tsx
@@ -156,6 +156,11 @@ const CreateListingStep = (props: Props) => {
         onClose={onCancel}
       />
       <Modal.Content>
+        {rental ? (
+          <div className={styles.editingCostWarning}>
+            {t('rental_modal.create_listing_step.editing_cost_warning')}
+          </div>
+        ) : null}
         <div className={styles.pricePerDay}>
           <ManaField
             type="text"

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -746,7 +746,7 @@
     }
   },
   "maintainance": {
-    "notice": "We're currently under maintainance, we'll be back soon!"
+    "notice": "We're currently under maintenance, we'll be back soon!"
   },
   "rental_modal": {
     "confirm_rent_step": {
@@ -790,6 +790,7 @@
         "edit": "Edit listing",
         "create": "List for Rent"
       },
+      "editing_cost_warning": "Editing the publication will require executing a new transaction for which you will need to pay its gas fees.",
       "update_listing": "Update listing",
       "remove_listing": "Remove listing",
       "price_per_day": "Price per day",

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -783,6 +783,7 @@
         "edit": "Editar listado de alquiler",
         "create": "Poner en alquiler"
       },
+      "editing_cost_warning": "Editar la publicación va a requerir ejecutar una nueva transacción para la cual será necesario pagar los costos de la misma.",
       "update_listing": "Actualizar listado de alquiler",
       "remove_listing": "Remover listado de alquiler",
       "price_per_day": "Precio por día",

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -785,6 +785,7 @@
         "edit": "编辑出租列表",
         "create": "列出土地出租"
       },
+      "editing_cost_warning": "编辑出版物将需要执行一项新交易，您需要为此支付汽油费。",
       "update_listing": "更新出租清单",
       "remove_listing": "删除出租列表",
       "price_per_day": "每天的价格",


### PR DESCRIPTION
This PR adds a missing editing cost warning message when editing the rental listings.
<img width="410" alt="Screen Shot 2023-01-03 at 09 20 32" src="https://user-images.githubusercontent.com/1120791/210357696-59badc52-112a-4165-bd19-9018a4989002.png">
<img width="538" alt="Screen Shot 2023-01-03 at 09 20 22" src="https://user-images.githubusercontent.com/1120791/210357700-114b34ec-66a0-4255-970f-329cfc832f7a.png">
Closes #1146
