### PR TITLE
fix: Re-redirect when being in the sign in page

### DIFF
--- a/webapp/src/components/AccountPage/AccountPage.tsx
+++ b/webapp/src/components/AccountPage/AccountPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
 import { Page, Loader, Center } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { AddressProvider } from 'decentraland-dapps/dist/containers/AddressProvider'
@@ -24,12 +25,14 @@ const AccountPage = ({
 }: Props) => {
   const isCurrentAccount =
     (!addressInUrl || wallet?.address === addressInUrl) && !viewAsGuest
+  const { pathname, search } = useLocation()
 
   // Redirect to signIn if trying to access current account without a wallet
   useEffect(() => {
     if (!addressInUrl && !isConnecting && !wallet) {
-      onRedirect(locations.signIn())
+      onRedirect(locations.signIn(`${pathname}${search}`))
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [addressInUrl, isConnecting, wallet, onRedirect])
 
   return (

--- a/webapp/src/components/ListsPage/ListsPage.tsx
+++ b/webapp/src/components/ListsPage/ListsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
 import { Header } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { locations } from '../../modules/routing/locations'
@@ -15,10 +16,13 @@ import styles from './ListsPage.module.css'
 
 const ListsPage = ({ wallet, isConnecting, onRedirect }: Props) => {
   // Redirect to signIn if trying to access current account without a wallet
+  const { pathname, search } = useLocation()
+
   useEffect(() => {
     if (!isConnecting && !wallet) {
-      onRedirect(locations.signIn())
+      onRedirect(locations.signIn(`${pathname}${search}`))
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isConnecting, wallet, onRedirect])
 
   return (

--- a/webapp/src/components/Navbar/Navbar.tsx
+++ b/webapp/src/components/Navbar/Navbar.tsx
@@ -15,7 +15,11 @@ const Navbar = (props: Props) => {
   }
 
   const handleOnSignIn = useCallback(() => {
-    onNavigate(locations.signIn(`${pathname}${search}`))
+    const searchParams = new URLSearchParams(search)
+    const redirectTo = !searchParams.has('redirectTo')
+      ? `${pathname}${search}`
+      : undefined
+    onNavigate(locations.signIn(redirectTo))
   }, [onNavigate, pathname, search])
 
   const handleOnClickAccount = useCallback(() => {

--- a/webapp/src/components/Navbar/Navbar.tsx
+++ b/webapp/src/components/Navbar/Navbar.tsx
@@ -16,9 +16,10 @@ const Navbar = (props: Props) => {
 
   const handleOnSignIn = useCallback(() => {
     const searchParams = new URLSearchParams(search)
-    const redirectTo = !searchParams.has('redirectTo')
+    const currentRedirectTo = searchParams.get('redirectTo')
+    const redirectTo = !currentRedirectTo
       ? `${pathname}${search}`
-      : undefined
+      : currentRedirectTo
     onNavigate(locations.signIn(redirectTo))
   }, [onNavigate, pathname, search])
 


### PR DESCRIPTION
This PR changes the Navbar to avoid adding multiple redirections to the sign in page to itself when clicking the `sign-in` button while being in the Sign in page.
It also adds redirection to the My Lists and the My Assets page.