### PR TITLE
fix: Incrase the content width of the toasts on all screens but mobile

### DIFF
--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -57,7 +57,7 @@ code {
   padding: 0;
 }
 
-@media only screen and (min-width: 1200px) {
+@media only screen and (min-width: 768px) {
   .dcl.toast .toast-info .body .list-flow-toast {
     width: 350px;
   }


### PR DESCRIPTION
Closes #1625 