### PR TITLE
fix: Avoid underlining the counter when has 0 picks

### DIFF
--- a/webapp/src/components/FavoritesCounter/FavoritesCounter.module.css
+++ b/webapp/src/components/FavoritesCounter/FavoritesCounter.module.css
@@ -85,6 +85,7 @@
 
 .FavoritesCounter.Collapsed .counter.nonClickable {
   cursor: default;
+  text-decoration-line: none;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
Closes #1597 

<img width="779" alt="image" src="https://user-images.githubusercontent.com/31735779/233341476-55ab0605-2692-451f-881b-7ffafe5fc0d4.png">

<img width="779" alt="image" src="https://user-images.githubusercontent.com/31735779/233341492-f68b729f-606f-46e4-8852-4824a207ffe3.png">
