### PR TITLE
fix: Loading my lists

### DIFF
--- a/webapp/src/components/AssetList/AssetList.container.ts
+++ b/webapp/src/components/AssetList/AssetList.container.ts
@@ -3,6 +3,7 @@ import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors
 
 import { RootState } from '../../modules/reducer'
 import { FETCH_NFTS_REQUEST } from '../../modules/nft/actions'
+import { FETCH_FAVORITED_ITEMS_REQUEST } from '../../modules/favorites/actions'
 import { browse, clearFilters } from '../../modules/routing/actions'
 import { getNFTs, getCount, getItems } from '../../modules/ui/browse/selectors'
 import {
@@ -16,6 +17,7 @@ import {
 } from '../../modules/routing/selectors'
 import { getLoading as getLoadingNFTs } from '../../modules/nft/selectors'
 import { getLoading as getLoadingItems } from '../../modules/item/selectors'
+import { getLoading as getLoadingFavorites } from '../../modules/favorites/selectors'
 import { MapStateProps, MapDispatch, MapDispatchProps } from './AssetList.types'
 import AssetList from './AssetList'
 import { FETCH_ITEMS_REQUEST } from '../../modules/item/actions'
@@ -35,7 +37,11 @@ const mapState = (state: RootState): MapStateProps => {
     search: getSearch(state),
     isLoading:
       assetType === AssetType.ITEM
-        ? isLoadingType(getLoadingItems(state), FETCH_ITEMS_REQUEST)
+        ? isLoadingType(getLoadingItems(state), FETCH_ITEMS_REQUEST) ||
+          isLoadingType(
+            getLoadingFavorites(state),
+            FETCH_FAVORITED_ITEMS_REQUEST
+          )
         : isLoadingType(getLoadingNFTs(state), FETCH_NFTS_REQUEST),
     hasFiltersEnabled: hasFiltersEnabled(state),
     visitedLocations: getVisitedLocations(state)


### PR DESCRIPTION
This PR fixes an early message that showed that there weren't any results instead of a loader when the favorites were being loaded before querying the nft-server for the items.