### PR TITLE
fix: add margin to asset topbar

### DIFF
--- a/webapp/src/components/AssetTopbar/AssetTopbar.module.css
+++ b/webapp/src/components/AssetTopbar/AssetTopbar.module.css
@@ -162,4 +162,8 @@
   .assetTopbar {
     margin-bottom: 0;
   }
+
+  .assetTopbar .infoRow {
+    margin-bottom: 10px;
+  }
 }


### PR DESCRIPTION
Add some margin to asset topbar on mobile