### PR TITLE
feat: Force getting the identity for the favorites feature

### DIFF
--- a/webapp/src/components/AssetList/AssetList.tsx
+++ b/webapp/src/components/AssetList/AssetList.tsx
@@ -56,7 +56,9 @@ const AssetList = (props: Props) => {
   const maxQuerySize = getMaxQuerySize(vendor)
 
   const hasMorePages =
-    (assets.length !== count || count === maxQuerySize) && page <= MAX_PAGE
+    count !== undefined &&
+    (assets.length !== count || count === maxQuerySize) &&
+    page <= MAX_PAGE
 
   const emptyStateTranslationString = useMemo(() => {
     if (assets.length > 0) {

--- a/webapp/src/components/AssetList/AssetList.tsx
+++ b/webapp/src/components/AssetList/AssetList.tsx
@@ -56,9 +56,7 @@ const AssetList = (props: Props) => {
   const maxQuerySize = getMaxQuerySize(vendor)
 
   const hasMorePages =
-    count !== undefined &&
-    (assets.length !== count || count === maxQuerySize) &&
-    page <= MAX_PAGE
+    (assets.length !== count || count === maxQuerySize) && page <= MAX_PAGE
 
   const emptyStateTranslationString = useMemo(() => {
     if (assets.length > 0) {

--- a/webapp/src/modules/favorites/sagas.spec.ts
+++ b/webapp/src/modules/favorites/sagas.spec.ts
@@ -165,7 +165,7 @@ describe('when handling the request for unpicking a favorite item', () => {
     })
   })
 
-  describe('and the call to the favorites api fauks', () => {
+  describe('and the call to the favorites api fails', () => {
     it('should dispatch an action signaling the failure of the handled action', () => {
       return expectSaga(favoritesSaga, getIdentity)
         .provide([

--- a/webapp/src/modules/favorites/sagas.ts
+++ b/webapp/src/modules/favorites/sagas.ts
@@ -17,6 +17,7 @@ import {
   FavoritesAPI,
   MARKETPLACE_FAVORITES_SERVER_URL
 } from '../vendor/decentraland/favorites/api'
+import { getIdentity as getAccountIdentity } from '../identity/utils'
 import { retryParams } from '../vendor/decentraland/utils'
 import { getAddress } from '../wallet/selectors'
 import { ItemAPI } from '../vendor/decentraland/item/api'
@@ -104,7 +105,8 @@ export function* favoritesSaga(getIdentity: () => AuthIdentity | undefined) {
 
         if (success) yield put(closeModal('LoginModal'))
       }
-
+      // Force the user to have the signed identity
+      yield call(getAccountIdentity)
       yield call([favoritesAPI, 'pickItemAsFavorite'], item.id)
       yield put(pickItemAsFavoriteSuccess(item))
     } catch (error) {
@@ -117,6 +119,8 @@ export function* favoritesSaga(getIdentity: () => AuthIdentity | undefined) {
   ) {
     const { item } = action.payload
     try {
+      // Force the user to have the signed identity
+      yield call(getAccountIdentity)
       yield call([favoritesAPI, 'unpickItemAsFavorite'], item.id)
 
       yield put(unpickItemAsFavoriteSuccess(item))
@@ -130,6 +134,8 @@ export function* favoritesSaga(getIdentity: () => AuthIdentity | undefined) {
   ) {
     const { item } = action.payload
     try {
+      // Force the user to have the signed identity
+      yield call(getAccountIdentity)
       yield call([favoritesAPI, 'pickItemAsFavorite'], item.id)
 
       yield put(undoUnpickingItemAsFavoriteSuccess(item))
@@ -145,6 +151,9 @@ export function* favoritesSaga(getIdentity: () => AuthIdentity | undefined) {
   ) {
     const { filters } = action.payload.options
     try {
+      // Force the user to have the signed identity
+      yield call(getAccountIdentity)
+
       let items: Item[] = []
       const listId: string = yield select(getListId)
       const {


### PR DESCRIPTION
This PR mitigates the case where there's no identity loaded and the user wants to perform a favorites action.
Closes #1638