### PR TITLE
feat: add infinite scroll to asset list

### DIFF
--- a/webapp/src/components/AssetList/AssetList.container.ts
+++ b/webapp/src/components/AssetList/AssetList.container.ts
@@ -1,4 +1,3 @@
-import { getLocation } from 'connected-react-router'
 import { connect } from 'react-redux'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 
@@ -10,7 +9,6 @@ import {
   getVendor,
   getPage,
   getAssetType,
-  getCurrentBrowseOptions,
   getSection,
   getSearch,
   hasFiltersEnabled
@@ -20,7 +18,6 @@ import { getLoading as getLoadingItems } from '../../modules/item/selectors'
 import { MapStateProps, MapDispatch, MapDispatchProps } from './AssetList.types'
 import AssetList from './AssetList'
 import { FETCH_ITEMS_REQUEST } from '../../modules/item/actions'
-import { buildBrowseURL } from '../../modules/routing/utils'
 import { AssetType } from '../../modules/asset/types'
 
 const mapState = (state: RootState): MapStateProps => {
@@ -39,10 +36,6 @@ const mapState = (state: RootState): MapStateProps => {
       assetType === AssetType.ITEM
         ? isLoadingType(getLoadingItems(state), FETCH_ITEMS_REQUEST)
         : isLoadingType(getLoadingNFTs(state), FETCH_NFTS_REQUEST),
-    urlNext: buildBrowseURL(getLocation(state).pathname, {
-      ...getCurrentBrowseOptions(state),
-      page: page + 1
-    }),
     hasFiltersEnabled: hasFiltersEnabled(state)
   }
 }

--- a/webapp/src/components/AssetList/AssetList.tsx
+++ b/webapp/src/components/AssetList/AssetList.tsx
@@ -1,16 +1,17 @@
 import React, { useCallback, useMemo } from 'react'
-import { Card, Button, Loader } from 'decentraland-ui'
+import { Card, Loader } from 'decentraland-ui'
 import { Item, NFTCategory } from '@dcl/schemas'
 import { T, t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
 import { getCategoryFromSection } from '../../modules/routing/search'
-import { getMaxQuerySize, MAX_PAGE, PAGE_SIZE } from '../../modules/vendor/api'
+import { getMaxQuerySize, MAX_PAGE } from '../../modules/vendor/api'
 import { AssetType } from '../../modules/asset/types'
 import { NFT } from '../../modules/nft/types'
 import * as events from '../../utils/events'
 import { AssetCard } from '../AssetCard'
 import { Props } from './AssetList.types'
 import './AssetList.css'
+import { InfiniteScroll } from '../InfiniteScroll'
 
 const AssetList = (props: Props) => {
   const {
@@ -25,7 +26,6 @@ const AssetList = (props: Props) => {
     isLoading,
     hasFiltersEnabled,
     onBrowse,
-    urlNext,
     isManager,
     onClearFilters
   } = props
@@ -33,21 +33,19 @@ const AssetList = (props: Props) => {
   const assets: (NFT | Item)[] = assetType === AssetType.ITEM ? items : nfts
 
   const handleLoadMore = useCallback(
-    (e: React.MouseEvent<HTMLButtonElement>) => {
-      e.preventDefault()
-      const newPage = page + 1
+    newPage => {
       onBrowse({ page: newPage })
       getAnalytics().track(events.LOAD_MORE, { page: newPage })
     },
-    [onBrowse, page]
+    [onBrowse]
   )
 
   const maxQuerySize = getMaxQuerySize(vendor)
 
-  const hasExtraPages =
+  const hasMorePages =
     (assets.length !== count || count === maxQuerySize) && page <= MAX_PAGE
 
-  const isLoadingNewPage = isLoading && nfts.length >= PAGE_SIZE
+  // const isLoadingNewPage = isLoading && nfts.length >= PAGE_SIZE
 
   const emptyStateTranslationString = useMemo(() => {
     if (assets.length > 0) {
@@ -88,67 +86,60 @@ const AssetList = (props: Props) => {
             ))
           : null}
       </Card.Group>
+      <InfiniteScroll
+        page={page}
+        hasMorePages={hasMorePages}
+        onLoadMore={handleLoadMore}
+        maxScrollPages={1}
+      >
+        {assets.length === 0 && !isLoading ? (
+          <div className="empty">
+            <div className="watermelon" />
 
-      {assets.length === 0 && !isLoading ? (
-        <div className="empty">
-          <div className="watermelon" />
-
-          <T
-            id={emptyStateTranslationString}
-            values={{
-              search,
-              currentSection:
-                assetType === AssetType.ITEM
-                  ? t('browse_page.primary_market_title').toLocaleLowerCase()
-                  : t('browse_page.secondary_market_title').toLocaleLowerCase(),
-              section:
-                assetType === AssetType.ITEM
-                  ? t('browse_page.secondary_market_title').toLocaleLowerCase()
-                  : t('browse_page.primary_market_title').toLocaleLowerCase(),
-              searchStore: (chunks: string) => (
-                <button
-                  className="empty-actions"
-                  onClick={() =>
-                    onBrowse({
-                      assetType:
-                        assetType === AssetType.ITEM
-                          ? AssetType.NFT
-                          : AssetType.ITEM
-                    })
-                  }
-                >
-                  {chunks}
-                </button>
-              ),
-              'if-filters': (chunks: string) =>
-                hasFiltersEnabled ? chunks : '',
-              clearFilters: (chunks: string) => (
-                <button className="empty-actions" onClick={onClearFilters}>
-                  {chunks}
-                </button>
-              ),
-              br: () => <br />
-            }}
-          />
-        </div>
-      ) : null}
-
-      {assets.length > 0 &&
-      hasExtraPages &&
-      (!isLoading || isLoadingNewPage) ? (
-        <div className="load-more">
-          <Button
-            as="a"
-            href={urlNext}
-            loading={isLoading}
-            inverted
-            primary
-            onClick={handleLoadMore}
-          >
-            {t('global.load_more')}
-          </Button>
-        </div>
-      ) : null}
+            <T
+              id={emptyStateTranslationString}
+              values={{
+                search,
+                currentSection:
+                  assetType === AssetType.ITEM
+                    ? t('browse_page.primary_market_title').toLocaleLowerCase()
+                    : t(
+                        'browse_page.secondary_market_title'
+                      ).toLocaleLowerCase(),
+                section:
+                  assetType === AssetType.ITEM
+                    ? t(
+                        'browse_page.secondary_market_title'
+                      ).toLocaleLowerCase()
+                    : t('browse_page.primary_market_title').toLocaleLowerCase(),
+                searchStore: (chunks: string) => (
+                  <button
+                    className="empty-actions"
+                    onClick={() =>
+                      onBrowse({
+                        assetType:
+                          assetType === AssetType.ITEM
+                            ? AssetType.NFT
+                            : AssetType.ITEM
+                      })
+                    }
+                  >
+                    {chunks}
+                  </button>
+                ),
+                'if-filters': (chunks: string) =>
+                  hasFiltersEnabled ? chunks : '',
+                clearFilters: (chunks: string) => (
+                  <button className="empty-actions" onClick={onClearFilters}>
+                    {chunks}
+                  </button>
+                ),
+                br: () => <br />
+              }}
+            />
+          </div>
+        ) : null}
+      </InfiniteScroll>
     </>
   )
 }

--- a/webapp/src/components/AssetList/AssetList.tsx
+++ b/webapp/src/components/AssetList/AssetList.tsx
@@ -104,6 +104,7 @@ const AssetList = (props: Props) => {
         page={page}
         hasMorePages={hasMorePages}
         onLoadMore={handleLoadMore}
+        isLoading={isLoading}
         maxScrollPages={3}
       >
         {assets.length === 0 && !isLoading ? (

--- a/webapp/src/components/AssetList/AssetList.tsx
+++ b/webapp/src/components/AssetList/AssetList.tsx
@@ -8,11 +8,11 @@ import { getMaxQuerySize, MAX_PAGE } from '../../modules/vendor/api'
 import { AssetType } from '../../modules/asset/types'
 import { NFT } from '../../modules/nft/types'
 import * as events from '../../utils/events'
+import { InfiniteScroll } from '../InfiniteScroll'
 import { AssetCard } from '../AssetCard'
 import { getLastVisitedElementId } from './utils'
 import { Props } from './AssetList.types'
 import './AssetList.css'
-import { InfiniteScroll } from '../InfiniteScroll'
 
 const AssetList = (props: Props) => {
   const {

--- a/webapp/src/components/AssetList/AssetList.tsx
+++ b/webapp/src/components/AssetList/AssetList.tsx
@@ -59,8 +59,6 @@ const AssetList = (props: Props) => {
   const hasMorePages =
     (assets.length !== count || count === maxQuerySize) && page <= MAX_PAGE
 
-  // const isLoadingNewPage = isLoading && nfts.length >= PAGE_SIZE
-
   const emptyStateTranslationString = useMemo(() => {
     if (assets.length > 0) {
       return ''

--- a/webapp/src/components/AssetList/AssetList.tsx
+++ b/webapp/src/components/AssetList/AssetList.tsx
@@ -90,7 +90,7 @@ const AssetList = (props: Props) => {
         page={page}
         hasMorePages={hasMorePages}
         onLoadMore={handleLoadMore}
-        maxScrollPages={1}
+        maxScrollPages={3}
       >
         {assets.length === 0 && !isLoading ? (
           <div className="empty">

--- a/webapp/src/components/AssetList/AssetList.types.ts
+++ b/webapp/src/components/AssetList/AssetList.types.ts
@@ -25,7 +25,6 @@ export type Props = {
   hasFiltersEnabled?: boolean
   onBrowse: typeof browse
   onClearFilters: typeof clearFilters
-  urlNext: string
   search: string
 }
 
@@ -39,7 +38,6 @@ export type MapStateProps = Pick<
   | 'count'
   | 'isLoading'
   | 'assetType'
-  | 'urlNext'
   | 'search'
   | 'hasFiltersEnabled'
 >

--- a/webapp/src/components/InfiniteScroll/InfiniteScroll.spec.tsx
+++ b/webapp/src/components/InfiniteScroll/InfiniteScroll.spec.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { InfiniteScroll } from './InfiniteScroll'

--- a/webapp/src/components/InfiniteScroll/InfiniteScroll.spec.tsx
+++ b/webapp/src/components/InfiniteScroll/InfiniteScroll.spec.tsx
@@ -1,0 +1,56 @@
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import { InfiniteScroll } from './InfiniteScroll'
+import { Props } from './InfiniteScroll.types'
+
+function renderInfiniteScroll(props: Partial<Props>) {
+  return render(
+    <InfiniteScroll
+      maxScrollPages={0}
+      hasMorePages
+      onLoadMore={jest.fn()}
+      page={0}
+      {...props}
+    >
+      <span>My container</span>
+    </InfiniteScroll>
+  )
+}
+
+describe('when maxScrollPages is 0', () => {
+  describe('and hasMorePages is true', () => {
+    it('should show load button from the start', () => {
+      const screen = renderInfiniteScroll({ maxScrollPages: 0 })
+      expect(
+        screen.getByRole('button', { name: t('global.load_more') })
+      ).toBeInTheDocument()
+    })
+
+    describe('and load more button is clicked', () => {
+      it('should call onLoadMore function', async () => {
+        const loadMoreMock = jest.fn()
+        const screen = renderInfiniteScroll({
+          maxScrollPages: 0,
+          onLoadMore: loadMoreMock
+        })
+        await userEvent.click(
+          screen.getByRole('button', { name: t('global.load_more') })
+        )
+        expect(loadMoreMock).toHaveBeenCalledWith(1)
+      })
+    })
+  })
+
+  describe('and hasMorePages is false', () => {
+    it('should not show load more button', () => {
+      const screen = renderInfiniteScroll({
+        maxScrollPages: 0,
+        hasMorePages: false
+      })
+      expect(
+        screen.queryByRole('button', { name: t('global.load_more') })
+      ).not.toBeInTheDocument()
+    })
+  })
+})

--- a/webapp/src/components/InfiniteScroll/InfiniteScroll.tsx
+++ b/webapp/src/components/InfiniteScroll/InfiniteScroll.tsx
@@ -11,7 +11,7 @@ export function InfiniteScroll({
   maxScrollPages,
   onLoadMore
 }: Props) {
-  const [initPage] = useState(page)
+  const [scrollPage, setScrollPage] = useState(0)
   const [showLoadMoreButton, setShowLoadMoreButton] = useState(
     maxScrollPages === 0
   )
@@ -21,19 +21,23 @@ export function InfiniteScroll({
     const scrollHeight = document.documentElement.scrollHeight
     const clientHeight = document.documentElement.clientHeight
     if (
+      !isLoading &&
       scrollTop + clientHeight >= scrollHeight &&
       hasMorePages &&
-      (!maxScrollPages || page - initPage < maxScrollPages)
+      (!maxScrollPages || scrollPage < maxScrollPages)
     ) {
+      setScrollPage(scrollPage + 1)
       onLoadMore(page + 1)
     }
-  }, [page, hasMorePages, initPage, maxScrollPages, onLoadMore])
+  }, [page, hasMorePages, isLoading, scrollPage, maxScrollPages, onLoadMore])
 
   useEffect(() => {
-    if (!isLoading && maxScrollPages && page - initPage >= maxScrollPages) {
+    if (!isLoading && maxScrollPages && scrollPage === maxScrollPages) {
       setShowLoadMoreButton(true)
+    } else {
+      setShowLoadMoreButton(false)
     }
-  }, [isLoading, initPage, maxScrollPages, page, setShowLoadMoreButton])
+  }, [isLoading, scrollPage, maxScrollPages, page, setShowLoadMoreButton])
 
   useEffect(() => {
     window.addEventListener('scroll', onScroll)
@@ -42,6 +46,7 @@ export function InfiniteScroll({
 
   const handleLoadMore = useCallback(() => {
     onLoadMore(page + 1)
+    setScrollPage(0)
   }, [onLoadMore, page])
 
   if (!hasMorePages) {

--- a/webapp/src/components/InfiniteScroll/InfiniteScroll.tsx
+++ b/webapp/src/components/InfiniteScroll/InfiniteScroll.tsx
@@ -30,10 +30,10 @@ export function InfiniteScroll({
   }, [page, hasMorePages, initPage, maxScrollPages, onLoadMore])
 
   useEffect(() => {
-    if (maxScrollPages && page - initPage >= maxScrollPages) {
+    if (!isLoading && maxScrollPages && page - initPage >= maxScrollPages) {
       setShowLoadMoreButton(true)
     }
-  }, [initPage, maxScrollPages, page, setShowLoadMoreButton])
+  }, [isLoading, initPage, maxScrollPages, page, setShowLoadMoreButton])
 
   useEffect(() => {
     window.addEventListener('scroll', onScroll)

--- a/webapp/src/components/InfiniteScroll/InfiniteScroll.tsx
+++ b/webapp/src/components/InfiniteScroll/InfiniteScroll.tsx
@@ -32,7 +32,7 @@ export function InfiniteScroll({
   }, [page, hasMorePages, isLoading, scrollPage, maxScrollPages, onLoadMore])
 
   useEffect(() => {
-    if (!isLoading && maxScrollPages && scrollPage === maxScrollPages) {
+    if (!isLoading && maxScrollPages !== undefined && scrollPage === maxScrollPages) {
       setShowLoadMoreButton(true)
     } else {
       setShowLoadMoreButton(false)

--- a/webapp/src/components/InfiniteScroll/InfiniteScroll.tsx
+++ b/webapp/src/components/InfiniteScroll/InfiniteScroll.tsx
@@ -1,6 +1,6 @@
+import { useCallback, useEffect, useState } from 'react'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Button } from 'decentraland-ui'
-import { useCallback, useEffect, useState } from 'react'
 import { Props } from './InfiniteScroll.types'
 
 export function InfiniteScroll({

--- a/webapp/src/components/InfiniteScroll/InfiniteScroll.tsx
+++ b/webapp/src/components/InfiniteScroll/InfiniteScroll.tsx
@@ -1,0 +1,63 @@
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import { Button } from 'decentraland-ui'
+import { useCallback, useEffect, useState } from 'react'
+import { Props } from './InfiniteScroll.types'
+
+export function InfiniteScroll({
+  page,
+  hasMorePages,
+  isLoading,
+  children,
+  maxScrollPages,
+  onLoadMore
+}: Props) {
+  const [initPage] = useState(page)
+  const [showLoadMoreButton, setShowLoadMoreButton] = useState(
+    maxScrollPages === 0
+  )
+
+  const onScroll = useCallback(() => {
+    const scrollTop = document.documentElement.scrollTop
+    const scrollHeight = document.documentElement.scrollHeight
+    const clientHeight = document.documentElement.clientHeight
+    if (
+      scrollTop + clientHeight >= scrollHeight &&
+      hasMorePages &&
+      (!maxScrollPages || page - initPage < maxScrollPages)
+    ) {
+      onLoadMore(page + 1)
+    }
+  }, [page, hasMorePages, initPage, maxScrollPages, onLoadMore])
+
+  useEffect(() => {
+    if (maxScrollPages && page - initPage >= maxScrollPages) {
+      setShowLoadMoreButton(true)
+    }
+  }, [initPage, maxScrollPages, page, setShowLoadMoreButton])
+
+  useEffect(() => {
+    window.addEventListener('scroll', onScroll)
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [onScroll])
+
+  const handleLoadMore = useCallback(() => {
+    onLoadMore(page + 1)
+  }, [onLoadMore, page])
+
+  if (!hasMorePages) {
+    return children
+  }
+
+  return (
+    <div role="feed">
+      {children}
+      {showLoadMoreButton && (
+        <div className="load-more">
+          <Button loading={isLoading} inverted primary onClick={handleLoadMore}>
+            {t('global.load_more')}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/webapp/src/components/InfiniteScroll/InfiniteScroll.types.ts
+++ b/webapp/src/components/InfiniteScroll/InfiniteScroll.types.ts
@@ -1,0 +1,8 @@
+export type Props = { 
+  page: number,
+  hasMorePages: boolean,
+  isLoading?: boolean,
+  maxScrollPages?: number,
+  children: JSX.Element | null,
+  onLoadMore: (page: number) => void
+}

--- a/webapp/src/components/InfiniteScroll/index.ts
+++ b/webapp/src/components/InfiniteScroll/index.ts
@@ -1,0 +1,1 @@
+export * from './InfiniteScroll'


### PR DESCRIPTION
Add infinite scroll to asset lists with the possibility to limit the amount of pages in infinite scroll and adding "Load more button" after those pages


https://user-images.githubusercontent.com/11800206/228586746-fddf2856-26b2-4543-b421-cadca03a0484.mov

