### PR TITLE
fix: Show list for rent button after expired rental listing

### DIFF
--- a/webapp/src/components/ManageAssetPage/Rent/Rent.tsx
+++ b/webapp/src/components/ManageAssetPage/Rent/Rent.tsx
@@ -84,7 +84,7 @@ export const Rent = (props: Props) => {
     wallet && rental && canBeClaimed(wallet.address, rental, nft)
 
   const rentButton = useMemo(() => {
-    if (!rental) {
+    if (!rental || (isRentalListingCancelled(rental) && !canBeClaimedBack)) {
       return (
         <Button
           className={styles.actionButtonRounded}
@@ -93,11 +93,10 @@ export const Rent = (props: Props) => {
           {t('manage_asset_page.rent.list_for_rent')}
         </Button>
       )
-    }
-    if (rental && isRentalListingOpen(rental)) {
+    } else if (rental && isRentalListingOpen(rental)) {
       return <IconButton iconName="pencil" onClick={handleOnCreateOrEdit} />
     }
-  }, [handleOnCreateOrEdit, rental])
+  }, [handleOnCreateOrEdit, rental, canBeClaimedBack])
 
   return (
     <section className={classNames(styles.box, className)}>


### PR DESCRIPTION
This PR fixes an issue where rented lands that expired were not able to be listed for rent again (the button was not visible).