### PR TITLE
fix: Loading more than 20 items in my lists broke pagination

### DIFF
--- a/webapp/src/modules/favorites/sagas.spec.ts
+++ b/webapp/src/modules/favorites/sagas.spec.ts
@@ -302,7 +302,7 @@ describe('when handling the request for fetching favorited items', () => {
         .put(
           fetchItemsRequest({
             ...options,
-            filters: { ...options.filters, ids: [item.id] }
+            filters: { ...options.filters, ids: [item.id], first: 1 }
           })
         )
         .dispatch(fetchFavoritedItemsRequest(options))

--- a/webapp/src/modules/favorites/sagas.ts
+++ b/webapp/src/modules/favorites/sagas.ts
@@ -147,6 +147,7 @@ function* handleFetchFavoritedItemsRequest(
     const options: ItemBrowseOptions = {
       ...action.payload,
       filters: {
+        first: results.length,
         ids: results.map(({ itemId }) => itemId)
       }
     }


### PR DESCRIPTION
This PR fixes an issue where loading more than 20 items broke the My List pagination due to the nft-server waiting for the `first` parameter to come along with the queried ids.

Closes #1580 