### PR TITLE
fix: Remove scientific notation in small numbers

### DIFF
--- a/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
+++ b/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
@@ -25,7 +25,7 @@ import { isPartOfEstate } from '../../../modules/nft/utils'
 import { AssetType } from '../../../modules/asset/types'
 import { builderUrl } from '../../../lib/environment'
 import { isOwnedBy } from '../../../modules/asset/utils'
-import { addressEquals } from '../../../modules/wallet/utils'
+import { addressEquals, formatBalance } from '../../../modules/wallet/utils'
 import { Mana } from '../../Mana'
 import { ManaToFiat } from '../../ManaToFiat'
 import { AuthorizationModal } from '../../AuthorizationModal'
@@ -123,7 +123,7 @@ const SaleRentActionBox = ({
       !!rental &&
       !!currentMana &&
       ethers.utils
-        .parseEther(currentMana.toString())
+        .parseEther(formatBalance(currentMana))
         .gte(
           ethers.BigNumber.from(
             rental.periods[selectedRentalPeriodIndex].pricePerDay
@@ -135,7 +135,7 @@ const SaleRentActionBox = ({
     () =>
       !!order &&
       !!currentMana &&
-      ethers.utils.parseEther(currentMana.toString()).gte(order.price),
+      ethers.utils.parseEther(formatBalance(currentMana)).gte(order.price),
     [order, currentMana]
   )
 

--- a/webapp/src/modules/wallet/utils.spec.ts
+++ b/webapp/src/modules/wallet/utils.spec.ts
@@ -1,0 +1,21 @@
+import { formatBalance } from './utils'
+
+describe('when formatting the balance', () => {
+  describe('and the number is 0', () => {
+    it('should return 0', () => {
+      expect(formatBalance(0.0)).toBe('0')
+    })
+  })
+
+  describe('and the number is too low', () => {
+    it('should fixed the number based on the scientific notation', () => {
+      expect(formatBalance(0.000000000000008588)).toBe('0.000000000000009')
+    })
+  })
+
+  describe('and is near to the max amount of MANA', () => {
+    it('should return the same number', () => {
+      expect(formatBalance(229355146838009200000)).toBe('229355146838009200000')
+    })
+  })
+})

--- a/webapp/src/modules/wallet/utils.ts
+++ b/webapp/src/modules/wallet/utils.ts
@@ -28,3 +28,15 @@ export async function getEth(): Promise<ethers.providers.Web3Provider> {
 
   return new ethers.providers.Web3Provider(provider)
 }
+
+// TODO: remove after fixing the following issue https://app.zenhub.com/workspaces/dapps-5ffc44ecec9f8500140e173c/issues/gh/decentraland/dapps-issues/45
+function removeScientificNotationForSmallNumbers(number: number): string {
+  // fix the amount of decimals to the exponent of the scientific notation when the number is too low
+  return number.toFixed(parseInt(number.toString().split('-')[1]))
+}
+
+export function formatBalance(balance: number) {
+  return balance.toString().includes('-')
+    ? removeScientificNotationForSmallNumbers(balance)
+    : balance.toString()
+}


### PR DESCRIPTION
It works both for small numbers and for the max amount of MANA that a user could have.