### PR TITLE
feat: add more memory to GH action runner

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -29,6 +29,8 @@ jobs:
       - name: Install
         run: npm ci --legacy-peer-deps
       - name: Build
+        env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
         run: npm run build
       - name: Publish
         uses: menduz/oddish-action@master


### PR DESCRIPTION
The GH runner is runnig out of memory space when running the `npm run build`, we need to override the default value to use more memory.