### PR TITLE
fix: onSale reset behavior and keyboard usage for category menu

### DIFF
--- a/webapp/src/components/Menu/MenuItem/MenuItem.tsx
+++ b/webapp/src/components/Menu/MenuItem/MenuItem.tsx
@@ -30,8 +30,22 @@ const MenuItem = <T extends unknown>(props: Props<T>) => {
     onClick(value)
   }, [value, onClick])
 
+  const handleOnKeyDown = useCallback(
+    event => {
+      if (event.keyCode === 13) {
+        handleOnClick()
+      }
+    },
+    [handleOnClick]
+  )
+
   return (
-    <li className={classNames.join(' ')} onClick={handleOnClick} tabIndex={0}>
+    <li
+      className={classNames.join(' ')}
+      onClick={handleOnClick}
+      tabIndex={0}
+      onKeyDown={handleOnKeyDown}
+    >
       {image && <Image alt={image} src={image} width="25" circular />}
 
       <div className="content">

--- a/webapp/src/modules/routing/sagas.ts
+++ b/webapp/src/modules/routing/sagas.ts
@@ -148,9 +148,15 @@ function* handleClearFilters() {
     'minPrice',
     'maxPrice',
     'onlySmart',
-    'onlyOnSale',
     'search'
   ])
+
+  // The onlyOnSale filter is ON by default. The clear should remove it if it's off so it's back on (default state)
+  if (!browseOptions.onlyOnSale) {
+    clearedBrowseOptions.onlyOnSale = true
+  }
+  // reset the pages to the first one
+  clearedBrowseOptions.page = 1
 
   yield call(fetchAssetsFromRoute, clearedBrowseOptions)
   yield put(push(buildBrowseURL(pathname, clearedBrowseOptions)))


### PR DESCRIPTION
Closes #1241

![image](https://user-images.githubusercontent.com/8763687/212119857-6c56551e-0450-4000-b008-b49534845a2a.png)


When clicking clear filters the URL will have `onlyOnSale=true`:
```
http://localhost:3000/browse?assetType=nft&section=wearables_facial_hair&vendor=decentraland&page=1&sortBy=recently_listed&onlyOnSale=true&viewAsGuest=false
```
![image](https://user-images.githubusercontent.com/8763687/212120142-5396810e-e99f-4315-94b9-683faecfc839.png)


