### PR TITLE
feat: redirect after log in

### DIFF
--- a/webapp/src/components/ActivityPage/ActivityPage.tsx
+++ b/webapp/src/components/ActivityPage/ActivityPage.tsx
@@ -44,7 +44,7 @@ const ActivityPage = (props: Props) => {
               id="wallet.sign_in_required"
               values={{
                 sign_in: (
-                  <Link to={locations.signIn()}>{t('wallet.sign_in')}</Link>
+                  <Link to={locations.signIn(locations.activity())}>{t('wallet.sign_in')}</Link>
                 )
               }}
             />

--- a/webapp/src/components/Bids/Bids.tsx
+++ b/webapp/src/components/Bids/Bids.tsx
@@ -6,6 +6,7 @@ import { locations } from '../../modules/routing/locations'
 import { Bid } from '../Bid'
 import { Props } from './Bids.types'
 import './Bids.css'
+import { useLocation } from 'react-router-dom'
 
 const Bids = (props: Props) => {
   const {
@@ -20,6 +21,7 @@ const Bids = (props: Props) => {
   } = props
 
   const [showArchived, setShowArchivedSeller] = useState(false)
+  const { pathname, search } = useLocation()
 
   const handleToggleSeller = useCallback(
     () => setShowArchivedSeller(!showArchived),
@@ -29,9 +31,9 @@ const Bids = (props: Props) => {
   // Redirect to signIn if trying to access current account without a wallet
   useEffect(() => {
     if (!isConnecting && !wallet) {
-      onNavigate(locations.signIn())
+      onNavigate(locations.signIn(`${pathname}${search}`))
     }
-  }, [isConnecting, wallet, onNavigate])
+  }, [isConnecting, wallet, onNavigate, pathname, search])
 
   useEffect(() => {
     if (wallet) {

--- a/webapp/src/components/Bids/Bids.tsx
+++ b/webapp/src/components/Bids/Bids.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState, useCallback } from 'react'
 import { Loader, HeaderMenu, Header, Button } from 'decentraland-ui'
+import { useLocation } from 'react-router-dom'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 
 import { locations } from '../../modules/routing/locations'
 import { Bid } from '../Bid'
 import { Props } from './Bids.types'
 import './Bids.css'
-import { useLocation } from 'react-router-dom'
 
 const Bids = (props: Props) => {
   const {

--- a/webapp/src/components/Navbar/Navbar.container.ts
+++ b/webapp/src/components/Navbar/Navbar.container.ts
@@ -10,7 +10,7 @@ import Navbar from './Navbar'
 
 const mapState = (state: RootState): MapStateProps => ({
   isConnected: isConnected(state),
-  pathname: getLocation(state).pathname,
+  location: getLocation(state),
   hasPendingTransactions: getTransactions(state).some(tx =>
     isPending(tx.status)
   )

--- a/webapp/src/components/Navbar/Navbar.tsx
+++ b/webapp/src/components/Navbar/Navbar.tsx
@@ -7,15 +7,16 @@ import { Props } from './Navbar.types'
 import './Navbar.css'
 
 const Navbar = (props: Props) => {
-  const { pathname, onNavigate, isConnected } = props
+  const { location, onNavigate, isConnected } = props
+  const { pathname, search } = location
 
   if (isConnected) {
     props = { ...props, rightMenu: <UserMenu /> }
   }
 
   const handleOnSignIn = useCallback(() => {
-    onNavigate(locations.signIn())
-  }, [onNavigate])
+    onNavigate(locations.signIn(`${pathname}${search}`))
+  }, [onNavigate, pathname, search])
 
   const handleOnClickAccount = useCallback(() => {
     onNavigate(locations.settings())

--- a/webapp/src/components/Navbar/Navbar.types.ts
+++ b/webapp/src/components/Navbar/Navbar.types.ts
@@ -1,9 +1,9 @@
 import { Dispatch } from 'redux'
-import { CallHistoryMethodAction } from 'connected-react-router'
+import { CallHistoryMethodAction, RouterLocation } from 'connected-react-router'
 import { NavbarProps } from 'decentraland-ui'
 
 export type Props = Partial<NavbarProps> & {
-  pathname: string
+  location: RouterLocation<unknown>
   isConnected: boolean
   hasPendingTransactions: boolean
   enablePartialSupportAlert?: boolean
@@ -14,7 +14,7 @@ export type OwnProps = Pick<Props, 'enablePartialSupportAlert'>
 
 export type MapStateProps = Pick<
   Props,
-  'pathname' | 'hasPendingTransactions' | 'isConnected'
+  'location' | 'hasPendingTransactions' | 'isConnected'
 >
 export type MapDispatchProps = Pick<Props, 'onNavigate'>
 export type MapDispatch = Dispatch<CallHistoryMethodAction>

--- a/webapp/src/components/SettingsPage/SettingsPage.tsx
+++ b/webapp/src/components/SettingsPage/SettingsPage.tsx
@@ -18,6 +18,7 @@ import { Props } from './SettingsPage.types'
 import copyText from '../../lib/copyText'
 
 import './SettingsPage.css'
+import { useLocation } from 'react-router-dom'
 
 const SettingsPage = (props: Props) => {
   const {
@@ -32,12 +33,13 @@ const SettingsPage = (props: Props) => {
   } = props
 
   const [hasCopiedText, setHasCopiedAddress] = useTimer(1200)
+  const {pathname, search} = useLocation()
 
   useEffect(() => {
     if (!wallet) {
-      onNavigate(locations.signIn())
+      onNavigate(locations.signIn(`${pathname}${search}`))
     }
-  }, [wallet, onNavigate])
+  }, [wallet, onNavigate, pathname, search])
 
   useEffect(() => {
     // When this condition is met, the previous useEffect will redirect to the sign in page.

--- a/webapp/src/modules/routing/locations.ts
+++ b/webapp/src/modules/routing/locations.ts
@@ -6,7 +6,9 @@ import { BrowseOptions } from './types'
 
 export const locations = {
   root: () => '/',
-  signIn: () => '/sign-in',
+  signIn: (redirectTo?: string) => {
+    return `/sign-in${redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : ''}`
+  },
   settings: () => '/settings',
   lands: (options?: BrowseOptions) => {
     const params = getSearchParams(options)

--- a/webapp/src/modules/ui/sagas.ts
+++ b/webapp/src/modules/ui/sagas.ts
@@ -23,8 +23,14 @@ export function* uiSaga() {
 
 function* handleConnectWalletSuccess(_action: ConnectWalletSuccessAction) {
   const location: ReturnType<typeof getLocation> = yield select(getLocation)
-  if (location.pathname === locations.signIn()) {
-    yield put(push(locations.defaultCurrentAccount()))
+  const { pathname, search } = location
+  if (pathname === locations.signIn()) {
+    const redirectTo = new URLSearchParams(search).get('redirectTo')
+    if (redirectTo) {
+      yield put(push(decodeURIComponent(redirectTo)))
+    } else {
+      yield put(push(locations.defaultCurrentAccount()))
+    }
   }
 }
 


### PR DESCRIPTION
Add `redirectTo` query param in signin page so when sign in finishes it redirects to the desired page instead of always redirecting to account view