### PR TITLE
fix: Update dcl dapps to fix the provider lacking context issue

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -19,7 +19,7 @@
         "dcl-catalyst-commons": "^9.0.1",
         "decentraland-connect": "^3.3.2",
         "decentraland-crypto-fetch": "^1.0.3",
-        "decentraland-dapps": "^13.46.0",
+        "decentraland-dapps": "^13.47.1",
         "decentraland-transactions": "^1.43.1",
         "decentraland-ui": "^3.88.0",
         "dotenv": "^10.0.0",
@@ -8960,9 +8960,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "13.46.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.46.0.tgz",
-      "integrity": "sha512-cs8pLoI9aV99TuQ6W6HxTtw9nK559AQtAAlR+CFS4YU6G+ZnJld1hmNCWBKDTlJZ9DZ6oBxA6ZzByjcRCQi8UQ==",
+      "version": "13.47.1",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.47.1.tgz",
+      "integrity": "sha512-RnH+FyuCggirV+doy+Pp+p15opOonqaaHfiMoxRltBuNUhagXBw8cqtu5y911ANK8uFn5/Qf1jYrRd4Ec0nS1g==",
       "dependencies": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
@@ -8977,7 +8977,7 @@
         "decentraland-connect": "^3.5.0",
         "decentraland-crypto-fetch": "^1.0.3",
         "decentraland-transactions": "^1.43.1",
-        "decentraland-ui": "^3.92.2",
+        "decentraland-ui": "^3.94.0",
         "ethers": "^5.6.8",
         "events": "^3.3.0",
         "flat": "^5.0.2",
@@ -9073,9 +9073,9 @@
       "integrity": "sha512-JJf6xrQJIFoS5DGzL6ZgSuRd5PtO5HOqK1pxLkxtShGmUFnVAV+gIqBA8o2oTzUzGc6uPXdR0zBar7/eyY6f8w=="
     },
     "node_modules/decentraland-ui": {
-      "version": "3.93.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.93.0.tgz",
-      "integrity": "sha512-4VrkpWa4qFvRzyVWwbqVe09zvfmjOoSDS9dAT7RUCfeK+JCTmx0UNJNv/N6y7skBgy2T3bj8ChhEVjkoqi7wHw==",
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.94.0.tgz",
+      "integrity": "sha512-Vz94Ylza4OuWIjV4t4pVaeXo9wUa24W81+SWI//gBsI1fVq+kW2T03uPvhSIo6V0ZG2lSjkgCZJHWDdaDllvkg==",
       "dependencies": {
         "@dcl/schemas": "^6.10.0",
         "balloon-css": "^0.5.0",
@@ -32481,9 +32481,9 @@
       }
     },
     "decentraland-dapps": {
-      "version": "13.46.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.46.0.tgz",
-      "integrity": "sha512-cs8pLoI9aV99TuQ6W6HxTtw9nK559AQtAAlR+CFS4YU6G+ZnJld1hmNCWBKDTlJZ9DZ6oBxA6ZzByjcRCQi8UQ==",
+      "version": "13.47.1",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.47.1.tgz",
+      "integrity": "sha512-RnH+FyuCggirV+doy+Pp+p15opOonqaaHfiMoxRltBuNUhagXBw8cqtu5y911ANK8uFn5/Qf1jYrRd4Ec0nS1g==",
       "requires": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
@@ -32498,7 +32498,7 @@
         "decentraland-connect": "^3.5.0",
         "decentraland-crypto-fetch": "^1.0.3",
         "decentraland-transactions": "^1.43.1",
-        "decentraland-ui": "^3.92.2",
+        "decentraland-ui": "^3.94.0",
         "ethers": "^5.6.8",
         "events": "^3.3.0",
         "flat": "^5.0.2",
@@ -32564,9 +32564,9 @@
       "integrity": "sha512-JJf6xrQJIFoS5DGzL6ZgSuRd5PtO5HOqK1pxLkxtShGmUFnVAV+gIqBA8o2oTzUzGc6uPXdR0zBar7/eyY6f8w=="
     },
     "decentraland-ui": {
-      "version": "3.93.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.93.0.tgz",
-      "integrity": "sha512-4VrkpWa4qFvRzyVWwbqVe09zvfmjOoSDS9dAT7RUCfeK+JCTmx0UNJNv/N6y7skBgy2T3bj8ChhEVjkoqi7wHw==",
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.94.0.tgz",
+      "integrity": "sha512-Vz94Ylza4OuWIjV4t4pVaeXo9wUa24W81+SWI//gBsI1fVq+kW2T03uPvhSIo6V0ZG2lSjkgCZJHWDdaDllvkg==",
       "requires": {
         "@dcl/schemas": "^6.10.0",
         "balloon-css": "^0.5.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -13,7 +13,7 @@
     "dcl-catalyst-commons": "^9.0.1",
     "decentraland-connect": "^3.3.2",
     "decentraland-crypto-fetch": "^1.0.3",
-    "decentraland-dapps": "^13.46.0",
+    "decentraland-dapps": "^13.47.1",
     "decentraland-transactions": "^1.43.1",
     "decentraland-ui": "^3.88.0",
     "dotenv": "^10.0.0",


### PR DESCRIPTION
This PR updates the `decentraland-dapps` dependency to fix the issue with the `_getInternalBlockNumber` function being called from a nulled instance.
[Link to the decentraland-dapps PR](https://github.com/decentraland/decentraland-dapps/pull/404)

![image](https://user-images.githubusercontent.com/1120791/231802619-ca5545bf-279f-438d-ba21-aca08e140842.png)
