### PR TITLE
fix: Validate wearable has a valid representation for the current avatar

### DIFF
--- a/webapp/src/components/AssetImage/AssetImage.tsx
+++ b/webapp/src/components/AssetImage/AssetImage.tsx
@@ -256,7 +256,7 @@ const AssetImage = (props: Props) => {
               }
               skin={skin}
               hair={hair}
-              emote={previewEmote}
+              emote={isTryingOnEnabled ? previewEmote : undefined}
               onLoad={handleLoad}
               onError={handleError}
               dev={config.is(Env.DEVELOPMENT)}


### PR DESCRIPTION
This PR avoids sending a preview emote to the WearablePreview with an undefined avatar.

Closes #1377 