### PR TITLE
feat: Remove favorited items & start using skip instead of pages

### DIFF
--- a/webapp/src/components/AssetCard/AssetCard.spec.tsx
+++ b/webapp/src/components/AssetCard/AssetCard.spec.tsx
@@ -1,4 +1,11 @@
-import { BodyShape, ChainId, Network, NFTCategory, Rarity } from '@dcl/schemas'
+import {
+  BodyShape,
+  ChainId,
+  Network,
+  NFTCategory,
+  Rarity,
+  WearableCategory
+} from '@dcl/schemas'
 import { Asset } from '../../modules/asset/types'
 import { INITIAL_STATE } from '../../modules/favorites/reducer'
 import { renderWithProviders } from '../../utils/test'
@@ -59,6 +66,7 @@ describe('AssetCard', () => {
       data: {
         wearable: {
           rarity: Rarity.UNIQUE,
+          category: WearableCategory.BODY_SHAPE,
           bodyShapes: [BodyShape.MALE]
         } as Asset['data']['wearable']
       },

--- a/webapp/src/components/AssetList/AssetList.container.ts
+++ b/webapp/src/components/AssetList/AssetList.container.ts
@@ -9,46 +9,43 @@ import {
   getNFTs,
   getCount,
   getItems,
-  getItemsPickedByUser,
-  getView
+  getItemsPickedByUser
 } from '../../modules/ui/browse/selectors'
 import {
   getVendor,
-  getPage,
   getAssetType,
   getSection,
   getSearch,
   hasFiltersEnabled,
-  getVisitedLocations,
-  getSkip
+  getVisitedLocations
 } from '../../modules/routing/selectors'
 import { getLoading as getLoadingNFTs } from '../../modules/nft/selectors'
 import { getLoading as getLoadingItems } from '../../modules/item/selectors'
 import { getLoading as getLoadingFavorites } from '../../modules/favorites/selectors'
+import { FETCH_ITEMS_REQUEST } from '../../modules/item/actions'
+import { Asset, AssetType } from '../../modules/asset/types'
+import { Sections } from '../../modules/routing/types'
 import { MapStateProps, MapDispatch, MapDispatchProps } from './AssetList.types'
 import AssetList from './AssetList'
-import { FETCH_ITEMS_REQUEST } from '../../modules/item/actions'
-import { AssetType } from '../../modules/asset/types'
-import { Sections } from '../../modules/routing/types'
 
 const mapState = (state: RootState): MapStateProps => {
   const section = getSection(state)
-  const page = getPage(state)
   const assetType = getAssetType(state)
-  console.log('Items picked by user', getItemsPickedByUser(state))
-  console.log('Count', getCount(state))
-  console.log('View', getView(state))
+  let assets: Asset[]
+  if (assetType === AssetType.ITEM) {
+    assets =
+      section === Sections.decentraland.LISTS
+        ? getItemsPickedByUser(state)
+        : getItems(state)
+  } else {
+    assets = getNFTs(state)
+  }
+
   return {
     vendor: getVendor(state),
     assetType,
     section,
-    nfts: getNFTs(state),
-    items:
-      section === Sections.decentraland.LISTS
-        ? getItemsPickedByUser(state)
-        : getItems(state),
-    page,
-    skip: getSkip(state),
+    assets,
     count: getCount(state),
     search: getSearch(state),
     isLoading:

--- a/webapp/src/components/AssetList/AssetList.container.ts
+++ b/webapp/src/components/AssetList/AssetList.container.ts
@@ -5,7 +5,13 @@ import { RootState } from '../../modules/reducer'
 import { FETCH_NFTS_REQUEST } from '../../modules/nft/actions'
 import { FETCH_FAVORITED_ITEMS_REQUEST } from '../../modules/favorites/actions'
 import { browse, clearFilters } from '../../modules/routing/actions'
-import { getNFTs, getCount, getItems } from '../../modules/ui/browse/selectors'
+import {
+  getNFTs,
+  getCount,
+  getItems,
+  getItemsPickedByUser,
+  getView
+} from '../../modules/ui/browse/selectors'
 import {
   getVendor,
   getPage,
@@ -13,7 +19,8 @@ import {
   getSection,
   getSearch,
   hasFiltersEnabled,
-  getVisitedLocations
+  getVisitedLocations,
+  getSkip
 } from '../../modules/routing/selectors'
 import { getLoading as getLoadingNFTs } from '../../modules/nft/selectors'
 import { getLoading as getLoadingItems } from '../../modules/item/selectors'
@@ -22,17 +29,26 @@ import { MapStateProps, MapDispatch, MapDispatchProps } from './AssetList.types'
 import AssetList from './AssetList'
 import { FETCH_ITEMS_REQUEST } from '../../modules/item/actions'
 import { AssetType } from '../../modules/asset/types'
+import { Sections } from '../../modules/routing/types'
 
 const mapState = (state: RootState): MapStateProps => {
+  const section = getSection(state)
   const page = getPage(state)
   const assetType = getAssetType(state)
+  console.log('Items picked by user', getItemsPickedByUser(state))
+  console.log('Count', getCount(state))
+  console.log('View', getView(state))
   return {
     vendor: getVendor(state),
     assetType,
-    section: getSection(state),
+    section,
     nfts: getNFTs(state),
-    items: getItems(state),
+    items:
+      section === Sections.decentraland.LISTS
+        ? getItemsPickedByUser(state)
+        : getItems(state),
     page,
+    skip: getSkip(state),
     count: getCount(state),
     search: getSearch(state),
     isLoading:

--- a/webapp/src/components/AssetList/AssetList.tsx
+++ b/webapp/src/components/AssetList/AssetList.tsx
@@ -1,12 +1,11 @@
 import React, { useCallback, useMemo, useEffect } from 'react'
 import { Card, Loader } from 'decentraland-ui'
-import { Item, NFTCategory } from '@dcl/schemas'
+import { NFTCategory } from '@dcl/schemas'
 import { T, t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
 import { getCategoryFromSection } from '../../modules/routing/search'
 import { PAGE_SIZE, getMaxQuerySize } from '../../modules/vendor/api'
 import { AssetType } from '../../modules/asset/types'
-import { NFT } from '../../modules/nft/types'
 import * as events from '../../utils/events'
 import { InfiniteScroll } from '../InfiniteScroll'
 import { AssetCard } from '../AssetCard'
@@ -19,9 +18,7 @@ const AssetList = (props: Props) => {
     vendor,
     section,
     assetType,
-    items,
-    nfts,
-    skip,
+    assets,
     count,
     search,
     isLoading,
@@ -31,8 +28,6 @@ const AssetList = (props: Props) => {
     isManager,
     onClearFilters
   } = props
-
-  const assets: (NFT | Item)[] = assetType === AssetType.ITEM ? items : nfts
 
   useEffect(() => {
     if (visitedLocations.length > 1) {
@@ -49,14 +44,10 @@ const AssetList = (props: Props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const handleLoadMore = useCallback(
-    newSkip => {
-      console.log('Loading more', items.length)
-      onBrowse({ skip: items.length })
-      getAnalytics().track(events.LOAD_MORE, { skip: newSkip })
-    },
-    [onBrowse, items]
-  )
+  const handleLoadMore = useCallback(() => {
+    onBrowse({ skip: assets.length })
+    getAnalytics().track(events.LOAD_MORE, { skip: assets.length })
+  }, [onBrowse, assets.length])
 
   const maxQuerySize = getMaxQuerySize(vendor)
 
@@ -102,7 +93,7 @@ const AssetList = (props: Props) => {
           : null}
       </Card.Group>
       <InfiniteScroll
-        skip={skip}
+        skip={assets.length}
         hasMorePages={hasMoreAssets}
         onLoadMore={handleLoadMore}
         isLoading={isLoading}

--- a/webapp/src/components/AssetList/AssetList.tsx
+++ b/webapp/src/components/AssetList/AssetList.tsx
@@ -51,10 +51,11 @@ const AssetList = (props: Props) => {
 
   const handleLoadMore = useCallback(
     newPage => {
-      onBrowse({ page: newPage })
+      console.log('Items length', items.length)
+      onBrowse({ skip: items.length })
       getAnalytics().track(events.LOAD_MORE, { page: newPage })
     },
-    [onBrowse]
+    [onBrowse, items]
   )
 
   const maxQuerySize = getMaxQuerySize(vendor)

--- a/webapp/src/components/AssetList/AssetList.tsx
+++ b/webapp/src/components/AssetList/AssetList.tsx
@@ -4,7 +4,7 @@ import { Item, NFTCategory } from '@dcl/schemas'
 import { T, t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
 import { getCategoryFromSection } from '../../modules/routing/search'
-import { getMaxQuerySize, MAX_PAGE } from '../../modules/vendor/api'
+import { PAGE_SIZE, getMaxQuerySize } from '../../modules/vendor/api'
 import { AssetType } from '../../modules/asset/types'
 import { NFT } from '../../modules/nft/types'
 import * as events from '../../utils/events'
@@ -21,7 +21,7 @@ const AssetList = (props: Props) => {
     assetType,
     items,
     nfts,
-    page,
+    skip,
     count,
     search,
     isLoading,
@@ -50,18 +50,17 @@ const AssetList = (props: Props) => {
   }, [])
 
   const handleLoadMore = useCallback(
-    newPage => {
-      console.log('Items length', items.length)
+    newSkip => {
+      console.log('Loading more', items.length)
       onBrowse({ skip: items.length })
-      getAnalytics().track(events.LOAD_MORE, { page: newPage })
+      getAnalytics().track(events.LOAD_MORE, { skip: newSkip })
     },
     [onBrowse, items]
   )
 
   const maxQuerySize = getMaxQuerySize(vendor)
 
-  const hasMorePages =
-    (assets.length !== count || count === maxQuerySize) && page <= MAX_PAGE
+  const hasMoreAssets = assets.length !== count || count === maxQuerySize
 
   const emptyStateTranslationString = useMemo(() => {
     if (assets.length > 0) {
@@ -103,11 +102,11 @@ const AssetList = (props: Props) => {
           : null}
       </Card.Group>
       <InfiniteScroll
-        page={page}
-        hasMorePages={hasMorePages}
+        skip={skip}
+        hasMorePages={hasMoreAssets}
         onLoadMore={handleLoadMore}
         isLoading={isLoading}
-        maxScrollPages={3}
+        maxScrollAssets={3 * PAGE_SIZE}
       >
         {assets.length === 0 && !isLoading ? (
           <div className="empty">

--- a/webapp/src/components/AssetList/AssetList.tsx
+++ b/webapp/src/components/AssetList/AssetList.tsx
@@ -4,7 +4,7 @@ import { NFTCategory } from '@dcl/schemas'
 import { T, t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
 import { getCategoryFromSection } from '../../modules/routing/search'
-import { PAGE_SIZE, getMaxQuerySize } from '../../modules/vendor/api'
+import { getMaxQuerySize } from '../../modules/vendor/api'
 import { AssetType } from '../../modules/asset/types'
 import * as events from '../../utils/events'
 import { InfiniteScroll } from '../InfiniteScroll'
@@ -93,11 +93,10 @@ const AssetList = (props: Props) => {
           : null}
       </Card.Group>
       <InfiniteScroll
-        skip={assets.length}
         hasMorePages={hasMoreAssets}
         onLoadMore={handleLoadMore}
         isLoading={isLoading}
-        maxScrollAssets={3 * PAGE_SIZE}
+        maxInfiniteScrolls={3}
       >
         {assets.length === 0 && !isLoading ? (
           <div className="empty">

--- a/webapp/src/components/AssetList/AssetList.types.ts
+++ b/webapp/src/components/AssetList/AssetList.types.ts
@@ -1,7 +1,5 @@
 import { Dispatch } from 'redux'
 import { RouterLocation } from 'connected-react-router'
-import { Item } from '@dcl/schemas'
-import { NFT } from '../../modules/nft/types'
 import { VendorName } from '../../modules/vendor/types'
 import {
   browse,
@@ -10,16 +8,13 @@ import {
   ClearFiltersAction
 } from '../../modules/routing/actions'
 import { Section } from '../../modules/vendor/routing/types'
-import { AssetType } from '../../modules/asset/types'
+import { Asset, AssetType } from '../../modules/asset/types'
 
 export type Props = {
   vendor: VendorName
   assetType: AssetType
   section?: Section
-  nfts: NFT[]
-  items: Item[]
-  page: number
-  skip: number
+  assets: Asset[]
   count?: number
   isLoading: boolean
   isManager?: boolean
@@ -34,10 +29,7 @@ export type MapStateProps = Pick<
   Props,
   | 'vendor'
   | 'section'
-  | 'skip'
-  | 'nfts'
-  | 'items'
-  | 'page'
+  | 'assets'
   | 'count'
   | 'isLoading'
   | 'assetType'

--- a/webapp/src/components/AssetList/AssetList.types.ts
+++ b/webapp/src/components/AssetList/AssetList.types.ts
@@ -19,6 +19,7 @@ export type Props = {
   nfts: NFT[]
   items: Item[]
   page: number
+  skip: number
   count?: number
   isLoading: boolean
   isManager?: boolean
@@ -33,6 +34,7 @@ export type MapStateProps = Pick<
   Props,
   | 'vendor'
   | 'section'
+  | 'skip'
   | 'nfts'
   | 'items'
   | 'page'

--- a/webapp/src/components/Campaign/CampaignBadge/CampaignBadge.tsx
+++ b/webapp/src/components/Campaign/CampaignBadge/CampaignBadge.tsx
@@ -18,7 +18,7 @@ const CampaignBadge = ({ contract, isCampaignBrowserEnabled }: Props) => {
     return locations.campaign({
       section: decentraland.Section.WEARABLES,
       vendor: VendorName.DECENTRALAND,
-      page: 1,
+      skip: 0,
       sortBy: SortBy.RECENTLY_LISTED,
       onlyOnSale: true,
       assetType: AssetType.ITEM,

--- a/webapp/src/components/Campaign/banners/CampaignCollectiblesBanner/CampaignCollectiblesBanner.tsx
+++ b/webapp/src/components/Campaign/banners/CampaignCollectiblesBanner/CampaignCollectiblesBanner.tsx
@@ -23,7 +23,7 @@ const CampaignCollectiblesBanner: React.FC = () => {
         to={locations.campaign({
           section: decentraland.Section.WEARABLES,
           vendor: VendorName.DECENTRALAND,
-          page: 1,
+          skip: 0,
           sortBy: SortBy.RECENTLY_LISTED,
           onlyOnSale: true,
           assetType: AssetType.ITEM

--- a/webapp/src/components/Campaign/banners/CampaignHomepageBanner/CampaignHomepageBanner.tsx
+++ b/webapp/src/components/Campaign/banners/CampaignHomepageBanner/CampaignHomepageBanner.tsx
@@ -23,7 +23,7 @@ const CampaignHomepageBanner: React.FC = () => {
         to={locations.campaign({
           section: decentraland.Section.WEARABLES,
           vendor: VendorName.DECENTRALAND,
-          page: 1,
+          skip: 0,
           sortBy: SortBy.RECENTLY_LISTED,
           onlyOnSale: true,
           assetType: AssetType.ITEM

--- a/webapp/src/components/CollectionList/CollectionList.container.ts
+++ b/webapp/src/components/CollectionList/CollectionList.container.ts
@@ -8,7 +8,7 @@ import {
 } from '../../modules/collection/selectors'
 import { RootState } from '../../modules/reducer'
 import { browse } from '../../modules/routing/actions'
-import { getPage, getSearch, getSortBy } from '../../modules/routing/selectors'
+import { getSearch, getSkip, getSortBy } from '../../modules/routing/selectors'
 import CollectionList from './CollectionList'
 import {
   MapStateProps,
@@ -22,7 +22,7 @@ const mapState = (state: RootState): MapStateProps => ({
   isLoading: isLoadingType(getLoading(state), FETCH_COLLECTIONS_REQUEST),
   search: getSearch(state),
   sortBy: getSortBy(state),
-  page: getPage(state)
+  skip: getSkip(state)
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({

--- a/webapp/src/components/CollectionList/CollectionList.tsx
+++ b/webapp/src/components/CollectionList/CollectionList.tsx
@@ -16,7 +16,7 @@ const CollectionList = ({
   isLoading,
   search,
   sortBy,
-  page,
+  skip,
   onBrowse
 }: Props) => {
   const sortOptions = useRef([
@@ -29,8 +29,8 @@ const CollectionList = ({
     { value: SortBy.SIZE, text: t('filters.size') }
   ])
 
+  const page = Math.ceil(skip / COLLECTIONS_PER_PAGE) + 1
   const pages = Math.ceil(count / COLLECTIONS_PER_PAGE)
-
   const hasPagination = pages > 1
 
   return (
@@ -41,7 +41,10 @@ const CollectionList = ({
             value={search}
             onChange={newSearch => {
               if (search !== newSearch) {
-                onBrowse({ search: newSearch, page: 1 })
+                onBrowse({
+                  search: newSearch,
+                  skip: 0
+                })
               }
             }}
             placeholder={t('collection_list.search', {
@@ -113,7 +116,9 @@ const CollectionList = ({
                 activePage={page}
                 onPageChange={(_, data) => {
                   if (page !== data.activePage) {
-                    onBrowse({ page: Number(data.activePage) })
+                    onBrowse({
+                      skip: (Number(data.activePage) - 1) * COLLECTIONS_PER_PAGE
+                    })
                   }
                 }}
               />

--- a/webapp/src/components/CollectionList/CollectionList.types.ts
+++ b/webapp/src/components/CollectionList/CollectionList.types.ts
@@ -8,14 +8,14 @@ export type Props = {
   count: number
   isLoading: boolean
   search: string
-  page: number
+  skip: number
   sortBy?: SortBy
   onBrowse: (...params: Parameters<typeof browse>) => void
 }
 
 export type MapStateProps = Pick<
   Props,
-  'collections' | 'count' | 'isLoading' | 'search' | 'sortBy' | 'page'
+  'collections' | 'count' | 'isLoading' | 'search' | 'sortBy' | 'skip'
 >
 
 export type MapDispatchProps = Pick<Props, 'onBrowse'>

--- a/webapp/src/components/HomePage/HomePage.tsx
+++ b/webapp/src/components/HomePage/HomePage.tsx
@@ -124,7 +124,7 @@ const HomePage = (props: Props) => {
         view,
         assetType: assetTypes[view],
         sortBy: sort[view],
-        page: 1,
+        skip: 0,
         onlyOnSale: true
       }),
     [onFetchAssetsFromRoute, vendor, sections, assetTypes, sort]

--- a/webapp/src/components/InfiniteScroll/InfiniteScroll.spec.tsx
+++ b/webapp/src/components/InfiniteScroll/InfiniteScroll.spec.tsx
@@ -7,10 +7,9 @@ import { Props } from './InfiniteScroll.types'
 function renderInfiniteScroll(props: Partial<Props>) {
   return render(
     <InfiniteScroll
-      maxScrollPages={0}
+      maxInfiniteScrolls={0}
       hasMorePages
       onLoadMore={jest.fn()}
-      page={0}
       {...props}
     >
       <span>My container</span>
@@ -21,7 +20,7 @@ function renderInfiniteScroll(props: Partial<Props>) {
 describe('when maxScrollPages is 0', () => {
   describe('and hasMorePages is true', () => {
     it('should show load button from the start', () => {
-      const screen = renderInfiniteScroll({ maxScrollPages: 0 })
+      const screen = renderInfiniteScroll({ maxInfiniteScrolls: 0 })
       expect(
         screen.getByRole('button', { name: t('global.load_more') })
       ).toBeInTheDocument()
@@ -31,13 +30,13 @@ describe('when maxScrollPages is 0', () => {
       it('should call onLoadMore function', async () => {
         const loadMoreMock = jest.fn()
         const screen = renderInfiniteScroll({
-          maxScrollPages: 0,
+          maxInfiniteScrolls: 0,
           onLoadMore: loadMoreMock
         })
         await userEvent.click(
           screen.getByRole('button', { name: t('global.load_more') })
         )
-        expect(loadMoreMock).toHaveBeenCalledWith(1)
+        expect(loadMoreMock).toHaveBeenCalled()
       })
     })
   })
@@ -45,7 +44,7 @@ describe('when maxScrollPages is 0', () => {
   describe('and hasMorePages is false', () => {
     it('should not show load more button', () => {
       const screen = renderInfiniteScroll({
-        maxScrollPages: 0,
+        maxInfiniteScrolls: 0,
         hasMorePages: false
       })
       expect(

--- a/webapp/src/components/InfiniteScroll/InfiniteScroll.tsx
+++ b/webapp/src/components/InfiniteScroll/InfiniteScroll.tsx
@@ -2,18 +2,19 @@ import { useCallback, useEffect, useState } from 'react'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Button } from 'decentraland-ui'
 import { Props } from './InfiniteScroll.types'
+import { PAGE_SIZE } from '../../modules/vendor/api'
 
 export function InfiniteScroll({
-  page,
+  skip,
   hasMorePages,
   isLoading,
   children,
-  maxScrollPages,
+  maxScrollAssets,
   onLoadMore
 }: Props) {
   const [scrollPage, setScrollPage] = useState(0)
   const [showLoadMoreButton, setShowLoadMoreButton] = useState(
-    maxScrollPages === 0
+    maxScrollAssets === 0
   )
 
   const onScroll = useCallback(() => {
@@ -24,20 +25,24 @@ export function InfiniteScroll({
       !isLoading &&
       scrollTop + clientHeight >= scrollHeight &&
       hasMorePages &&
-      (!maxScrollPages || scrollPage < maxScrollPages)
+      (!maxScrollAssets || scrollPage < maxScrollAssets)
     ) {
       setScrollPage(scrollPage + 1)
-      onLoadMore(page + 1)
+      onLoadMore(skip + 1 * PAGE_SIZE)
     }
-  }, [page, hasMorePages, isLoading, scrollPage, maxScrollPages, onLoadMore])
+  }, [skip, hasMorePages, isLoading, scrollPage, maxScrollAssets, onLoadMore])
 
   useEffect(() => {
-    if (!isLoading && maxScrollPages !== undefined && scrollPage === maxScrollPages) {
+    if (
+      !isLoading &&
+      maxScrollAssets !== undefined &&
+      scrollPage === maxScrollAssets
+    ) {
       setShowLoadMoreButton(true)
     } else {
       setShowLoadMoreButton(false)
     }
-  }, [isLoading, scrollPage, maxScrollPages, page, setShowLoadMoreButton])
+  }, [isLoading, scrollPage, maxScrollAssets, skip, setShowLoadMoreButton])
 
   useEffect(() => {
     window.addEventListener('scroll', onScroll)
@@ -45,9 +50,9 @@ export function InfiniteScroll({
   }, [onScroll])
 
   const handleLoadMore = useCallback(() => {
-    onLoadMore(page + 1)
+    onLoadMore(skip + 1 * PAGE_SIZE)
     setScrollPage(0)
-  }, [onLoadMore, page])
+  }, [onLoadMore, skip])
 
   if (!hasMorePages) {
     return children

--- a/webapp/src/components/InfiniteScroll/InfiniteScroll.tsx
+++ b/webapp/src/components/InfiniteScroll/InfiniteScroll.tsx
@@ -2,20 +2,15 @@ import { useCallback, useEffect, useState } from 'react'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Button } from 'decentraland-ui'
 import { Props } from './InfiniteScroll.types'
-import { PAGE_SIZE } from '../../modules/vendor/api'
 
 export function InfiniteScroll({
-  skip,
   hasMorePages,
   isLoading,
   children,
-  maxScrollAssets,
+  maxInfiniteScrolls,
   onLoadMore
 }: Props) {
-  const [scrollAssets, setScrollPage] = useState(0)
-  const [showLoadMoreButton, setShowLoadMoreButton] = useState(
-    maxScrollAssets === 0
-  )
+  const [scrolledTimes, setScrolledTimes] = useState(0)
 
   const onScroll = useCallback(() => {
     const scrollTop = document.documentElement.scrollTop
@@ -25,24 +20,12 @@ export function InfiniteScroll({
       !isLoading &&
       scrollTop + clientHeight >= scrollHeight &&
       hasMorePages &&
-      (!maxScrollAssets || scrollAssets < maxScrollAssets)
+      (!maxInfiniteScrolls || scrolledTimes < maxInfiniteScrolls)
     ) {
-      setScrollPage(scrollAssets + 1)
-      onLoadMore(skip + PAGE_SIZE)
+      setScrolledTimes(scrolledTimes + 1)
+      onLoadMore()
     }
-  }, [skip, hasMorePages, isLoading, scrollAssets, maxScrollAssets, onLoadMore])
-
-  useEffect(() => {
-    if (
-      !isLoading &&
-      maxScrollAssets !== undefined &&
-      scrollAssets === maxScrollAssets
-    ) {
-      setShowLoadMoreButton(true)
-    } else {
-      setShowLoadMoreButton(false)
-    }
-  }, [isLoading, scrollAssets, maxScrollAssets, skip, setShowLoadMoreButton])
+  }, [hasMorePages, isLoading, scrolledTimes, maxInfiniteScrolls, onLoadMore])
 
   useEffect(() => {
     window.addEventListener('scroll', onScroll)
@@ -50,9 +33,14 @@ export function InfiniteScroll({
   }, [onScroll])
 
   const handleLoadMore = useCallback(() => {
-    onLoadMore(skip + PAGE_SIZE)
-    setScrollPage(0)
-  }, [onLoadMore, skip])
+    onLoadMore()
+    setScrolledTimes(0)
+  }, [onLoadMore])
+
+  const showLoadMoreButton =
+    !isLoading &&
+    maxInfiniteScrolls !== undefined &&
+    scrolledTimes === maxInfiniteScrolls
 
   if (!hasMorePages) {
     return children

--- a/webapp/src/components/InfiniteScroll/InfiniteScroll.tsx
+++ b/webapp/src/components/InfiniteScroll/InfiniteScroll.tsx
@@ -12,7 +12,7 @@ export function InfiniteScroll({
   maxScrollAssets,
   onLoadMore
 }: Props) {
-  const [scrollPage, setScrollPage] = useState(0)
+  const [scrollAssets, setScrollPage] = useState(0)
   const [showLoadMoreButton, setShowLoadMoreButton] = useState(
     maxScrollAssets === 0
   )
@@ -25,24 +25,24 @@ export function InfiniteScroll({
       !isLoading &&
       scrollTop + clientHeight >= scrollHeight &&
       hasMorePages &&
-      (!maxScrollAssets || scrollPage < maxScrollAssets)
+      (!maxScrollAssets || scrollAssets < maxScrollAssets)
     ) {
-      setScrollPage(scrollPage + 1)
-      onLoadMore(skip + 1 * PAGE_SIZE)
+      setScrollPage(scrollAssets + 1)
+      onLoadMore(skip + PAGE_SIZE)
     }
-  }, [skip, hasMorePages, isLoading, scrollPage, maxScrollAssets, onLoadMore])
+  }, [skip, hasMorePages, isLoading, scrollAssets, maxScrollAssets, onLoadMore])
 
   useEffect(() => {
     if (
       !isLoading &&
       maxScrollAssets !== undefined &&
-      scrollPage === maxScrollAssets
+      scrollAssets === maxScrollAssets
     ) {
       setShowLoadMoreButton(true)
     } else {
       setShowLoadMoreButton(false)
     }
-  }, [isLoading, scrollPage, maxScrollAssets, skip, setShowLoadMoreButton])
+  }, [isLoading, scrollAssets, maxScrollAssets, skip, setShowLoadMoreButton])
 
   useEffect(() => {
     window.addEventListener('scroll', onScroll)
@@ -50,7 +50,7 @@ export function InfiniteScroll({
   }, [onScroll])
 
   const handleLoadMore = useCallback(() => {
-    onLoadMore(skip + 1 * PAGE_SIZE)
+    onLoadMore(skip + PAGE_SIZE)
     setScrollPage(0)
   }, [onLoadMore, skip])
 

--- a/webapp/src/components/InfiniteScroll/InfiniteScroll.types.ts
+++ b/webapp/src/components/InfiniteScroll/InfiniteScroll.types.ts
@@ -1,8 +1,8 @@
-export type Props = { 
-  page: number,
-  hasMorePages: boolean,
-  isLoading?: boolean,
-  maxScrollPages?: number,
-  children: JSX.Element | null,
+export type Props = {
+  skip: number
+  hasMorePages: boolean
+  isLoading?: boolean
+  maxScrollAssets?: number
+  children: JSX.Element | null
   onLoadMore: (page: number) => void
 }

--- a/webapp/src/components/InfiniteScroll/InfiniteScroll.types.ts
+++ b/webapp/src/components/InfiniteScroll/InfiniteScroll.types.ts
@@ -1,8 +1,7 @@
 export type Props = {
-  skip: number
   hasMorePages: boolean
   isLoading?: boolean
-  maxScrollAssets?: number
+  maxInfiniteScrolls?: number
   children: JSX.Element | null
-  onLoadMore: (page: number) => void
+  onLoadMore: () => void
 }

--- a/webapp/src/components/Modals/RentalsLaunchModal/RentalsLaunchModal.tsx
+++ b/webapp/src/components/Modals/RentalsLaunchModal/RentalsLaunchModal.tsx
@@ -5,7 +5,7 @@ import {
   // Image,
   Button,
   useMobileMediaQuery,
-  Close,
+  Close
 } from 'decentraland-ui'
 import classNames from 'classnames'
 import { Link } from 'react-router-dom'
@@ -58,7 +58,7 @@ export const RentalsLaunchModal = ({
             assetType: AssetType.NFT,
             section: 'land',
             vendor: VendorName.DECENTRALAND,
-            page: 1,
+            skip: 0,
             sortBy: SortBy.NAME,
             onlyOnSale: false,
             viewAsGuest: false
@@ -98,7 +98,9 @@ export const RentalsLaunchModal = ({
           className={classNames(styles.rentalImage, 'ui medium image')}
         ></div>
         <Modal.Description className={styles.modalDescription}>
-          <h2 className={styles.modalTitle}>{t('rentals_promotional_modal.title')}</h2>
+          <h2 className={styles.modalTitle}>
+            {t('rentals_promotional_modal.title')}
+          </h2>
           {t('rentals_promotional_modal.description', {
             p: (children: React.ReactElement) => <p>{children}</p>,
             a: (children: React.ReactElement) => (

--- a/webapp/src/components/Navigation/Navigation.tsx
+++ b/webapp/src/components/Navigation/Navigation.tsx
@@ -44,7 +44,7 @@ const Navigation = (props: Props) => {
               to={locations.campaign({
                 section: decentraland.Section.WEARABLES,
                 vendor: VendorName.DECENTRALAND,
-                page: 1,
+                skip: 0,
                 sortBy: SortBy.RECENTLY_LISTED,
                 onlyOnSale: true,
                 assetType: AssetType.ITEM
@@ -65,7 +65,7 @@ const Navigation = (props: Props) => {
             to={locations.browse({
               section: decentraland.Section.WEARABLES,
               vendor: VendorName.DECENTRALAND,
-              page: 1,
+              skip: 0,
               sortBy: SortBy.RECENTLY_LISTED,
               onlyOnSale: true
             })}

--- a/webapp/src/components/Sales/Activity/Activity.container.ts
+++ b/webapp/src/components/Sales/Activity/Activity.container.ts
@@ -1,6 +1,7 @@
+import { Dispatch } from 'redux'
+import { connect } from 'react-redux'
 import { Item, Sale, SaleType } from '@dcl/schemas'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
-import { connect } from 'react-redux'
 import { NFT } from '../../../modules/nft/types'
 import { RootState } from '../../../modules/reducer'
 import {
@@ -20,11 +21,10 @@ import Activity from './Activity'
 import { FETCH_SALES_REQUEST } from '../../../modules/sale/actions'
 import { FETCH_ITEM_REQUEST } from '../../../modules/item/actions'
 import { FETCH_NFT_REQUEST } from '../../../modules/nft/actions'
-import { MapStateProps, MapDispatchProps } from './Activity.types'
 import { browse } from '../../../modules/routing/actions'
-import { Dispatch } from 'redux'
-import { getPage } from '../../../modules/routing/selectors'
+import { getSkip } from '../../../modules/routing/selectors'
 import { Asset } from '../../../modules/asset/types'
+import { MapStateProps, MapDispatchProps } from './Activity.types'
 
 const getAssets = (
   sales: Sale[],
@@ -56,7 +56,7 @@ const mapState = (state: RootState): MapStateProps => {
   const count = getCount(state)
   const items = getItemsData(state)
   const nfts = getNftData(state)
-  const page = getPage(state)
+  const skip = getSkip(state)
   const assets = getAssets(sales, items, nfts)
   const isLoading = getIsLoading(state)
 
@@ -64,7 +64,7 @@ const mapState = (state: RootState): MapStateProps => {
     sales,
     assets,
     count,
-    page,
+    skip,
     isLoading
   }
 }

--- a/webapp/src/components/Sales/Activity/Activity.tsx
+++ b/webapp/src/components/Sales/Activity/Activity.tsx
@@ -21,12 +21,12 @@ const Activity = ({
   count,
   sales,
   assets,
-  page,
+  skip,
   isLoading,
   onBrowse
 }: Props) => {
+  const page = Math.ceil(skip / SALES_PER_PAGE) + 1
   const pages = Math.ceil(count / SALES_PER_PAGE)
-
   const hasPagination = pages > 1
 
   return (
@@ -105,7 +105,9 @@ const Activity = ({
                 activePage={page}
                 onPageChange={(_, data) => {
                   if (page !== data.activePage) {
-                    onBrowse({ page: Number(data.activePage) })
+                    onBrowse({
+                      skip: (Number(data.activePage) - 1) * SALES_PER_PAGE
+                    })
                   }
                 }}
               />

--- a/webapp/src/components/Sales/Activity/Activity.types.ts
+++ b/webapp/src/components/Sales/Activity/Activity.types.ts
@@ -6,13 +6,13 @@ export type Props = {
   sales: Sale[]
   assets: Record<string, Asset>
   count: number
-  page: number
+  skip: number
   isLoading: boolean
   onBrowse: (options: BrowseOptions) => void
 }
 
 export type MapStateProps = Pick<
   Props,
-  'sales' | 'assets' | 'count' | 'page' | 'isLoading'
+  'sales' | 'assets' | 'count' | 'skip' | 'isLoading'
 >
 export type MapDispatchProps = Pick<Props, 'onBrowse'>

--- a/webapp/src/modules/favorites/actions.spec.ts
+++ b/webapp/src/modules/favorites/actions.spec.ts
@@ -32,8 +32,7 @@ import {
 import { FavoritedItemIds } from './types'
 
 const itemBrowseOptions: ItemBrowseOptions = {
-  view: View.LISTS,
-  page: 0
+  view: View.LISTS
 }
 
 const item = {

--- a/webapp/src/modules/favorites/reducer.spec.ts
+++ b/webapp/src/modules/favorites/reducer.spec.ts
@@ -37,8 +37,7 @@ import {
 } from '../item/actions'
 
 const itemBrowseOptions: ItemBrowseOptions = {
-  view: View.LISTS,
-  page: 0
+  view: View.LISTS
 }
 
 const item = {

--- a/webapp/src/modules/favorites/sagas.spec.ts
+++ b/webapp/src/modules/favorites/sagas.spec.ts
@@ -8,6 +8,7 @@ import { closeModal, CLOSE_MODAL, openModal } from '../modal/actions'
 import { FavoritesAPI } from '../vendor/decentraland/favorites/api'
 import { getAddress } from '../wallet/selectors'
 import { ItemBrowseOptions } from '../item/types'
+import { fetchItemsRequest, fetchItemsSuccess } from '../item/actions'
 import { View } from '../ui/types'
 import {
   cancelPickItemAsFavorite,
@@ -26,7 +27,6 @@ import {
 } from './actions'
 import { favoritesSaga } from './sagas'
 import { getListId } from './selectors'
-import { fetchItemsRequest, fetchItemsSuccess } from '../item/actions'
 import { FavoritedItemIds } from './types'
 
 let item: Item

--- a/webapp/src/modules/favorites/sagas.spec.ts
+++ b/webapp/src/modules/favorites/sagas.spec.ts
@@ -1,14 +1,11 @@
-import { call, select, take } from 'redux-saga/effects'
+import { select, take } from 'redux-saga/effects'
 import * as matchers from 'redux-saga-test-plan/matchers'
 import { expectSaga } from 'redux-saga-test-plan'
 import { throwError } from 'redux-saga-test-plan/providers'
 import { Item } from '@dcl/schemas'
 import { CONNECT_WALLET_SUCCESS } from 'decentraland-dapps/dist/modules/wallet/actions'
 import { closeModal, CLOSE_MODAL, openModal } from '../modal/actions'
-import {
-  FavoritesAPI,
-  MARKETPLACE_FAVORITES_SERVER_URL
-} from '../vendor/decentraland/favorites/api'
+import { FavoritesAPI } from '../vendor/decentraland/favorites/api'
 import { getAddress } from '../wallet/selectors'
 import { ItemBrowseOptions } from '../item/types'
 import { View } from '../ui/types'
@@ -29,11 +26,7 @@ import {
 } from './actions'
 import { favoritesSaga } from './sagas'
 import { getListId } from './selectors'
-import {
-  FETCH_ITEMS_SUCCESS,
-  fetchItemsRequest,
-  fetchItemsSuccess
-} from '../item/actions'
+import { fetchItemsRequest, fetchItemsSuccess } from '../item/actions'
 import { FavoritedItemIds } from './types'
 
 let item: Item
@@ -230,8 +223,7 @@ describe('when handling the request for fetching favorited items', () => {
 
   beforeEach(() => {
     options = {
-      view: View.LISTS,
-      page: 0
+      view: View.LISTS
     }
     listId = 'listId'
   })

--- a/webapp/src/modules/item/types.ts
+++ b/webapp/src/modules/item/types.ts
@@ -4,7 +4,6 @@ import { Section } from '../vendor/routing/types'
 
 export type ItemBrowseOptions = {
   view?: View
-  page?: number
   filters?: ItemFilters
   section?: Section
 }

--- a/webapp/src/modules/routing/locations.ts
+++ b/webapp/src/modules/routing/locations.ts
@@ -9,7 +9,9 @@ import { BrowseOptions } from './types'
 export const locations = {
   root: () => '/',
   signIn: (redirectTo?: string) => {
-    return `/sign-in${redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : ''}`
+    return `/sign-in${
+      redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : ''
+    }`
   },
   settings: () => '/settings',
   lands: (options?: BrowseOptions) => {
@@ -45,7 +47,7 @@ export const locations = {
   defaultList: function() {
     return this.list(DEFAULT_FAVORITES_LIST_ID, {
       assetType: AssetType.ITEM,
-      page: 1,
+      skip: 0,
       section: Section.LISTS,
       view: View.LISTS
     })

--- a/webapp/src/modules/routing/sagas.spec.ts
+++ b/webapp/src/modules/routing/sagas.spec.ts
@@ -243,7 +243,7 @@ describe('when handling the browse action', () => {
     browseOptions = {
       onlyOnSale: undefined,
       sortBy: undefined,
-      skip: 1,
+      skip: 0,
       onlyOnRent: undefined,
       isMap: undefined,
       isFullscreen: undefined,

--- a/webapp/src/modules/routing/sagas.spec.ts
+++ b/webapp/src/modules/routing/sagas.spec.ts
@@ -46,7 +46,7 @@ describe('when handling the clear filters request action', () => {
       address: '0x...',
       vendor: VendorName.DECENTRALAND,
       section: Section.LAND,
-      page: 1,
+      skip: 0,
       view: View.MARKET,
       sortBy: SortBy.NAME,
       search: 'aText',
@@ -75,7 +75,7 @@ describe('when handling the clear filters request action', () => {
     delete browseOptionsWithoutFilters.maxEstateSize
     delete browseOptionsWithoutFilters.search
     delete browseOptionsWithoutFilters.onlyOnSale
-    browseOptionsWithoutFilters.page = 1
+    browseOptionsWithoutFilters.skip = 0
     pathname = 'aPath'
   })
   describe('and the filters are set', () => {
@@ -171,12 +171,11 @@ describe('when handling the fetchAssetsFromRoute request action', () => {
       vendor: VendorName.DECENTRALAND,
       section: Section.EMOTES,
       view: View.ACCOUNT,
-      page: 1
+      skip: 0
     }
 
     const filters: ItemBrowseOptions = {
       view: browseOptions.view,
-      page: browseOptions.page,
       filters: {
         first: 24,
         skip: 0,
@@ -208,7 +207,7 @@ describe('when handling the fetchAssetsFromRoute request action', () => {
 
   it('should fetch favorited items when providing the LISTS section', () => {
     const browseOptions: BrowseOptions = {
-      page: 1,
+      skip: 0,
       address: '0x...',
       vendor: VendorName.DECENTRALAND,
       section: Section.LISTS,
@@ -217,7 +216,6 @@ describe('when handling the fetchAssetsFromRoute request action', () => {
 
     const filters: ItemBrowseOptions = {
       view: browseOptions.view,
-      page: browseOptions.page,
       section: browseOptions.section as Section,
       filters: {
         first: 24,
@@ -245,7 +243,7 @@ describe('when handling the browse action', () => {
     browseOptions = {
       onlyOnSale: undefined,
       sortBy: undefined,
-      page: 1,
+      skip: 1,
       onlyOnRent: undefined,
       isMap: undefined,
       isFullscreen: undefined,
@@ -914,7 +912,7 @@ describe('when handling the browse action', () => {
       }
       expectedBrowseOptions = {
         ...newBrowseOptions,
-        page: 1,
+        skip: 0,
         onlyOnSale: undefined,
         onlyOnRent: undefined,
         sortBy: undefined,

--- a/webapp/src/modules/routing/sagas.ts
+++ b/webapp/src/modules/routing/sagas.ts
@@ -44,12 +44,7 @@ import {
 } from '../nft/actions'
 import { setView } from '../ui/actions'
 import { getFilters } from '../vendor/utils'
-import {
-  MAX_PAGE,
-  PAGE_SIZE,
-  getMaxQuerySize,
-  MAX_QUERY_SIZE
-} from '../vendor/api'
+import { PAGE_SIZE, getMaxQuerySize, MAX_QUERY_SIZE } from '../vendor/api'
 import { locations } from './locations'
 import {
   getCategoryFromSection,
@@ -186,7 +181,7 @@ export function* fetchAssetsFromRoute(options: BrowseOptions) {
   const view = options.view!
   const vendor = options.vendor!
   const page = options.page!
-  let skip = options.skip
+  let skip = options.skip ?? 0
   const section = options.section!
   const sortBy = options.sortBy!
   const {
@@ -215,9 +210,9 @@ export function* fetchAssetsFromRoute(options: BrowseOptions) {
 
   const category = getCategoryFromSection(section)
 
-  const offset = isLoadMore ? page - 1 : 0
-  skip = skip ?? Math.min(offset, MAX_PAGE) * PAGE_SIZE
-  const first = Math.min(page * PAGE_SIZE - skip, getMaxQuerySize(vendor))
+  skip = isLoadMore ? skip : 0
+  const first = Math.min(PAGE_SIZE, getMaxQuerySize(vendor))
+  console.log('Browse', { skip, first })
 
   switch (section) {
     case Section.BIDS:

--- a/webapp/src/modules/routing/sagas.ts
+++ b/webapp/src/modules/routing/sagas.ts
@@ -186,6 +186,7 @@ export function* fetchAssetsFromRoute(options: BrowseOptions) {
   const view = options.view!
   const vendor = options.vendor!
   const page = options.page!
+  let skip = options.skip
   const section = options.section!
   const sortBy = options.sortBy!
   const {
@@ -215,7 +216,7 @@ export function* fetchAssetsFromRoute(options: BrowseOptions) {
   const category = getCategoryFromSection(section)
 
   const offset = isLoadMore ? page - 1 : 0
-  const skip = Math.min(offset, MAX_PAGE) * PAGE_SIZE
+  skip = skip ?? Math.min(offset, MAX_PAGE) * PAGE_SIZE
   const first = Math.min(page * PAGE_SIZE - skip, getMaxQuerySize(vendor))
 
   switch (section) {
@@ -577,7 +578,8 @@ function* deriveCurrentOptions(
 }
 
 function deriveView(previous: BrowseOptions, current: BrowseOptions) {
-  return previous.page! < current.page!
+  return (previous.page && current.page && previous.page < current.page) ||
+    (previous.skip && current.skip && previous.skip < current.skip)
     ? View.LOAD_MORE
     : current.view || previous.view
 }

--- a/webapp/src/modules/routing/sagas.ts
+++ b/webapp/src/modules/routing/sagas.ts
@@ -180,7 +180,6 @@ export function* fetchAssetsFromRoute(options: BrowseOptions) {
   const isItems = options.assetType === AssetType.ITEM
   const view = options.view!
   const vendor = options.vendor!
-  const page = options.page!
   let skip = options.skip ?? 0
   const section = options.section!
   const sortBy = options.sortBy!
@@ -244,13 +243,13 @@ export function* fetchAssetsFromRoute(options: BrowseOptions) {
     case Section.SALES:
       yield spawn(handleFetchSales, {
         address: Array.isArray(address) ? address[0] : address,
-        page,
+        page: Math.round(skip / PAGE_SIZE),
         pageSize: SALES_PER_PAGE
       })
       break
     case Section.COLLECTIONS:
       yield handleFetchCollections(
-        page,
+        Math.round(skip / PAGE_SIZE),
         Array.isArray(address) ? address[0] : address,
         sortBy,
         search
@@ -261,7 +260,7 @@ export function* fetchAssetsFromRoute(options: BrowseOptions) {
         fetchFavoritedItemsRequest({
           view,
           section,
-          page,
+          page: Math.round(skip / PAGE_SIZE),
           filters: { first, skip }
         })
       )
@@ -288,7 +287,6 @@ export function* fetchAssetsFromRoute(options: BrowseOptions) {
         yield put(
           fetchItemsRequest({
             view,
-            page,
             filters: {
               first,
               skip,

--- a/webapp/src/modules/routing/search.ts
+++ b/webapp/src/modules/routing/search.ts
@@ -56,9 +56,6 @@ export function getSearchParams(options?: BrowseOptions) {
     if (options.vendor) {
       params.set('vendor', options.vendor)
     }
-    if (options.page) {
-      params.set('page', options.page.toString())
-    }
     if (options.skip) {
       params.set('skip', options.skip.toString())
     }

--- a/webapp/src/modules/routing/search.ts
+++ b/webapp/src/modules/routing/search.ts
@@ -59,6 +59,9 @@ export function getSearchParams(options?: BrowseOptions) {
     if (options.page) {
       params.set('page', options.page.toString())
     }
+    if (options.skip) {
+      params.set('skip', options.skip.toString())
+    }
     if (options.sortBy) {
       params.set('sortBy', options.sortBy)
     }

--- a/webapp/src/modules/routing/selectors.spec.ts
+++ b/webapp/src/modules/routing/selectors.spec.ts
@@ -21,6 +21,7 @@ import {
   getOnlyOnRent,
   getOnlySmart,
   getSection,
+  getSkip,
   getSortBy,
   getViewAsGuest,
   hasFiltersEnabled
@@ -530,6 +531,49 @@ describe('when getting if it should filter for guests', () => {
 
     it('should return undefined', () => {
       expect(getViewAsGuest.resultFunc(url)).toBe(undefined)
+    })
+  })
+})
+
+// export const getSkip = createSelector<RootState, string, number>(
+//   getRouterSearch,
+//   search => {
+//     const skip = getURLParam(search, 'skip')
+//     return skip === null || isNaN(+skip) ? 0 : +skip
+//   }
+// )
+
+describe('when getting the skip parameter', () => {
+  let searchParams: URLSearchParams
+  beforeEach(() => {
+    searchParams = new URLSearchParams()
+  })
+
+  describe("and it's not set", () => {
+    it('should return 0', () => {
+      expect(getSkip.resultFunc(searchParams.toString())).toBe(0)
+    })
+  })
+
+  describe("and it's not set to a parsable number", () => {
+    beforeEach(() => {
+      searchParams.set('skip', 'notANumber')
+    })
+
+    it('should return 0', () => {
+      expect(getSkip.resultFunc(searchParams.toString())).toBe(0)
+    })
+  })
+
+  describe("and it's a parsable number", () => {
+    beforeEach(() => {
+      searchParams.set('skip', '1')
+    })
+
+    it('should return the number', () => {
+      expect(getSkip.resultFunc(searchParams.toString())).toBe(
+        Number(searchParams.get('skip'))
+      )
     })
   })
 })

--- a/webapp/src/modules/routing/selectors.spec.ts
+++ b/webapp/src/modules/routing/selectors.spec.ts
@@ -535,14 +535,6 @@ describe('when getting if it should filter for guests', () => {
   })
 })
 
-// export const getSkip = createSelector<RootState, string, number>(
-//   getRouterSearch,
-//   search => {
-//     const skip = getURLParam(search, 'skip')
-//     return skip === null || isNaN(+skip) ? 0 : +skip
-//   }
-// )
-
 describe('when getting the skip parameter', () => {
   let searchParams: URLSearchParams
   beforeEach(() => {

--- a/webapp/src/modules/routing/selectors.ts
+++ b/webapp/src/modules/routing/selectors.ts
@@ -77,14 +77,6 @@ export const getSection = createSelector<
   return section as Section
 })
 
-export const getPage = createSelector<RootState, string, number>(
-  getRouterSearch,
-  search => {
-    const page = getURLParam(search, 'page')
-    return page === null || isNaN(+page) ? 1 : +page
-  }
-)
-
 export const getSkip = createSelector<RootState, string, number>(
   getRouterSearch,
   search => {
@@ -341,10 +333,10 @@ export const getCurrentLocationAddress = createSelector<
 )
 
 export const getPaginationUrlParams = createSelector(
-  getPage,
+  getSkip,
   getSortBy,
   getSearch,
-  (page, sortBy, search) => ({ page, sortBy, search })
+  (skip, sortBy, search) => ({ skip, sortBy, search })
 )
 
 export const getAssetsUrlParams = createSelector(

--- a/webapp/src/modules/routing/selectors.ts
+++ b/webapp/src/modules/routing/selectors.ts
@@ -85,6 +85,14 @@ export const getPage = createSelector<RootState, string, number>(
   }
 )
 
+export const getSkip = createSelector<RootState, string, number>(
+  getRouterSearch,
+  search => {
+    const skip = getURLParam(search, 'skip')
+    return skip === null || isNaN(+skip) ? 0 : +skip
+  }
+)
+
 export const getSortBy = createSelector<
   RootState,
   string,

--- a/webapp/src/modules/routing/types.ts
+++ b/webapp/src/modules/routing/types.ts
@@ -39,6 +39,7 @@ export type BrowseOptions = {
   view?: View
   vendor?: VendorName
   page?: number
+  skip?: number
   section?: string
   sortBy?: SortBy
   onlyOnSale?: boolean

--- a/webapp/src/modules/routing/types.ts
+++ b/webapp/src/modules/routing/types.ts
@@ -38,7 +38,6 @@ export type BrowseOptions = {
   assetType?: AssetType
   view?: View
   vendor?: VendorName
-  page?: number
   skip?: number
   section?: string
   sortBy?: SortBy

--- a/webapp/src/modules/ui/browse/reducer.ts
+++ b/webapp/src/modules/ui/browse/reducer.ts
@@ -59,7 +59,6 @@ export function browseReducer(
 ): BrowseUIState {
   switch (action.type) {
     case SET_VIEW: {
-      console.log('Setting view to ', action.payload.view)
       return {
         ...state,
         view: action.payload.view
@@ -160,14 +159,12 @@ export function browseReducer(
       }
 
     case UNPICK_ITEM_AS_FAVORITE_SUCCESS:
-      console.log('Reducing count', state.count)
       return {
         ...state,
         count: state.count !== undefined ? --state.count : state.count
       }
 
     case UNDO_UNPICKING_ITEM_AS_FAVORITE_SUCCESS:
-      console.log('Increasing count', state.count)
       return {
         ...state,
         count: state.count !== undefined ? ++state.count : state.count

--- a/webapp/src/modules/ui/browse/reducer.ts
+++ b/webapp/src/modules/ui/browse/reducer.ts
@@ -1,6 +1,10 @@
 import {
   FETCH_FAVORITED_ITEMS_SUCCESS,
-  FetchFavoritedItemsSuccessAction
+  FetchFavoritedItemsSuccessAction,
+  UNDO_UNPICKING_ITEM_AS_FAVORITE_SUCCESS,
+  UNPICK_ITEM_AS_FAVORITE_SUCCESS,
+  UndoUnpickingItemAsFavoriteSuccessAction,
+  UnpickItemAsFavoriteSuccessAction
 } from '../../favorites/actions'
 import {
   FetchItemsRequestAction,
@@ -46,6 +50,8 @@ type UIReducerAction =
   | FetchItemsRequestAction
   | FetchItemsSuccessAction
   | FetchFavoritedItemsSuccessAction
+  | UnpickItemAsFavoriteSuccessAction
+  | UndoUnpickingItemAsFavoriteSuccessAction
 
 export function browseReducer(
   state: BrowseUIState = INITIAL_STATE,
@@ -53,6 +59,7 @@ export function browseReducer(
 ): BrowseUIState {
   switch (action.type) {
     case SET_VIEW: {
+      console.log('Setting view to ', action.payload.view)
       return {
         ...state,
         view: action.payload.view
@@ -150,6 +157,20 @@ export function browseReducer(
       return {
         ...state,
         count: action.payload.total
+      }
+
+    case UNPICK_ITEM_AS_FAVORITE_SUCCESS:
+      console.log('Reducing count', state.count)
+      return {
+        ...state,
+        count: state.count !== undefined ? --state.count : state.count
+      }
+
+    case UNDO_UNPICKING_ITEM_AS_FAVORITE_SUCCESS:
+      console.log('Increasing count', state.count)
+      return {
+        ...state,
+        count: state.count !== undefined ? ++state.count : state.count
       }
 
     case FETCH_ITEMS_SUCCESS: {

--- a/webapp/src/modules/ui/browse/selector.spec.ts
+++ b/webapp/src/modules/ui/browse/selector.spec.ts
@@ -13,11 +13,13 @@ import {
 import { NFT } from '../../nft/types'
 import { RootState } from '../../reducer'
 import { CLAIM_ASSET_TRANSACTION_SUBMITTED } from '../../rental/actions'
+import { FavoritesData } from '../../favorites/types'
 import { View } from '../types'
 import { BrowseUIState } from './reducer'
 import {
   getCount,
   getItems,
+  getItemsPickedByUser,
   getNFTs,
   getOnRentNFTsByLessor,
   getOnRentNFTsByTenant,
@@ -193,6 +195,22 @@ describe('when getting the NFTs of the ui browse state', () => {
 describe('when getting the Items of the ui browse state', () => {
   it('should retrieve the Items of the ui browse state', () => {
     expect(getItems(rootState)).toStrictEqual([item, itemOnSale])
+  })
+})
+
+describe('when getting the user favorited items of the ui browse state', () => {
+  let favoritedItems: Record<string, FavoritesData>
+  beforeEach(() => {
+    favoritedItems = {
+      [item.id]: { pickedByUser: true, count: 1 },
+      [itemOnSale.id]: { pickedByUser: false, count: 4 }
+    }
+  })
+
+  it('should retrieve the items that were favorited by the user', () => {
+    expect(
+      getItemsPickedByUser.resultFunc(favoritedItems, [item, itemOnSale])
+    ).toEqual([item])
   })
 })
 

--- a/webapp/src/modules/ui/browse/selectors.ts
+++ b/webapp/src/modules/ui/browse/selectors.ts
@@ -23,8 +23,10 @@ import { ItemState } from '../../item/reducer'
 import { VendorName } from '../../vendor'
 import { getAddress, getWallet } from '../../wallet/selectors'
 import { getTransactionsByType } from '../../transaction/selectors'
+import { getFavoritedItems as getFavoritedItemsFromState } from '../../favorites/selectors'
 import { View } from '../types'
 import { OnRentNFT, OnSaleElement, OnSaleNFT } from './types'
+import { FavoritesData } from '../../favorites/types'
 
 export const getState = (state: RootState) => state.ui.browse
 export const getView = (state: RootState): View | undefined =>
@@ -47,6 +49,15 @@ export const getItems = createSelector<
   Item[]
 >(getState, getItemData, (browse, itemsById) =>
   browse.itemIds.map(id => itemsById[id])
+)
+
+export const getItemsPickedByUser = createSelector<
+  RootState,
+  Record<string, FavoritesData | undefined>,
+  Item[],
+  Item[]
+>(getFavoritedItemsFromState, getItems, (favoritedItems, items) =>
+  items.filter(item => favoritedItems[item.id]?.pickedByUser === true)
 )
 
 export const getOnSaleItems = createSelector<


### PR DESCRIPTION
This PR introduces the following:
- The capability to remove favorited items and make them disappear from the My Lists UI.
- The usage of skip instead of pages, which allows the removal of elements to not break the pagination.
- Simplifies the `AssetList` component so it receives assets instead of nfts or items.
