### PR TITLE
fix: map view filter issues

### DIFF
--- a/webapp/src/components/Atlas/Atlas.css
+++ b/webapp/src/components/Atlas/Atlas.css
@@ -18,6 +18,11 @@
   align-items: center;
   justify-content: center;
   padding: 0;
+  background: #736e7d;
+}
+
+.atlas-wrapper .ui.button.primary.atlas-info-button.atlas-info-open {
+  background: var(--primary);
 }
 
 .atlas-wrapper .ui.button.primary.atlas-info-button:focus {

--- a/webapp/src/components/Atlas/Atlas.tsx
+++ b/webapp/src/components/Atlas/Atlas.tsx
@@ -98,7 +98,6 @@ const Atlas: React.FC<Props> = (props: Props) => {
   )
 
   const userRentedTiles = useMemo(() => {
-    console.log({ nftsOnRent })
     return nftsOnRent.reduce(
       (lands, [nft, rental]) =>
         setLand(
@@ -177,7 +176,6 @@ const Atlas: React.FC<Props> = (props: Props) => {
   const userLayer: Layer = useCallback(
     (x: number, y: number) => {
       const tile = allUserTiles.get(getCoords(x, y))
-      console.log(tile)
       if (showOwned && tile) {
         return tile
       }

--- a/webapp/src/components/Atlas/Atlas.tsx
+++ b/webapp/src/components/Atlas/Atlas.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Popup as UIPopup } from 'decentraland-ui'
-import { NFTCategory } from '@dcl/schemas'
+import { NFTCategory, RentalStatus } from '@dcl/schemas'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import {
   Atlas as AtlasComponent,
@@ -16,6 +16,7 @@ import { VendorName } from '../../modules/vendor'
 import { NFT } from '../../modules/nft/types'
 import Popup from './Popup'
 import './Atlas.css'
+import classNames from 'classnames'
 
 const getCoords = (x: number | string, y: number | string) => `${x},${y}`
 
@@ -39,6 +40,7 @@ const Atlas: React.FC<Props> = (props: Props) => {
   } = props
 
   const [showPopup, setShowPopup] = useState(false)
+  const [isInfoPopupOpen, setIsInfoPopupOpen] = useState(false)
   const [hoveredTile, setHoveredTile] = useState<Tile | null>(null)
   const [mouseX, setMouseX] = useState(-1)
   const [mouseY, setMouseY] = useState(-1)
@@ -95,16 +97,18 @@ const Atlas: React.FC<Props> = (props: Props) => {
     [nfts, setLand]
   )
 
-  const userRentedTiles = useMemo(
-    () =>
-      nftsOnRent
-        .map(([nft]) => nft)
-        .reduce(
-          (lands, nft) => setLand(lands, nft, Color.SUNISH),
-          new Map<string, ReturnType<Layer>>()
+  const userRentedTiles = useMemo(() => {
+    console.log({ nftsOnRent })
+    return nftsOnRent.reduce(
+      (lands, [nft, rental]) =>
+        setLand(
+          lands,
+          nft,
+          rental.status === RentalStatus.EXECUTED ? Color.SUNISH : Color.SUMMER_RED
         ),
-    [nftsOnRent, setLand]
-  )
+      new Map<string, ReturnType<Layer>>()
+    )
+  }, [nftsOnRent, setLand])
 
   const isSelected = useCallback(
     (x: number, y: number) => {
@@ -173,6 +177,7 @@ const Atlas: React.FC<Props> = (props: Props) => {
   const userLayer: Layer = useCallback(
     (x: number, y: number) => {
       const tile = allUserTiles.get(getCoords(x, y))
+      console.log(tile)
       if (showOwned && tile) {
         return tile
       }
@@ -290,6 +295,15 @@ const Atlas: React.FC<Props> = (props: Props) => {
     }
   }, [withPopup, showPopup, mouseX, mouseY])
 
+  function handleInfoPopupOpen() {
+    setIsInfoPopupOpen(true)
+  }
+
+  function handleInfoPopupClose(evt: React.MouseEvent) {
+    evt.stopPropagation()
+    setIsInfoPopupOpen(false)
+  }
+
   // layers
   const layers = [
     userLayer,
@@ -331,10 +345,14 @@ const Atlas: React.FC<Props> = (props: Props) => {
             </div>
           }
           position="top right"
+          onClose={handleInfoPopupClose}
+          onOpen={handleInfoPopupOpen}
           trigger={
             <Button
               primary
-              className="atlas-info-button"
+              className={classNames('atlas-info-button', {
+                'atlas-info-open': isInfoPopupOpen
+              })}
               aria-label="info"
               tabIndex={0}
             >

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -395,8 +395,8 @@
       "all_items": "All networks"
     },
     "map": {
-      "on_rent": "Available for rent",
-      "on_sale": "Available for sale",
+      "on_rent": "Available to rent",
+      "on_sale": "Available to buy",
       "owned": "Owned by me",
       "map_colors": "Map colors",
       "plaza": "Plaza",

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -391,8 +391,8 @@
       "all_items": "Todas las redes"
     },
     "map": {
-      "on_rent": "Disponible para la renta",
-      "on_sale": "Disponible para la venta",
+      "on_rent": "Disponible para rentar",
+      "on_sale": "Disponible para comprar",
       "owned": "Mis tierras",
       "map_colors": "Colores del mapa",
       "plaza": "Plaza",

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -392,8 +392,8 @@
       "all_items": "所有网络"
     },
     "map": {
-      "on_rent": "可供出租",
-      "on_sale": "可供出售",
+      "on_rent": "可出租",
+      "on_sale": "可购买",
       "owned": "归我所有",
       "map_colors": "地图颜色",
       "plaza": "广场",


### PR DESCRIPTION
This pr fixes several issues in land map view:
- When it's not active, the info icon button should be gray
- Change labels to "Available to buy" and "Available to rent" instead "Available for rent"
- When clicking outside of popup and pressing on land parcel do not go directly to land, instead just close the popup.
- Only paint land in yellow when there is an rental in state "EXECUTED". If there is no current rental or its just a listing then we show it the same color as "YOUR LAND"