### PR TITLE
chore: Update decentraland dapps

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -8916,9 +8916,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "13.46.0",
-      "resolved": "file:decentraland-dapps-13.46.0.tgz",
-      "integrity": "sha512-rCgrDtZOYfXtZkvBspdsA2gH2er2F75SZmjZff61Vavg5cYDzF+bMohAIj7gqkUpdCGWKpjLIxcEtitj6Uk1Jg==",
+      "version": "13.45.1",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.45.1.tgz",
+      "integrity": "sha512-EAHatDlp5UN/Qhln2Nij/p2ejugQnSA3NEGa3CWbyiN+VSO+Hz8jKc/wt0yq8F5mYOHuNye9atrIjXGDqLAjmg==",
       "dependencies": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
@@ -32357,8 +32357,9 @@
       }
     },
     "decentraland-dapps": {
-      "version": "13.46.0",
-      "integrity": "sha512-rCgrDtZOYfXtZkvBspdsA2gH2er2F75SZmjZff61Vavg5cYDzF+bMohAIj7gqkUpdCGWKpjLIxcEtitj6Uk1Jg==",
+      "version": "13.45.1",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.45.1.tgz",
+      "integrity": "sha512-EAHatDlp5UN/Qhln2Nij/p2ejugQnSA3NEGa3CWbyiN+VSO+Hz8jKc/wt0yq8F5mYOHuNye9atrIjXGDqLAjmg==",
       "requires": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -19,7 +19,7 @@
         "dcl-catalyst-commons": "^9.0.1",
         "decentraland-connect": "^3.3.2",
         "decentraland-crypto-fetch": "^1.0.3",
-        "decentraland-dapps": "^13.45.0",
+        "decentraland-dapps": "^13.45.1",
         "decentraland-transactions": "^1.43.1",
         "decentraland-ui": "^3.87.1",
         "dotenv": "^10.0.0",
@@ -8916,9 +8916,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "13.45.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.45.0.tgz",
-      "integrity": "sha512-41xXFDCaCfOlUjd4lcEVNvma3nFlaAOH1dEWgfsR1qRN/WIk/f1MRIWMKHTIrvWsPp7UjVQk+BfKpzq4UIm1kg==",
+      "version": "13.46.0",
+      "resolved": "file:decentraland-dapps-13.46.0.tgz",
+      "integrity": "sha512-rCgrDtZOYfXtZkvBspdsA2gH2er2F75SZmjZff61Vavg5cYDzF+bMohAIj7gqkUpdCGWKpjLIxcEtitj6Uk1Jg==",
       "dependencies": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
@@ -32357,9 +32357,8 @@
       }
     },
     "decentraland-dapps": {
-      "version": "13.45.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.45.0.tgz",
-      "integrity": "sha512-41xXFDCaCfOlUjd4lcEVNvma3nFlaAOH1dEWgfsR1qRN/WIk/f1MRIWMKHTIrvWsPp7UjVQk+BfKpzq4UIm1kg==",
+      "version": "13.46.0",
+      "integrity": "sha512-rCgrDtZOYfXtZkvBspdsA2gH2er2F75SZmjZff61Vavg5cYDzF+bMohAIj7gqkUpdCGWKpjLIxcEtitj6Uk1Jg==",
       "requires": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -13,7 +13,7 @@
     "dcl-catalyst-commons": "^9.0.1",
     "decentraland-connect": "^3.3.2",
     "decentraland-crypto-fetch": "^1.0.3",
-    "decentraland-dapps": "^13.45.0",
+    "decentraland-dapps": "^13.45.1",
     "decentraland-transactions": "^1.43.1",
     "decentraland-ui": "^3.87.1",
     "dotenv": "^10.0.0",


### PR DESCRIPTION
This PR updates the decentraland dapps dependency to include the fix for the issue with dropped transactions when changing networks.