### PR TITLE
fix: hide assetbrowse left sidebar on mobile

### DIFF
--- a/webapp/src/components/AssetBrowse/AssetBrowse.css
+++ b/webapp/src/components/AssetBrowse/AssetBrowse.css
@@ -138,6 +138,10 @@
     max-width: 100%;
   }
 
+  .AssetBrowse .sidebar {
+    display: none;
+  }
+
   .AssetBrowse .Layout .right.column > div {
     width: 100%;
   }

--- a/webapp/src/components/BackToTopButton/BackToTopButton.module.css
+++ b/webapp/src/components/BackToTopButton/BackToTopButton.module.css
@@ -14,7 +14,7 @@
     min-width: unset;
     padding: 16px 18px;
   }
-  .backToTop:global(.ui.button > .arrow.up.icon) {
+  .backToTop:global(.ui.button:not(.icon) > .icon:not(.button):not(.dropdown)) {
     margin-right: -4px;
   }
 }


### PR DESCRIPTION
Without these changes, it looks like this:

![image](https://user-images.githubusercontent.com/8763687/211018239-2cb4f995-fede-4e8c-9da8-de16257e5eee.png)


## after the changes

![image](https://user-images.githubusercontent.com/8763687/211018272-0d0a5264-6a32-4958-8999-25c204c3c96d.png)
