### PR TITLE
fix: Loading empty list of favorited items

### DIFF
--- a/webapp/src/modules/favorites/sagas.spec.ts
+++ b/webapp/src/modules/favorites/sagas.spec.ts
@@ -27,7 +27,11 @@ import {
 } from './actions'
 import { favoritesSaga } from './sagas'
 import { getListId } from './selectors'
-import { fetchItemsRequest } from '../item/actions'
+import {
+  FETCH_ITEMS_SUCCESS,
+  fetchItemsRequest,
+  fetchItemsSuccess
+} from '../item/actions'
 import { FavoritedItemIds } from './types'
 
 let item: Item
@@ -278,35 +282,85 @@ describe('when handling the request for fetching favorited items', () => {
     let favoritedItemIds: FavoritedItemIds
     let total: number
 
-    beforeEach(() => {
-      favoritedItemIds = [{ itemId: item.id }]
-      total = 1
+    describe("and there's more than favorited item", () => {
+      beforeEach(() => {
+        favoritedItemIds = [{ itemId: item.id }]
+        total = 1
+      })
+
+      it('should dispatch an action signaling the success of the handled action and the request of the retrieved items', () => {
+        return expectSaga(favoritesSaga)
+          .provide([
+            [call(getIdentity), identity],
+            [select(getListId), listId],
+            [
+              call(
+                [favoritesAPI, 'getPicksByList'],
+                listId,
+                options.filters,
+                identity
+              ),
+              { results: favoritedItemIds, total }
+            ]
+          ])
+          .put(fetchFavoritedItemsSuccess(favoritedItemIds, total))
+          .put(
+            fetchItemsRequest({
+              ...options,
+              filters: { ...options.filters, ids: [item.id], first: 1 }
+            })
+          )
+          .dispatch(fetchFavoritedItemsRequest(options))
+          .run({ silenceTimeout: true })
+      })
     })
 
-    it('should dispatch an action signaling the success of the handled action and the request of the retrieved items', () => {
-      return expectSaga(favoritesSaga)
-        .provide([
-          [call(getIdentity), identity],
-          [select(getListId), listId],
-          [
-            call(
-              [favoritesAPI, 'getPicksByList'],
-              listId,
-              options.filters,
-              identity
-            ),
-            { results: favoritedItemIds, total }
-          ]
-        ])
-        .put(fetchFavoritedItemsSuccess(favoritedItemIds, total))
-        .put(
-          fetchItemsRequest({
-            ...options,
-            filters: { ...options.filters, ids: [item.id], first: 1 }
-          })
-        )
-        .dispatch(fetchFavoritedItemsRequest(options))
-        .run({ silenceTimeout: true })
+    describe('and there are no favorited items', () => {
+      let currentTimestamp: number
+
+      beforeEach(() => {
+        favoritedItemIds = []
+        total = 0
+        currentTimestamp = Date.now()
+        jest.spyOn(Date, 'now').mockReturnValueOnce(currentTimestamp)
+      })
+
+      it('should dispatch an action signaling the success of the handled action and the success the items request', () => {
+        return expectSaga(favoritesSaga)
+          .provide([
+            [call(getIdentity), identity],
+            [select(getListId), listId],
+            [
+              call(
+                [favoritesAPI, 'getPicksByList'],
+                listId,
+                options.filters,
+                identity
+              ),
+              { results: favoritedItemIds, total }
+            ]
+          ])
+          .not.put(
+            fetchItemsRequest({
+              ...options,
+              filters: { ids: [item.id], first: 1 }
+            })
+          )
+          .put(
+            fetchItemsSuccess(
+              [],
+              total,
+              {
+                ...options,
+                filters: { first: total, ids: [] }
+              },
+              currentTimestamp
+            )
+          )
+          .put(fetchFavoritedItemsSuccess(favoritedItemIds, total))
+          .dispatch(fetchFavoritedItemsRequest(options))
+          .run({ silenceTimeout: true })
+      })
     })
   })
 })

--- a/webapp/src/modules/favorites/sagas.ts
+++ b/webapp/src/modules/favorites/sagas.ts
@@ -6,7 +6,7 @@ import {
 } from 'decentraland-dapps/dist/modules/wallet/actions'
 import { call, put, race, select, take, takeEvery } from 'redux-saga/effects'
 import { getIdentity } from '../identity/utils'
-import { fetchItemsRequest } from '../item/actions'
+import { fetchItemsRequest, fetchItemsSuccess } from '../item/actions'
 import { ItemBrowseOptions } from '../item/types'
 import {
   closeModal,
@@ -152,7 +152,12 @@ function* handleFetchFavoritedItemsRequest(
       }
     }
 
-    yield put(fetchItemsRequest(options))
+    if (results.length > 0) {
+      yield put(fetchItemsRequest(options))
+    } else {
+      yield put(fetchItemsSuccess([], 0, options, Date.now()))
+    }
+
     yield put(fetchFavoritedItemsSuccess(results, total))
   } catch (error) {
     yield put(fetchFavoritedItemsFailure((error as Error).message))

--- a/webapp/src/modules/favorites/sagas.ts
+++ b/webapp/src/modules/favorites/sagas.ts
@@ -155,7 +155,7 @@ function* handleFetchFavoritedItemsRequest(
     if (results.length > 0) {
       yield put(fetchItemsRequest(options))
     } else {
-      yield put(fetchItemsSuccess([], 0, options, Date.now()))
+      yield put(fetchItemsSuccess([], total, options, Date.now()))
     }
 
     yield put(fetchFavoritedItemsSuccess(results, total))


### PR DESCRIPTION
This PR fixes an error that prevented users with no favorited items from loading the tab correctly.
The fix puts either the `fetchItemsRequest` or the `fetchItemsSuccess` depending on if the favorites API response resulted in more than one id or not.

Closes #1590