### PR TITLE
fix: Make small name brighter in the names cards

### DIFF
--- a/webapp/src/components/AssetImage/AssetImage.css
+++ b/webapp/src/components/AssetImage/AssetImage.css
@@ -73,6 +73,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   text-transform: lowercase;
+  color: #CFCDD4;
 }
 
 .AssetImage .WearablePreview {


### PR DESCRIPTION
In order to improve accessibility and avoid name scams, this PR changes the color of the name detail in the ENS names cards.

Before:
![Screenshot 2023-03-17 at 09 49 28](https://user-images.githubusercontent.com/1120791/225909497-da23af9e-a46a-4704-b228-9960483bd032.png)

After:
![Screenshot 2023-03-17 at 09 49 08](https://user-images.githubusercontent.com/1120791/225909503-58742ce2-7427-4a3c-a0b9-70183a0428b3.png)

Closes #1467