### PR TITLE
fix: Creators filter NFT params

### DIFF
--- a/webapp/src/modules/vendor/utils.ts
+++ b/webapp/src/modules/vendor/utils.ts
@@ -65,7 +65,7 @@ export function getFilters(
         rarities,
         wearableGenders,
         contracts,
-        creator: address ? [address] : creators,
+        creator: creators,
         network,
         emotePlayMode,
         rentalStatus:
@@ -80,7 +80,7 @@ export function getFilters(
         minDistanceToPlaza,
         maxDistanceToPlaza,
         rentalDays
-      } as NFTsFetchFilters<VendorName.DECENTRALAND>
+      }
     }
     default:
       return {}


### PR DESCRIPTION
The `address` param for My assets page will have the current address, so it's not what we want. It should always use the `creators` param which is read from the URL. 