### PR TITLE
feat: Add rentals to tile map

### DIFF
--- a/webapp/src/components/Atlas/Atlas.tsx
+++ b/webapp/src/components/Atlas/Atlas.tsx
@@ -28,6 +28,7 @@ const Atlas: React.FC<Props> = (props: Props) => {
     nftsOnRent,
     withPopup,
     showOnSale,
+    showForRent,
     tilesByEstateId,
     getContract
   } = props
@@ -124,11 +125,15 @@ const Atlas: React.FC<Props> = (props: Props) => {
     [selection, tiles, isEstate]
   )
 
-  const forSaleLayer: Layer = useCallback(
+  const forSaleOrRentLayer: Layer = useCallback(
     (x, y) => {
       const key = getCoords(x, y)
       const tile = tiles[key] as AtlasTile & { price?: string }
-      if (tile && 'price' in tile) {
+      if (
+        tile &&
+        (('price' in tile && showOnSale) ||
+          ('rentalListing' in tile && showForRent))
+      ) {
         return {
           color: '#00d3ff',
           left: !!tile.left,
@@ -138,7 +143,7 @@ const Atlas: React.FC<Props> = (props: Props) => {
       }
       return null
     },
-    [tiles]
+    [tiles, showOnSale, showForRent]
   )
 
   const selectedStrokeLayer: Layer = useCallback(
@@ -282,8 +287,8 @@ const Atlas: React.FC<Props> = (props: Props) => {
     selectedFillLayer
   ]
 
-  if (showOnSale) {
-    layers.unshift(forSaleLayer)
+  if (showOnSale || showForRent) {
+    layers.unshift(forSaleOrRentLayer)
   }
 
   return (
@@ -309,7 +314,8 @@ const Atlas: React.FC<Props> = (props: Props) => {
 }
 
 Atlas.defaultProps = {
-  showOnSale: true
+  showOnSale: true,
+  showForRent: true
 }
 
 export default Atlas

--- a/webapp/src/components/Atlas/Atlas.types.ts
+++ b/webapp/src/components/Atlas/Atlas.types.ts
@@ -1,4 +1,5 @@
 import { Dispatch } from 'redux'
+import { RentalListing } from '@dcl/schemas'
 import { CallHistoryMethodAction } from 'connected-react-router'
 import { AtlasTile, AtlasProps } from 'decentraland-ui'
 import { OnRentNFT } from '../../modules/ui/browse/types'
@@ -6,11 +7,14 @@ import { NFT } from '../../modules/nft/types'
 import { Contract } from '../../modules/vendor/services'
 import { getContract } from '../../modules/contract/selectors'
 
+export type TileRentalListing = Pick<RentalListing, 'expiration' | 'periods'>
+
 export type Tile = AtlasTile & {
   estate_id?: string
   price?: number
   owner?: string
   name?: string
+  rentalListing?: TileRentalListing
 }
 
 export type Props = Partial<AtlasProps> & {
@@ -23,6 +27,7 @@ export type Props = Partial<AtlasProps> & {
   withPopup?: boolean
   withNavigation?: boolean
   showOnSale?: boolean
+  showForRent?: boolean
   getContract: (query: Partial<Contract>) => ReturnType<typeof getContract>
   onNavigate: (path: string) => void
 }

--- a/webapp/src/components/Atlas/Popup/Popup.css
+++ b/webapp/src/components/Atlas/Popup/Popup.css
@@ -40,6 +40,23 @@
 
 .AtlasPopup .price .dcl.mana {
   font-size: 14px;
+  margin-bottom: 0px;
+  margin-top: 0px;
+  padding: 0px
+}
+
+.AtlasPopup .dcl.mana + .dcl.mana {
+  margin-left: 20px;
+}
+
+.AtlasPopup .prices {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.AtlasPopup .rental-day {
+  font-size: 14px;
 }
 
 .AtlasPopup.no-owner .owner {

--- a/webapp/src/components/Atlas/Popup/Popup.tsx
+++ b/webapp/src/components/Atlas/Popup/Popup.tsx
@@ -1,17 +1,30 @@
 import * as React from 'react'
 import { ethers } from 'ethers'
-import { Row, Section, Header } from 'decentraland-ui'
+import { Row, Section, Header, HeaderSubheader } from 'decentraland-ui'
 import { Profile } from 'decentraland-dapps/dist/containers'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import { getMaxPriceOfPeriods } from '../../../modules/rental/utils'
 import { Coordinate } from '../../Coordinate'
 import { Mana } from '../../Mana'
 import { Props } from './Popup.types'
 import './Popup.css'
+import { formatWeiMANA } from '../../../lib/mana'
 
 export default class Popup extends React.PureComponent<Props> {
+  subPriceHeader() {
+    const { tile } = this.props
+    if (tile.price && tile.rentalListing) {
+      return t('atlas.for_sale_and_rent')
+    } else if (tile.price) {
+      return t('atlas.for_sale')
+    }
+    return t('atlas.for_rent')
+  }
+
   render() {
     const { x, y, visible, tile, position } = this.props
     const isEstate = !!tile.estate_id
+
     return (
       <div
         className={`AtlasPopup ${position} ${
@@ -30,17 +43,28 @@ export default class Popup extends React.PureComponent<Props> {
         </Section>
 
         <Section className="owner">
-          <Header sub>{t('asset_page.owner')}</Header>
+          <Header sub>{t('atlas.owner')}</Header>
           <Profile
             address={tile.owner || ethers.constants.AddressZero}
             debounce={500}
           />
         </Section>
 
-        {tile.price ? (
+        {tile.price || tile.rentalListing ? (
           <Section className="price">
-            <Header sub>{t('asset_page.price')}</Header>
-            <Mana>{tile.price.toLocaleString()}</Mana>
+            <Header sub>{t('atlas.price')}</Header>
+            <HeaderSubheader>{this.subPriceHeader()}</HeaderSubheader>
+            <div className={'prices'}>
+              {tile.price ? <Mana>{tile.price.toLocaleString()}</Mana> : null}
+              {tile.rentalListing ? (
+                <>
+                  <Mana>
+                    {formatWeiMANA(getMaxPriceOfPeriods(tile.rentalListing))}
+                  </Mana>
+                  <span className="rental-day">/{t('global.day')}</span>
+                </>
+              ) : null}
+            </div>
           </Section>
         ) : null}
       </div>

--- a/webapp/src/modules/rental/utils.ts
+++ b/webapp/src/modules/rental/utils.ts
@@ -138,7 +138,9 @@ export function getOpenRentalId(asset: Asset | null): string | null {
   return (asset as NFT | null)?.openRentalId ?? null
 }
 
-export function getMaxPriceOfPeriods(rental: RentalListing): string {
+export function getMaxPriceOfPeriods<
+  T extends { periods: RentalListing['periods'] }
+>(rental: T): string {
   return rental.periods.reduce(
     (maxPeriodPrice, period) =>
       BigNumber.from(maxPeriodPrice).gte(period.pricePerDay)

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -928,5 +928,12 @@
     "browse_listings": "Browse listings",
     "list_your_land": "List your land for rent",
     "description": "<p>If you are a LAND owner you can now earn MANA by renting your parcels or estates to content creators.</p> <p>Are you a content creator? Now you can publish your builds to Genesis City without the need of owning LAND.</p> <p>If you want to learn more, <a>read our blog post</a>.</p>"
+  },
+  "atlas": {
+    "price": "Price",
+    "owner": "Owner",
+    "for_sale_and_rent": "Available for sale or rent",
+    "for_sale": "Available for sale",
+    "for_rent": "Available for rent"
   }
 }

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -921,5 +921,12 @@
     "browse_listings": "Ver tierras para rentar",
     "list_your_land": "Lista tu tierra a la renta",
     "description": "<p>Si eres dueño de tierra ahora puede ganar MANA rentando tus parcelas o estates a creadores de contenido.</p> <p>¿Eres un creador de contenido? Ahora puedes publicar tu escenas en la Genesis City sin la necesidad de poseer tierras.</p> <p>Si quieres leer más sobre ésto, <a>lee nuestro blog post</a>.</p>"
+  },
+  "atlas": {
+    "price": "Precio",
+    "owner": "Dueño",
+    "for_sale_and_rent": "Disponible para la compra o renta",
+    "for_sale": "Disponible para la compra",
+    "for_rent": "Disponible para la renta"
   }
 }

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -923,5 +923,12 @@
     "browse_listings": "BROWSE LISTINGS",
     "list_your_land": "LIST YOUR LAND ON RENT",
     "description": "<p>If you are a LAND owner you can now earn MANA by renting your parcels or estates to content creators.</p> <p>Are you a content creator? Now you can publish your builds to Genesis City without the need of owning LAND.</p> <p>If you want to learn more, <a>read our blog post</a>.</p>"
+  },
+  "atlas": {
+    "price": "价钱",
+    "owner": "所有者",
+    "for_sale_and_rent": "可供出售或出租",
+    "for_sale": "可供出售",
+    "for_rent": "可供出租"
   }
 }


### PR DESCRIPTION
This PR adds the capability to process rental listing that come from the atlas server and show them painted as light blue (the same color as the ones for sale) in the map. It also changes the popups to show the rental price.
<img width="286" alt="Screen Shot 2023-01-07 at 20 22 54" src="https://user-images.githubusercontent.com/1120791/211174038-5b3b87ae-06f5-47bf-9317-6935ebba49b2.png">
