### PR TITLE
fix: Wearable asset page show incorrect gender badge text

### DIFF
--- a/webapp/src/modules/nft/utils.spec.ts
+++ b/webapp/src/modules/nft/utils.spec.ts
@@ -1,6 +1,7 @@
-import { NFTCategory } from '@dcl/schemas'
+import { BodyShape, NFTCategory } from '@dcl/schemas'
+import { NFTData } from '../vendor/decentraland'
 import { NFT } from './types'
-import { isPartOfEstate } from './utils'
+import { isPartOfEstate, getBodyShapeUrn, isGender } from './utils'
 
 describe('when checking that a NFT is part of a Estate', () => {
   let nft: NFT
@@ -94,6 +95,139 @@ describe('when checking that a NFT is part of a Estate', () => {
 
     it('should return false', () => {
       expect(isPartOfEstate(nft)).toBe(false)
+    })
+  })
+})
+
+describe('when getting the Wearable BodyShapeUrn', () => {
+  let nft: NFT
+  beforeEach(() => {
+    nft = {
+      data: {
+        wearable: {} as NFTData[NFTCategory.WEARABLE]
+      }
+    } as NFT
+  })
+
+  describe('and the NFT bodyShape is "BaseMale"', () => {
+    beforeEach(() => {
+      nft.data.wearable = {
+        bodyShapes: ['BaseMale' as BodyShape.MALE]
+      } as NFTData[NFTCategory.WEARABLE]
+    })
+
+    it('should return "urn:decentraland:off-chain:base-avatars:BaseMale"', () => {
+      const bodyShape: string = nft.data.wearable
+        ? nft.data.wearable.bodyShapes[0]
+        : ''
+      expect(getBodyShapeUrn(bodyShape)).toBe(BodyShape.MALE)
+    })
+  })
+
+  describe('and the NFT bodyShape is "BaseFemale"', () => {
+    beforeEach(() => {
+      nft.data.wearable = {
+        bodyShapes: ['BaseFemale' as BodyShape.FEMALE]
+      } as NFTData[NFTCategory.WEARABLE]
+    })
+
+    it('should return "urn:decentraland:off-chain:base-avatars:BaseFemale"', () => {
+      const bodyShape: string = nft.data.wearable
+        ? nft.data.wearable.bodyShapes[0]
+        : ''
+      expect(getBodyShapeUrn(bodyShape)).toBe(BodyShape.FEMALE)
+    })
+  })
+})
+
+describe('when checking that a Wearable is gender or unisex', () => {
+  let nft: NFT
+  beforeEach(() => {
+    nft = {
+      data: {
+        wearable: {} as NFTData[NFTCategory.WEARABLE]
+      }
+    } as NFT
+  })
+
+  describe('and the Wearable bodyShape is "BaseMale"', () => {
+    beforeEach(() => {
+      nft.data.wearable = {
+        bodyShapes: ['BaseMale' as BodyShape.MALE]
+      } as NFTData[NFTCategory.WEARABLE]
+    })
+
+    describe('and is comparing to "BodyShape.MALE"', () => {
+      it('should return true', () => {
+        const bodyShape: BodyShape[] = nft.data.wearable
+          ? [nft.data.wearable.bodyShapes[0]]
+          : []
+        expect(isGender(bodyShape, BodyShape.MALE)).toBe(true)
+      })
+    })
+
+    describe('and is comparing to "BodyShape.FEMALE"', () => {
+      it('should return false', () => {
+        const bodyShape: BodyShape[] = nft.data.wearable
+          ? [nft.data.wearable.bodyShapes[0]]
+          : []
+        expect(isGender(bodyShape, BodyShape.FEMALE)).toBe(false)
+      })
+    })
+  })
+
+  describe('and the Wearable bodyShape is "BaseFemale"', () => {
+    beforeEach(() => {
+      nft.data.wearable = {
+        bodyShapes: ['BaseFemale' as BodyShape.FEMALE]
+      } as NFTData[NFTCategory.WEARABLE]
+    })
+
+    describe('and is comparing to "BodyShape.FEMALE"', () => {
+      it('should return true', () => {
+        const bodyShape: BodyShape[] = nft.data.wearable
+          ? [nft.data.wearable.bodyShapes[0]]
+          : []
+        expect(isGender(bodyShape, BodyShape.FEMALE)).toBe(true)
+      })
+    })
+
+    describe('and is comparing to "BodyShape.MALE"', () => {
+      it('should return false', () => {
+        const bodyShape: BodyShape[] = nft.data.wearable
+          ? [nft.data.wearable.bodyShapes[0]]
+          : []
+        expect(isGender(bodyShape, BodyShape.MALE)).toBe(false)
+      })
+    })
+  })
+
+  describe('and the Wearable bodyShape is "Unisex"', () => {
+    beforeEach(() => {
+      nft.data.wearable = {
+        bodyShapes: [
+          'BaseMale' as BodyShape.MALE,
+          'BaseFemale' as BodyShape.FEMALE
+        ]
+      } as NFTData[NFTCategory.WEARABLE]
+    })
+
+    describe('and is comparing to "BodyShape.FEMALE"', () => {
+      it('should return false', () => {
+        const bodyShape: BodyShape[] = nft.data.wearable
+          ? nft.data.wearable.bodyShapes
+          : []
+        expect(isGender(bodyShape, BodyShape.FEMALE)).toBe(false)
+      })
+    })
+
+    describe('and is comparing to "BodyShape.MALE"', () => {
+      it('should return false', () => {
+        const bodyShape: BodyShape[] = nft.data.wearable
+          ? nft.data.wearable.bodyShapes
+          : []
+        expect(isGender(bodyShape, BodyShape.MALE)).toBe(false)
+      })
     })
   })
 })

--- a/webapp/src/modules/nft/utils.ts
+++ b/webapp/src/modules/nft/utils.ts
@@ -21,11 +21,14 @@ export function getNFT(
   return nftId in nfts ? nfts[nftId] : null
 }
 
+export const getBodyShapeUrn = (bodyShape: string) =>
+  `urn:decentraland:off-chain:base-avatars:${bodyShape}`
+
 export function isGender(bodyShapes: BodyShape[], gender: BodyShape) {
   if (bodyShapes.length !== 1) {
     return false
   }
-  return bodyShapes[0] === gender
+  return bodyShapes[0] === gender || getBodyShapeUrn(bodyShapes[0]) === gender
 }
 
 export function isUnisex(bodyShapes: BodyShape[]) {


### PR DESCRIPTION
This PR fixes the wrong gender text shown in the gender badge

Female gender badge:
![image](https://user-images.githubusercontent.com/3170051/216362740-48aca479-fd48-475a-a8df-7f289f30446e.png)

Male gender badge:
![image](https://user-images.githubusercontent.com/3170051/216362786-580e613c-8870-43fb-83cc-b5301b807375.png)

Closes #1376 