### PR TITLE
fix: Use page name instead of view

### DIFF
--- a/webapp/src/components/AssetCard/AssetCard.container.ts
+++ b/webapp/src/components/AssetCard/AssetCard.container.ts
@@ -5,19 +5,19 @@ import { RootState } from '../../modules/reducer'
 import { getData } from '../../modules/order/selectors'
 import { getActiveOrder } from '../../modules/order/utils'
 import { isClaimingBackLandTransactionPending } from '../../modules/ui/browse/selectors'
-import { getView } from '../../modules/ui/browse/selectors'
 import { getAssetPrice, isNFT } from '../../modules/asset/utils'
 import { locations } from '../../modules/routing/locations'
-import { View } from '../../modules/ui/types'
 import { getOpenRentalId } from '../../modules/rental/utils'
 import { getRentalById } from '../../modules/rental/selectors'
+import { getIsFavoritesEnabled } from '../../modules/features/selectors'
+import { getPageName } from '../../modules/routing/selectors'
 import { MapStateProps, OwnProps, MapDispatchProps } from './AssetCard.types'
 import AssetCard from './AssetCard'
-import { getIsFavoritesEnabled } from '../../modules/features/selectors'
+import { PageName } from '../../modules/routing/types'
 
 const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
   const { order, asset } = ownProps
-  const view = getView(state)
+  const pageName = getPageName(state)
   let price: string | null = null
 
   if (!order) {
@@ -33,16 +33,14 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
   return {
     price,
     showListedTag:
-      Boolean(view === View.CURRENT_ACCOUNT && price) &&
+      pageName === PageName.ACCOUNT &&
+      Boolean(price) &&
       getLocation(state).pathname !== locations.root(),
     isClaimingBackLandTransactionPending: isNFT(asset)
       ? isClaimingBackLandTransactionPending(state, asset)
       : false,
     rental: rentalOfNFT,
-    showRentalChip:
-      rentalOfNFT !== null &&
-      view === View.CURRENT_ACCOUNT &&
-      getLocation(state).pathname !== locations.root(),
+    showRentalChip: rentalOfNFT !== null && pageName === PageName.ACCOUNT,
     isFavoritesEnabled: getIsFavoritesEnabled(state)
   }
 }

--- a/webapp/src/components/AssetCard/AssetCard.container.ts
+++ b/webapp/src/components/AssetCard/AssetCard.container.ts
@@ -11,9 +11,9 @@ import { getOpenRentalId } from '../../modules/rental/utils'
 import { getRentalById } from '../../modules/rental/selectors'
 import { getIsFavoritesEnabled } from '../../modules/features/selectors'
 import { getPageName } from '../../modules/routing/selectors'
+import { PageName } from '../../modules/routing/types'
 import { MapStateProps, OwnProps, MapDispatchProps } from './AssetCard.types'
 import AssetCard from './AssetCard'
-import { PageName } from '../../modules/routing/types'
 
 const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
   const { order, asset } = ownProps

--- a/webapp/src/components/AssetList/AssetList.container.ts
+++ b/webapp/src/components/AssetList/AssetList.container.ts
@@ -8,7 +8,7 @@ import { browse, clearFilters } from '../../modules/routing/actions'
 import { getBrowseAssets, getCount } from '../../modules/ui/browse/selectors'
 import {
   getVendor,
-  getPage,
+  getPageNumber,
   getAssetType,
   getSection,
   getSearch,
@@ -26,7 +26,7 @@ import AssetList from './AssetList'
 
 const mapState = (state: RootState): MapStateProps => {
   const section = getSection(state)
-  const page = getPage(state)
+  const page = getPageNumber(state)
   const assetType = getAssetType(state)
 
   return {

--- a/webapp/src/components/CollectionList/CollectionList.container.ts
+++ b/webapp/src/components/CollectionList/CollectionList.container.ts
@@ -8,7 +8,11 @@ import {
 } from '../../modules/collection/selectors'
 import { RootState } from '../../modules/reducer'
 import { browse } from '../../modules/routing/actions'
-import { getPage, getSearch, getSortBy } from '../../modules/routing/selectors'
+import {
+  getPageNumber,
+  getSearch,
+  getSortBy
+} from '../../modules/routing/selectors'
 import CollectionList from './CollectionList'
 import {
   MapStateProps,
@@ -22,7 +26,7 @@ const mapState = (state: RootState): MapStateProps => ({
   isLoading: isLoadingType(getLoading(state), FETCH_COLLECTIONS_REQUEST),
   search: getSearch(state),
   sortBy: getSortBy(state),
-  page: getPage(state)
+  page: getPageNumber(state)
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({

--- a/webapp/src/components/Sales/Activity/Activity.container.ts
+++ b/webapp/src/components/Sales/Activity/Activity.container.ts
@@ -23,7 +23,7 @@ import { FETCH_NFT_REQUEST } from '../../../modules/nft/actions'
 import { MapStateProps, MapDispatchProps } from './Activity.types'
 import { browse } from '../../../modules/routing/actions'
 import { Dispatch } from 'redux'
-import { getPage } from '../../../modules/routing/selectors'
+import { getPageNumber } from '../../../modules/routing/selectors'
 import { Asset } from '../../../modules/asset/types'
 
 const getAssets = (
@@ -56,7 +56,7 @@ const mapState = (state: RootState): MapStateProps => {
   const count = getCount(state)
   const items = getItemsData(state)
   const nfts = getNftData(state)
-  const page = getPage(state)
+  const page = getPageNumber(state)
   const assets = getAssets(sales, items, nfts)
   const isLoading = getIsLoading(state)
 

--- a/webapp/src/components/Sales/Activity/Activity.container.ts
+++ b/webapp/src/components/Sales/Activity/Activity.container.ts
@@ -1,6 +1,7 @@
+import { Dispatch } from 'redux'
+import { connect } from 'react-redux'
 import { Item, Sale, SaleType } from '@dcl/schemas'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
-import { connect } from 'react-redux'
 import { NFT } from '../../../modules/nft/types'
 import { RootState } from '../../../modules/reducer'
 import {
@@ -16,15 +17,14 @@ import {
   getData as getNftData,
   getLoading as getNftLoading
 } from '../../../modules/nft/selectors'
-import Activity from './Activity'
 import { FETCH_SALES_REQUEST } from '../../../modules/sale/actions'
 import { FETCH_ITEM_REQUEST } from '../../../modules/item/actions'
 import { FETCH_NFT_REQUEST } from '../../../modules/nft/actions'
-import { MapStateProps, MapDispatchProps } from './Activity.types'
 import { browse } from '../../../modules/routing/actions'
-import { Dispatch } from 'redux'
 import { getPageNumber } from '../../../modules/routing/selectors'
 import { Asset } from '../../../modules/asset/types'
+import { MapStateProps, MapDispatchProps } from './Activity.types'
+import Activity from './Activity'
 
 const getAssets = (
   sales: Sale[],

--- a/webapp/src/modules/routing/locations.ts
+++ b/webapp/src/modules/routing/locations.ts
@@ -9,14 +9,15 @@ import { BrowseOptions } from './types'
 export const locations = {
   root: () => '/',
   signIn: (redirectTo?: string) => {
-    return `/sign-in${redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : ''}`
+    return `/sign-in${
+      redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : ''
+    }`
   },
   settings: () => '/settings',
   lands: (options?: BrowseOptions) => {
     const params = getSearchParams(options)
     return params ? `/lands?${params.toString()}` : '/lands'
   },
-  collectibles: () => '/collectibles',
   collection: (contractAddress: string = ':contractAddress') =>
     `/collections/${contractAddress}`,
   browse: (options?: BrowseOptions) => {

--- a/webapp/src/modules/routing/selectors.spec.ts
+++ b/webapp/src/modules/routing/selectors.spec.ts
@@ -8,7 +8,7 @@ import { AssetType } from '../asset/types'
 import { VendorName } from '../vendor'
 import { Section } from '../vendor/routing/types'
 import { View } from '../ui/types'
-import { Sections, SortBy } from './types'
+import { PageName, Sections, SortBy } from './types'
 import { locations } from './locations'
 import {
   getAssetType,
@@ -20,6 +20,7 @@ import {
   getMinPrice,
   getOnlyOnRent,
   getOnlySmart,
+  getPageName,
   getSection,
   getSortBy,
   getViewAsGuest,
@@ -530,6 +531,53 @@ describe('when getting if it should filter for guests', () => {
 
     it('should return undefined', () => {
       expect(getViewAsGuest.resultFunc(url)).toBe(undefined)
+    })
+  })
+})
+
+describe('when getting if the page name', () => {
+  describe('and the page is not one of the known ones', () => {
+    it('should throw an error', () => {
+      expect(() => getPageName.resultFunc('/unknown')).toThrowError(
+        'Unknown page'
+      )
+    })
+  })
+
+  describe.each([
+    ['/', PageName.HOME],
+    [locations.signIn(), PageName.SIGN_IN],
+    [locations.settings(), PageName.SETTINGS],
+    [locations.lands(), PageName.LANDS],
+    [locations.collection('anAddress'), PageName.COLLECTION],
+    [locations.browse(), PageName.BROWSE],
+    [locations.campaign(), PageName.CAMPAIGN],
+    [locations.currentAccount(), PageName.ACCOUNT],
+    [locations.list('aListId'), PageName.LIST],
+    [locations.lists(), PageName.LISTS],
+    [locations.account('anAddress'), PageName.ACCOUNTS],
+    [locations.nft('anAddress', 'anId'), PageName.NFT_DETAIL],
+    [locations.manage('anAddress', 'anId'), PageName.MANAGE_NFT],
+    [locations.item('anAddress', 'anId'), PageName.ITEM_DETAIL],
+    [locations.parcel('x', 'y'), PageName.PARCEL_DETAIL],
+    [locations.estate('anId'), PageName.ESTATE_DETAIL],
+    [locations.buy(AssetType.NFT, 'anAddress', 'anId'), PageName.BUY_NFT],
+    [locations.buy(AssetType.ITEM, 'anAddress', 'anId'), PageName.BUY_ITEM],
+    [
+      locations.buyStatusPage(AssetType.NFT, 'anAddress', 'anId'),
+      PageName.BUY_NFT_STATUS
+    ],
+    [
+      locations.buyStatusPage(AssetType.ITEM, 'anAddress', 'anId'),
+      PageName.BUY_ITEM_STATUS
+    ],
+    [locations.cancel('anAddress', 'anId'), PageName.CANCEL_NFT_SALE],
+    [locations.transfer('anAddress', 'anId'), PageName.TRANSFER_NFT],
+    [locations.bid('anAddress', 'anId'), PageName.BID_NFT],
+    [locations.activity(), PageName.ACTIVITY]
+  ])('and the current path is "%s"', (pathname, expectedName) => {
+    it(`should return the page name ${expectedName}`, () => {
+      expect(getPageName.resultFunc(pathname)).toBe(expectedName)
     })
   })
 })

--- a/webapp/src/modules/routing/selectors.ts
+++ b/webapp/src/modules/routing/selectors.ts
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect'
+import { matchPath } from 'react-router'
 import {
   getSearch as getRouterSearch,
   getLocation
@@ -25,7 +26,7 @@ import {
   getURLParam,
   getURLParamArray_nonStandard
 } from './search'
-import { BrowseOptions, SortBy } from './types'
+import { BrowseOptions, PageName, SortBy } from './types'
 import { locations } from './locations'
 
 export const getState = (state: RootState) => state.routing
@@ -77,7 +78,7 @@ export const getSection = createSelector<
   return section as Section
 })
 
-export const getPage = createSelector<RootState, string, number>(
+export const getPageNumber = createSelector<RootState, string, number>(
   getRouterSearch,
   search => {
     const page = getURLParam(search, 'page')
@@ -335,7 +336,7 @@ export const getCurrentLocationAddress = createSelector<
 )
 
 export const getPaginationUrlParams = createSelector(
-  getPage,
+  getPageNumber,
   getSortBy,
   getSearch,
   (page, sortBy, search) => ({ page, sortBy, search })
@@ -521,5 +522,79 @@ export const getIsBuyWithCardPage = createSelector<RootState, string, boolean>(
   search => {
     const withCard = getURLParam(search, 'withCard')
     return withCard !== null && withCard === 'true'
+  }
+)
+
+const buildExactMatchProps = (path: string) => {
+  return { path, exact: true }
+}
+
+export const getPageName = createSelector<RootState, string, PageName>(
+  getPathName,
+  pathname => {
+    if (pathname === '/') {
+      return PageName.HOME
+    } else if (
+      matchPath(
+        pathname,
+        buildExactMatchProps(locations.manage('anAddress', 'anId'))
+      )
+    ) {
+      return PageName.MANAGE_NFT
+    } else if (
+      matchPath(pathname, buildExactMatchProps(locations.buy(AssetType.NFT)))
+    ) {
+      return PageName.BUY_NFT
+    } else if (
+      matchPath(pathname, buildExactMatchProps(locations.buy(AssetType.ITEM)))
+    ) {
+      return PageName.BUY_ITEM
+    } else if (
+      matchPath(
+        pathname,
+        buildExactMatchProps(locations.buyStatusPage(AssetType.NFT))
+      )
+    ) {
+      return PageName.BUY_NFT_STATUS
+    } else if (matchPath(pathname, locations.buyStatusPage(AssetType.ITEM))) {
+      return PageName.BUY_ITEM_STATUS
+    } else if (matchPath(pathname, locations.cancel())) {
+      return PageName.CANCEL_NFT_SALE
+    } else if (matchPath(pathname, locations.transfer())) {
+      return PageName.TRANSFER_NFT
+    } else if (matchPath(pathname, locations.bid())) {
+      return PageName.BID_NFT
+    } else if (matchPath(pathname, locations.signIn())) {
+      return PageName.SIGN_IN
+    } else if (matchPath(pathname, locations.settings())) {
+      return PageName.SETTINGS
+    } else if (matchPath(pathname, locations.lands())) {
+      return PageName.LANDS
+    } else if (matchPath(pathname, locations.collection())) {
+      return PageName.COLLECTION
+    } else if (matchPath(pathname, locations.browse())) {
+      return PageName.BROWSE
+    } else if (matchPath(pathname, locations.campaign())) {
+      return PageName.CAMPAIGN
+    } else if (matchPath(pathname, locations.currentAccount())) {
+      return PageName.ACCOUNT
+    } else if (matchPath(pathname, locations.list())) {
+      return PageName.LIST
+    } else if (matchPath(pathname, locations.lists())) {
+      return PageName.LISTS
+    } else if (matchPath(pathname, locations.account())) {
+      return PageName.ACCOUNTS
+    } else if (matchPath(pathname, locations.nft())) {
+      return PageName.NFT_DETAIL
+    } else if (matchPath(pathname, locations.item())) {
+      return PageName.ITEM_DETAIL
+    } else if (matchPath(pathname, locations.parcel())) {
+      return PageName.PARCEL_DETAIL
+    } else if (matchPath(pathname, locations.estate())) {
+      return PageName.ESTATE_DETAIL
+    } else if (matchPath(pathname, locations.activity())) {
+      return PageName.ACTIVITY
+    }
+    throw new Error('Unknown page')
   }
 )

--- a/webapp/src/modules/routing/types.ts
+++ b/webapp/src/modules/routing/types.ts
@@ -67,3 +67,30 @@ export type BrowseOptions = {
   maxDistanceToPlaza?: string
   adjacentToRoad?: boolean
 }
+
+export enum PageName {
+  HOME,
+  SIGN_IN,
+  SETTINGS,
+  LANDS,
+  COLLECTION,
+  BROWSE,
+  CAMPAIGN,
+  ACCOUNT,
+  LISTS,
+  LIST,
+  ACCOUNTS,
+  NFT_DETAIL,
+  MANAGE_NFT,
+  ITEM_DETAIL,
+  PARCEL_DETAIL,
+  ESTATE_DETAIL,
+  BUY_NFT,
+  BUY_ITEM,
+  BUY_NFT_STATUS,
+  BUY_ITEM_STATUS,
+  CANCEL_NFT_SALE,
+  TRANSFER_NFT,
+  BID_NFT,
+  ACTIVITY
+}

--- a/webapp/src/modules/ui/browse/sagas.spec.ts
+++ b/webapp/src/modules/ui/browse/sagas.spec.ts
@@ -2,7 +2,7 @@ import { expectSaga } from 'redux-saga-test-plan'
 import { select } from 'redux-saga/effects'
 import { Item } from '@dcl/schemas'
 import { Section } from '../../vendor/decentraland/routing'
-import { getPage, getSection } from '../../routing/selectors'
+import { getPageNumber, getSection } from '../../routing/selectors'
 import {
   FETCH_FAVORITED_ITEMS_REQUEST,
   fetchFavoritedItemsRequest,
@@ -25,7 +25,7 @@ describe('when handling the success action of unpicking an item as favorite', ()
       return expectSaga(browseSaga)
         .provide([
           [select(getSection), section],
-          [select(getPage), 1],
+          [select(getPageNumber), 1],
           [select(getItemsPickedByUser), []],
           [select(getCount), 2]
         ])
@@ -51,7 +51,7 @@ describe('when handling the success action of unpicking an item as favorite', ()
         return expectSaga(browseSaga)
           .provide([
             [select(getSection), section],
-            [select(getPage), 1],
+            [select(getPageNumber), 1],
             [select(getItemsPickedByUser), pickedItems],
             [select(getCount), 2]
           ])
@@ -76,7 +76,7 @@ describe('when handling the success action of unpicking an item as favorite', ()
         return expectSaga(browseSaga)
           .provide([
             [select(getSection), section],
-            [select(getPage), 1],
+            [select(getPageNumber), 1],
             [select(getItemsPickedByUser), pickedItems],
             [select(getCount), 2]
           ])

--- a/webapp/src/modules/ui/browse/sagas.ts
+++ b/webapp/src/modules/ui/browse/sagas.ts
@@ -6,7 +6,7 @@ import {
   fetchFavoritedItemsRequest
 } from '../../favorites/actions'
 import { PAGE_SIZE } from '../../vendor/api'
-import { getPage, getSection } from '../../routing/selectors'
+import { getPageNumber, getSection } from '../../routing/selectors'
 import { View } from '../types'
 import { getCount, getItemsPickedByUser } from './selectors'
 
@@ -19,7 +19,7 @@ export function* browseSaga() {
 
 function* handleUnpickItemAsFavoriteSuccess() {
   const section: Section = yield select(getSection)
-  const page: number = yield select(getPage)
+  const page: number = yield select(getPageNumber)
   const favoritedAssets: Item[] = yield select(getItemsPickedByUser)
   const totalFavoritedAssets: number = yield select(getCount)
   if (


### PR DESCRIPTION
This PR introduces the `getPageName` selector which replaces the `getView` selector in cases where we want to know what the page the user is in.

Closes #1592 