### PR TITLE
fix: prevent CollectionProvider from looping forever when collection is not found

### DIFF
--- a/webapp/src/components/CollectionProvider/CollectionProvider.container.ts
+++ b/webapp/src/components/CollectionProvider/CollectionProvider.container.ts
@@ -9,7 +9,8 @@ import {
 import {
   getLoading,
   getCollectionsByAddress,
-  isFetchingCollection
+  isFetchingCollection,
+  getError as getCollectionError
 } from '../../modules/collection/selectors'
 import { fetchItemsRequest } from '../../modules/item/actions'
 import {
@@ -33,7 +34,8 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => ({
   isLoadingCollectionItems: isFetchingItemsOfCollection(
     state,
     ownProps.contractAddress
-  )
+  ),
+  error: getCollectionError(state)
 })
 
 const mapDispatch = (

--- a/webapp/src/components/CollectionProvider/CollectionProvider.tsx
+++ b/webapp/src/components/CollectionProvider/CollectionProvider.tsx
@@ -10,10 +10,11 @@ const CollectionProvider = ({
   contractAddress,
   onFetchCollection,
   onFetchCollectionItems,
-  children
+  children,
+  error
 }: Props) => {
   useEffect(() => {
-    if (!isLoadingCollection && !collection) {
+    if (!isLoadingCollection && !collection && !error) {
       onFetchCollection()
     }
 
@@ -33,7 +34,8 @@ const CollectionProvider = ({
     onFetchCollection,
     isLoadingCollection,
     isLoadingCollectionItems,
-    onFetchCollectionItems
+    onFetchCollectionItems,
+    error
   ])
 
   return (

--- a/webapp/src/components/CollectionProvider/CollectionProvider.types.tsx
+++ b/webapp/src/components/CollectionProvider/CollectionProvider.types.tsx
@@ -10,6 +10,7 @@ export type Props = {
   isLoadingCollectionItems: boolean
   onFetchCollection: () => void
   onFetchCollectionItems: (collection: Collection) => void
+  error: string | null
   children: (
     data: Pick<Props, 'collection' | 'items'> & { isLoading: boolean }
   ) => ReactNode
@@ -17,7 +18,11 @@ export type Props = {
 
 export type MapStateProps = Pick<
   Props,
-  'collection' | 'items' | 'isLoadingCollection' | 'isLoadingCollectionItems'
+  | 'collection'
+  | 'items'
+  | 'isLoadingCollection'
+  | 'isLoadingCollectionItems'
+  | 'error'
 >
 export type MapDispatchProps = Pick<
   Props,


### PR DESCRIPTION
Closes #1349