### PR TITLE
fix: Modal styles and data loading

### DIFF
--- a/webapp/src/components/Modals/FavoritesModal/FavoritesModal.module.css
+++ b/webapp/src/components/Modals/FavoritesModal/FavoritesModal.module.css
@@ -2,6 +2,12 @@
   margin-top: 20px;
 }
 
+.separator {
+  border-top: 2px var(--text) solid;
+  margin-bottom: 20px;
+  margin-top: 20px;
+}
+
 @media (max-width: 767px) {
   .favoritesList {
     height: 100%;
@@ -30,4 +36,19 @@
 
 .loading span {
   margin-left: 20px;
+}
+
+.modal :global(.Profile) {
+  display: flex !important;
+  align-items: center;
+}
+
+.modal :global(.Profile .name) {
+  margin-left: 10px;
+  font-size: 21px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 30px;
+  letter-spacing: 0.3149999976158142px;
+  text-align: left;
 }

--- a/webapp/src/components/Modals/FavoritesModal/FavoritesModal.tsx
+++ b/webapp/src/components/Modals/FavoritesModal/FavoritesModal.tsx
@@ -68,6 +68,7 @@ const FavoritesModal = ({ metadata: { itemId }, onClose }: Props) => {
       <div style={style} tabIndex={0}>
         {isItemLoaded(index) ? (
           <LinkedProfile
+            className={styles.user}
             size="huge"
             key={favorites.addresses[index]}
             sliceAddressBy={isMobile ? 18 : 40}
@@ -83,6 +84,7 @@ const FavoritesModal = ({ metadata: { itemId }, onClose }: Props) => {
 
   useEffect(() => {
     fetchNextPage(0, 100)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // Makes the modal dynamic in size.
@@ -118,33 +120,36 @@ const FavoritesModal = ({ metadata: { itemId }, onClose }: Props) => {
             <Empty className={styles.empty}>{t('favorites_modal.empty')}</Empty>
           ) : null}
           {favorites.addresses.length !== 0 ? (
-            <div
-              className={styles.favoritesList}
-              style={{ height: !isMobile ? desktopHeight : undefined }}
-            >
-              <AutoSizer>
-                {({ height, width }) => (
-                  <InfiniteLoader
-                    isItemLoaded={isItemLoaded}
-                    itemCount={favorites.total}
-                    loadMoreItems={fetchNextPage}
-                  >
-                    {({ onItemsRendered, ref }) => (
-                      <FixedSizeList
-                        itemCount={favorites.total}
-                        onItemsRendered={onItemsRendered}
-                        itemSize={ITEM_HEIGHT}
-                        height={height ?? DEFAULT_LIST_HEIGHT}
-                        width={width ?? DEFAULT_LIST_WIDTH}
-                        ref={ref}
-                      >
-                        {Row}
-                      </FixedSizeList>
-                    )}
-                  </InfiniteLoader>
-                )}
-              </AutoSizer>
-            </div>
+            <>
+              <div className={styles.separator}></div>
+              <div
+                className={styles.favoritesList}
+                style={{ height: !isMobile ? desktopHeight : undefined }}
+              >
+                <AutoSizer>
+                  {({ height, width }) => (
+                    <InfiniteLoader
+                      isItemLoaded={isItemLoaded}
+                      itemCount={favorites.total}
+                      loadMoreItems={fetchNextPage}
+                    >
+                      {({ onItemsRendered, ref }) => (
+                        <FixedSizeList
+                          itemCount={favorites.total}
+                          onItemsRendered={onItemsRendered}
+                          itemSize={ITEM_HEIGHT}
+                          height={height ?? DEFAULT_LIST_HEIGHT}
+                          width={width ?? DEFAULT_LIST_WIDTH}
+                          ref={ref}
+                        >
+                          {Row}
+                        </FixedSizeList>
+                      )}
+                    </InfiniteLoader>
+                  )}
+                </AutoSizer>
+              </div>
+            </>
           ) : null}
           {error ? (
             <Message

--- a/webapp/src/components/Modals/FavoritesModal/FavoritesModal.tsx
+++ b/webapp/src/components/Modals/FavoritesModal/FavoritesModal.tsx
@@ -68,7 +68,6 @@ const FavoritesModal = ({ metadata: { itemId }, onClose }: Props) => {
       <div style={style} tabIndex={0}>
         {isItemLoaded(index) ? (
           <LinkedProfile
-            className={styles.user}
             size="huge"
             key={favorites.addresses[index]}
             sliceAddressBy={isMobile ? 18 : 40}

--- a/webapp/src/modules/vendor/decentraland/favorites/api.spec.ts
+++ b/webapp/src/modules/vendor/decentraland/favorites/api.spec.ts
@@ -188,7 +188,7 @@ describe('when getting who favorited an item', () => {
       body = {
         ok: true,
         data: {
-          results: ['0x0'],
+          results: [{ userAddress: '0x0' }],
           total: 1
         }
       }
@@ -202,7 +202,9 @@ describe('when getting who favorited an item', () => {
       return expect(
         favoritesAPI.getWhoFavoritedAnItem(itemId, 0, 10)
       ).resolves.toEqual({
-        addresses: body.data?.results,
+        addresses: body.data?.results.map(
+          (pick: { userAddress: string }) => pick.userAddress
+        ),
         total: body.data?.total
       })
     })

--- a/webapp/src/modules/vendor/decentraland/favorites/api.ts
+++ b/webapp/src/modules/vendor/decentraland/favorites/api.ts
@@ -12,6 +12,25 @@ export const MARKETPLACE_FAVORITES_SERVER_URL = config.get(
   'MARKETPLACE_FAVORITES_SERVER_URL'
 )!
 
+type PaginatedResponse<T> = {
+  results: T[]
+  total: number
+  page: number
+  pages: number
+  limit: number
+}
+
+type HTTPBody<T> =
+  | {
+      ok: false
+      message: string
+      data?: object
+    }
+  | {
+      ok: true
+      data: PaginatedResponse<T>
+    }
+
 class FavoritesAPI extends BaseAPI {
   async getWhoFavoritedAnItem(
     itemId: string,
@@ -22,14 +41,18 @@ class FavoritesAPI extends BaseAPI {
       `${MARKETPLACE_FAVORITES_SERVER_URL}/picks/${itemId}?limit=${limit}&offset=${offset}`
     )
 
-    const parsedResponse = await response.json()
+    const parsedResponse: HTTPBody<{
+      userAddress: string
+    }> = await response.json()
 
-    if (!response.ok) {
-      throw new Error(parsedResponse?.message ?? 'Unknown error')
+    if (!response.ok || parsedResponse.ok === false) {
+      throw new Error(
+        parsedResponse.ok === false ? parsedResponse?.message : 'Unknown error'
+      )
     }
 
     return {
-      addresses: parsedResponse.data.results,
+      addresses: parsedResponse.data.results.map(pick => pick.userAddress),
       total: parsedResponse.data.total
     }
   }

--- a/webapp/src/modules/vendor/decentraland/favorites/api.ts
+++ b/webapp/src/modules/vendor/decentraland/favorites/api.ts
@@ -47,7 +47,9 @@ class FavoritesAPI extends BaseAPI {
 
     if (!response.ok || parsedResponse.ok === false) {
       throw new Error(
-        parsedResponse.ok === false ? parsedResponse?.message : 'Unknown error'
+        parsedResponse.ok === false && parsedResponse.message !== undefined
+          ? parsedResponse.message
+          : 'Unknown error'
       )
     }
 


### PR DESCRIPTION
This PR does the following:
- Adds a bar to split the modal text from the list.
- Changes the styles of the Profile component so the user's address / text is bigger and is centered.
- Fixes how picks were fetched.

![Screenshot 2023-04-12 at 16 50 37](https://user-images.githubusercontent.com/1120791/231574529-7a1dccec-42d3-4485-814c-70737905e45f.png)
![Screenshot 2023-04-12 at 16 50 24](https://user-images.githubusercontent.com/1120791/231574540-5fa270ff-295a-47b7-8aef-c4a31a1962e4.png)
