### PR TITLE
chore: Bump decentraland-dapps package

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -20,7 +20,7 @@
         "decentraland-connect": "^3.3.2",
         "decentraland-crypto-fetch": "^1.0.3",
         "decentraland-dapps": "^13.41.0",
-        "decentraland-transactions": "^1.42.0",
+        "decentraland-transactions": "^1.43.1",
         "decentraland-ui": "^3.87.1",
         "dotenv": "^10.0.0",
         "ethers": "^5.6.8",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -19,7 +19,7 @@
         "dcl-catalyst-commons": "^9.0.1",
         "decentraland-connect": "^3.3.2",
         "decentraland-crypto-fetch": "^1.0.3",
-        "decentraland-dapps": "^13.35.0",
+        "decentraland-dapps": "^13.41.0",
         "decentraland-transactions": "^1.42.0",
         "decentraland-ui": "^3.87.1",
         "dotenv": "^10.0.0",
@@ -8917,9 +8917,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "13.35.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.35.0.tgz",
-      "integrity": "sha512-aAmXP9by18R0iY8mdMp1isUuZVDvg90rOluRQh4X+njgFyPN48F9YnCFrCCOashs3OVvFqU84Wos3MqKI7nwNA==",
+      "version": "13.41.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.41.0.tgz",
+      "integrity": "sha512-nrYJu420VekIsWrxZD3xiDZwF6EeI3y9PUbwv2/EeHDmVaFjogbQgulcZleHnKz7CZE5y1AkdrFm0RvIEbIEvA==",
       "dependencies": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
@@ -8932,7 +8932,7 @@
         "date-fns": "^1.29.0",
         "dcl-catalyst-client": "^14.0.9",
         "decentraland-connect": "^3.5.0",
-        "decentraland-transactions": "^1.35.0",
+        "decentraland-transactions": "^1.43.1",
         "decentraland-ui": "^3.81.0",
         "ethers": "^5.6.8",
         "events": "^3.3.0",
@@ -9024,9 +9024,9 @@
       }
     },
     "node_modules/decentraland-transactions": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-1.42.0.tgz",
-      "integrity": "sha512-3AxbycNv7uI25xFEeX14EHPMTtDt2Jq0OAmnwYt8imeu5DYNhZjZ3QlXkNYv4ETraw17C153dSYKS6sCMJmuzg=="
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-1.43.1.tgz",
+      "integrity": "sha512-JJf6xrQJIFoS5DGzL6ZgSuRd5PtO5HOqK1pxLkxtShGmUFnVAV+gIqBA8o2oTzUzGc6uPXdR0zBar7/eyY6f8w=="
     },
     "node_modules/decentraland-ui": {
       "version": "3.87.1",
@@ -32369,9 +32369,9 @@
       }
     },
     "decentraland-dapps": {
-      "version": "13.35.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.35.0.tgz",
-      "integrity": "sha512-aAmXP9by18R0iY8mdMp1isUuZVDvg90rOluRQh4X+njgFyPN48F9YnCFrCCOashs3OVvFqU84Wos3MqKI7nwNA==",
+      "version": "13.41.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.41.0.tgz",
+      "integrity": "sha512-nrYJu420VekIsWrxZD3xiDZwF6EeI3y9PUbwv2/EeHDmVaFjogbQgulcZleHnKz7CZE5y1AkdrFm0RvIEbIEvA==",
       "requires": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
@@ -32384,7 +32384,7 @@
         "date-fns": "^1.29.0",
         "dcl-catalyst-client": "^14.0.9",
         "decentraland-connect": "^3.5.0",
-        "decentraland-transactions": "^1.35.0",
+        "decentraland-transactions": "^1.43.1",
         "decentraland-ui": "^3.81.0",
         "ethers": "^5.6.8",
         "events": "^3.3.0",
@@ -32446,9 +32446,9 @@
       }
     },
     "decentraland-transactions": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-1.42.0.tgz",
-      "integrity": "sha512-3AxbycNv7uI25xFEeX14EHPMTtDt2Jq0OAmnwYt8imeu5DYNhZjZ3QlXkNYv4ETraw17C153dSYKS6sCMJmuzg=="
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-1.43.1.tgz",
+      "integrity": "sha512-JJf6xrQJIFoS5DGzL6ZgSuRd5PtO5HOqK1pxLkxtShGmUFnVAV+gIqBA8o2oTzUzGc6uPXdR0zBar7/eyY6f8w=="
     },
     "decentraland-ui": {
       "version": "3.87.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -14,7 +14,7 @@
     "decentraland-connect": "^3.3.2",
     "decentraland-crypto-fetch": "^1.0.3",
     "decentraland-dapps": "^13.41.0",
-    "decentraland-transactions": "^1.42.0",
+    "decentraland-transactions": "^1.43.1",
     "decentraland-ui": "^3.87.1",
     "dotenv": "^10.0.0",
     "ethers": "^5.6.8",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -13,7 +13,7 @@
     "dcl-catalyst-commons": "^9.0.1",
     "decentraland-connect": "^3.3.2",
     "decentraland-crypto-fetch": "^1.0.3",
-    "decentraland-dapps": "^13.35.0",
+    "decentraland-dapps": "^13.41.0",
     "decentraland-transactions": "^1.42.0",
     "decentraland-ui": "^3.87.1",
     "dotenv": "^10.0.0",


### PR DESCRIPTION
This PR upgrades the `decentraland-dapps` and `decentraland-transactions` packages to show the new high network congestion modal.