### PR TITLE
fix: not show on sale and rent land on asset view

### DIFF
--- a/webapp/src/components/AssetImage/AssetImage.tsx
+++ b/webapp/src/components/AssetImage/AssetImage.tsx
@@ -184,6 +184,9 @@ const AssetImage = (props: Props) => {
           withNavigation={withNavigation}
           selection={selection}
           zoom={zoom}
+          showForRent={false}
+          showOnSale={false}
+          showOwned={false}
         >
           {hasBadges && children}
         </Atlas>
@@ -201,6 +204,9 @@ const AssetImage = (props: Props) => {
           withNavigation={withNavigation}
           selection={estateSelection}
           zoom={zoom}
+          showForRent={false}
+          showOnSale={false}
+          showOwned={false}
           isEstate
         >
           {hasBadges && children}


### PR DESCRIPTION
### Before
<img width="287" alt="image" src="https://user-images.githubusercontent.com/11800206/236312565-74eee260-f512-4c00-9503-feb0b5c17e51.png">

### After
<img width="902" alt="image" src="https://user-images.githubusercontent.com/11800206/236312467-6c9596c4-3f78-43a4-8da7-a49be64e1610.png">
