### PR TITLE
fix: Requesting favorites without wallet

### DIFF
--- a/webapp/src/components/ListsPage/ListsPage.tsx
+++ b/webapp/src/components/ListsPage/ListsPage.tsx
@@ -33,11 +33,13 @@ const ListsPage = ({ wallet, isConnecting, onRedirect }: Props) => {
         {/* TODO: use the name of the selected list */}
         {t('lists_page.default_title')}
       </Header>
-      <AssetBrowse
-        view={View.LISTS}
-        section={Section.LISTS}
-        vendor={VendorName.DECENTRALAND}
-      />
+      {wallet ? (
+        <AssetBrowse
+          view={View.LISTS}
+          section={Section.LISTS}
+          vendor={VendorName.DECENTRALAND}
+        />
+      ) : null}
       <Footer />
     </>
   )


### PR DESCRIPTION
This PR prevents the favorites request to be performed when the user is not connected.
Although the `useEffect` was in place, the `AssetBrose` got executed and favorites was tried to get requested without a wallet.