### PR TITLE
fix: Asset list changing positions when loading

### DIFF
--- a/webapp/src/components/AssetList/AssetList.css
+++ b/webapp/src/components/AssetList/AssetList.css
@@ -25,6 +25,12 @@
     left: 0;
     margin: auto;
   }
+
+  .transparentOverlay {
+    height: 100%;
+    width: 100%;
+    position: absolute;
+  }
 }
 
 @media (max-width: 767px) {

--- a/webapp/src/components/AssetList/AssetList.tsx
+++ b/webapp/src/components/AssetList/AssetList.tsx
@@ -52,8 +52,6 @@ const AssetList = (props: Props) => {
     },
     [onBrowse]
   )
-  console.log('Is loading', isLoading)
-
   const maxQuerySize = getMaxQuerySize(vendor)
 
   const hasMorePages =

--- a/webapp/src/components/AssetList/AssetList.tsx
+++ b/webapp/src/components/AssetList/AssetList.tsx
@@ -52,6 +52,7 @@ const AssetList = (props: Props) => {
     },
     [onBrowse]
   )
+  console.log('Is loading', isLoading)
 
   const maxQuerySize = getMaxQuerySize(vendor)
 
@@ -151,7 +152,9 @@ const AssetList = (props: Props) => {
       {isLoading ? (
         <>
           <div className="overlay" />
-          <Loader size="massive" active className="asset-loader" />
+          <div className="transparentOverlay">
+            <Loader size="massive" active className="asset-loader" />
+          </div>
         </>
       ) : null}
       <Card.Group>{assets.length > 0 ? renderAssetCards() : null}</Card.Group>


### PR DESCRIPTION
This PR fixes an issue where when loading a set of assets, the Assets would shift a bit down the page until. This was caused because the sticky position of the loader made the site take into consideration the height of it, making it grow although it was in other position.
As the loading is always paired with an overlay, this PR creates a new overlay that is transparent with absolute position where the loader can sit without increasing the size while being in the center.

Closes #1659