### PR TITLE
fix: My lists overflows

### DIFF
--- a/webapp/src/components/ListsPage/ListsPage.module.css
+++ b/webapp/src/components/ListsPage/ListsPage.module.css
@@ -1,24 +1,3 @@
-.ListsPage .PageHeader {
-  display: flex;
-  align-items: center;
-  background-color: var(--card);
-}
-
-.ListsPage .PageHeader > div {
-  margin: auto;
-  text-align: center;
-}
-
-.ListsPage ul.Menu {
-  margin-top: 0;
-  overflow: hidden;
-}
-
-.ListsPage .blockie-address {
-  margin-top: 16px;
-  font-size: 17px;
-}
-
-.back {
-  text-transform: none !important;
+.header:global(.ui.header) {
+  margin-left: 24px
 }

--- a/webapp/src/components/ListsPage/ListsPage.tsx
+++ b/webapp/src/components/ListsPage/ListsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { Page, Header } from 'decentraland-ui'
+import { Header } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { locations } from '../../modules/routing/locations'
 import { View } from '../../modules/ui/types'
@@ -22,27 +22,20 @@ const ListsPage = ({ wallet, isConnecting, onRedirect }: Props) => {
   }, [isConnecting, wallet, onRedirect])
 
   return (
-    <div className={styles.ListsPage}>
+    <>
       <Navbar isFullscreen />
       <Navigation activeTab={NavigationTab.MY_LISTS} />
-      <Page>
-        <Header sub className={styles.back}>
-          {/* TODO: use it on V1 */}
-          {/* <a href={locations.lists()}>{`< ${t('global.back')}`}</a> */}
-        </Header>
-        <Header size="large">
-          {/* TODO: use the name of the selected list */}
-          {t('lists_page.default_title')}
-        </Header>
-        <AssetBrowse
-          view={View.LISTS}
-          section={Section.LISTS}
-          vendor={VendorName.DECENTRALAND}
-          isFullscreen
-        />
-      </Page>
-      <Footer isFullscreen />
-    </div>
+      <Header className={styles.header} size="large">
+        {/* TODO: use the name of the selected list */}
+        {t('lists_page.default_title')}
+      </Header>
+      <AssetBrowse
+        view={View.LISTS}
+        section={Section.LISTS}
+        vendor={VendorName.DECENTRALAND}
+      />
+      <Footer />
+    </>
   )
 }
 


### PR DESCRIPTION
This PR does the following:
- Changes the `Footer` and `AssetBrowse` component props removing `isFullscreen` which is used when the map is shown and broke the screen.
- Removes unused CSS
- Removes unused header component

Closes #1557 