### PR TITLE
fix: Update Ubuntu version on rollouts

### DIFF
--- a/.github/workflows/set-rollout.yaml
+++ b/.github/workflows/set-rollout.yaml
@@ -5,7 +5,7 @@ on: [deployment_status]
 jobs:
   set-rollout:
     if: ${{ github.event.deployment.task == 'upload-to-cdn' && github.event.deployment_status.state == 'success' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: ./webapp

--- a/.github/workflows/set-rollout.yaml
+++ b/.github/workflows/set-rollout.yaml
@@ -5,7 +5,7 @@ on: [deployment_status]
 jobs:
   set-rollout:
     if: ${{ github.event.deployment.task == 'upload-to-cdn' && github.event.deployment_status.state == 'success' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./webapp


### PR DESCRIPTION
This PR updates the Ubuntu version that was deprecated in the Github Actions.