### PR TITLE
fix: ubuntu version on manual rollout

### DIFF
--- a/.github/workflows/set-rollout-manual.yaml
+++ b/.github/workflows/set-rollout-manual.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   set-manual-rollout:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./webapp


### PR DESCRIPTION
Set ubuntu version on manual rollout to be latest instead of 18.04 as it is deprecated