### PR TITLE
feat: remove error toast on authorization modal

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -19,7 +19,7 @@
         "dcl-catalyst-commons": "^9.0.1",
         "decentraland-connect": "^3.3.2",
         "decentraland-crypto-fetch": "^1.0.3",
-        "decentraland-dapps": "^13.59.0",
+        "decentraland-dapps": "^13.61.2",
         "decentraland-transactions": "^1.43.1",
         "decentraland-ui": "^3.102.0",
         "dotenv": "^10.0.0",
@@ -8960,9 +8960,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "13.59.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.59.0.tgz",
-      "integrity": "sha512-GKQRZ24RSq8b3smBOQFE/CS/xrWFxJ4xkLE/EmvTo069Edq8xx7xgeM3I4hvcfHFGE9423SCEoeztlO0e31DHQ==",
+      "version": "13.62.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.62.0.tgz",
+      "integrity": "sha512-zTBlaNBCxSXafakjt/AiNM6BetAQe06kQYFmRVqIjuQjlKZeL3u5pGP7f5vU3yZbem2r880p1onfZ1eoN0Krmw==",
       "dependencies": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
@@ -8977,7 +8977,7 @@
         "decentraland-connect": "^3.5.0",
         "decentraland-crypto-fetch": "^1.0.3",
         "decentraland-transactions": "^1.44.0",
-        "decentraland-ui": "^3.103.1",
+        "decentraland-ui": "^3.103.5",
         "ethers": "^5.6.8",
         "events": "^3.3.0",
         "flat": "^5.0.2",
@@ -9073,9 +9073,9 @@
       "integrity": "sha512-4h5wMP8S0QcYviJ88quKnqfVoV+QVVNlsgcZK1o5XOIkSOt9Na0ZvP2twT4s/PG5JZi5yIABHeKmw1gM7CuDwg=="
     },
     "node_modules/decentraland-ui": {
-      "version": "3.103.1",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.103.1.tgz",
-      "integrity": "sha512-KszxZIMjRAffmn1ipDH0WxraM90sWOvNlyzM8gCxS8A1XOpUCU5cTi3qcPjsriXx5ispq1l3hzUT9UMhCr8ZIQ==",
+      "version": "3.103.5",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.103.5.tgz",
+      "integrity": "sha512-I7NhlcTVTa5GsfVVe8zgNBiRkYAjG/E3VuaaqKpJSF5d3ir4oyrJ+8okJ5Gr3c+ZX6CMIgCSzZnjwxqv/+mX7A==",
       "dependencies": {
         "@dcl/schemas": "^6.10.0",
         "balloon-css": "^0.5.0",
@@ -32482,9 +32482,9 @@
       }
     },
     "decentraland-dapps": {
-      "version": "13.59.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.59.0.tgz",
-      "integrity": "sha512-GKQRZ24RSq8b3smBOQFE/CS/xrWFxJ4xkLE/EmvTo069Edq8xx7xgeM3I4hvcfHFGE9423SCEoeztlO0e31DHQ==",
+      "version": "13.62.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-13.62.0.tgz",
+      "integrity": "sha512-zTBlaNBCxSXafakjt/AiNM6BetAQe06kQYFmRVqIjuQjlKZeL3u5pGP7f5vU3yZbem2r880p1onfZ1eoN0Krmw==",
       "requires": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
@@ -32499,7 +32499,7 @@
         "decentraland-connect": "^3.5.0",
         "decentraland-crypto-fetch": "^1.0.3",
         "decentraland-transactions": "^1.44.0",
-        "decentraland-ui": "^3.103.1",
+        "decentraland-ui": "^3.103.5",
         "ethers": "^5.6.8",
         "events": "^3.3.0",
         "flat": "^5.0.2",
@@ -32565,9 +32565,9 @@
       "integrity": "sha512-4h5wMP8S0QcYviJ88quKnqfVoV+QVVNlsgcZK1o5XOIkSOt9Na0ZvP2twT4s/PG5JZi5yIABHeKmw1gM7CuDwg=="
     },
     "decentraland-ui": {
-      "version": "3.103.1",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.103.1.tgz",
-      "integrity": "sha512-KszxZIMjRAffmn1ipDH0WxraM90sWOvNlyzM8gCxS8A1XOpUCU5cTi3qcPjsriXx5ispq1l3hzUT9UMhCr8ZIQ==",
+      "version": "3.103.5",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-3.103.5.tgz",
+      "integrity": "sha512-I7NhlcTVTa5GsfVVe8zgNBiRkYAjG/E3VuaaqKpJSF5d3ir4oyrJ+8okJ5Gr3c+ZX6CMIgCSzZnjwxqv/+mX7A==",
       "requires": {
         "@dcl/schemas": "^6.10.0",
         "balloon-css": "^0.5.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -13,7 +13,7 @@
     "dcl-catalyst-commons": "^9.0.1",
     "decentraland-connect": "^3.3.2",
     "decentraland-crypto-fetch": "^1.0.3",
-    "decentraland-dapps": "^13.59.0",
+    "decentraland-dapps": "^13.61.2",
     "decentraland-transactions": "^1.43.1",
     "decentraland-ui": "^3.102.0",
     "dotenv": "^10.0.0",

--- a/webapp/src/components/BuyPage/BuyNFTModal/BuyNFTModal.containter.ts
+++ b/webapp/src/components/BuyPage/BuyNFTModal/BuyNFTModal.containter.ts
@@ -32,8 +32,8 @@ const mapState = (state: RootState): MapStateProps => ({
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
-  onExecuteOrder: (order, nft, fingerprint) =>
-    dispatch(executeOrderRequest(order, nft, fingerprint)),
+  onExecuteOrder: (order, nft, fingerprint, silent) =>
+    dispatch(executeOrderRequest(order, nft, fingerprint, silent)),
   onExecuteOrderWithCard: nft => dispatch(executeOrderWithCardRequest(nft))
 })
 

--- a/webapp/src/components/BuyPage/BuyNFTModal/BuyNFTModal.tsx
+++ b/webapp/src/components/BuyPage/BuyNFTModal/BuyNFTModal.tsx
@@ -50,13 +50,13 @@ const BuyNFTModal = (props: Props) => {
   const [fingerprint, isFingerprintLoading] = useFingerprint(nft)
   const analytics = getAnalytics()
 
-  const handleExecuteOrder = useCallback(() => {
+  const handleExecuteOrder = useCallback((alreadyAuthorized: boolean = true) => {
     if (isBuyWithCardPage) {
       analytics.track(events.CLICK_BUY_NFT_WITH_CARD)
       return onExecuteOrderWithCard(nft)
     }
 
-    onExecuteOrder(order!, nft, fingerprint)
+    onExecuteOrder(order!, nft, fingerprint, !alreadyAuthorized)
   }, [
     isBuyWithCardPage,
     onExecuteOrderWithCard,

--- a/webapp/src/modules/order/actions.ts
+++ b/webapp/src/modules/order/actions.ts
@@ -62,8 +62,9 @@ export const EXECUTE_ORDER_TRANSACTION_SUBMITTED =
 export const executeOrderRequest = (
   order: Order,
   nft: NFT,
-  fingerprint?: string
-) => action(EXECUTE_ORDER_REQUEST, { order, nft, fingerprint })
+  fingerprint?: string,
+  silent?: boolean
+) => action(EXECUTE_ORDER_REQUEST, { order, nft, fingerprint, silent })
 export const executeOrderTransactionSubmitted = (
   order: Order,
   nft: NFT,
@@ -85,8 +86,9 @@ export const executeOrderFailure = (
   order: Order,
   nft: NFT,
   error: string,
-  errorCode?: ErrorCode
-) => action(EXECUTE_ORDER_FAILURE, { order, nft, error, errorCode })
+  errorCode?: ErrorCode,
+  silent?: boolean
+) => action(EXECUTE_ORDER_FAILURE, { order, nft, error, errorCode, silent })
 
 export type ExecuteOrderRequestAction = ReturnType<typeof executeOrderRequest>
 export type ExecuteOrderSuccessAction = ReturnType<typeof executeOrderSuccess>

--- a/webapp/src/modules/order/sagas.ts
+++ b/webapp/src/modules/order/sagas.ts
@@ -88,7 +88,7 @@ function* handleCreateOrderRequest(action: CreateOrderRequestAction) {
 }
 
 function* handleExecuteOrderRequest(action: ExecuteOrderRequestAction) {
-  const { order, nft, fingerprint } = action.payload
+  const { order, nft, fingerprint, silent } = action.payload
 
   try {
     if (
@@ -136,7 +136,7 @@ function* handleExecuteOrderRequest(action: ExecuteOrderRequestAction) {
         ? (error as { code: ErrorCode }).code
         : undefined
 
-    yield put(executeOrderFailure(order, nft, errorMessage, errorCode))
+    yield put(executeOrderFailure(order, nft, errorMessage, errorCode, silent))
   }
 }
 

--- a/webapp/src/modules/toast/sagas.ts
+++ b/webapp/src/modules/toast/sagas.ts
@@ -18,7 +18,8 @@ import {
 } from '../item/actions'
 import {
   EXECUTE_ORDER_WITH_CARD_FAILURE,
-  EXECUTE_ORDER_FAILURE
+  EXECUTE_ORDER_FAILURE,
+  ExecuteOrderFailureAction
 } from '../order/actions'
 import {
   getBuyNFTWithCardErrorToast,
@@ -121,8 +122,11 @@ function* handleBuyNFTWithCardFailure() {
   yield put(showToast(getBuyNFTWithCardErrorToast(), 'bottom center'))
 }
 
-function* handleExcecuteOrderFailure() {
-  yield put(showToast(getExcecuteOrderFailureToast(), 'bottom center'))
+function* handleExcecuteOrderFailure(action: ExecuteOrderFailureAction) {
+  const { silent } = action.payload
+  if (!silent) {
+    yield put(showToast(getExcecuteOrderFailureToast(), 'bottom center'))
+  }
 }
 
 function* handlePickItemAsFavoriteSuccess(

--- a/webapp/src/modules/toast/toasts.tsx
+++ b/webapp/src/modules/toast/toasts.tsx
@@ -124,7 +124,8 @@ export function getExcecuteOrderFailureToast(): Omit<Toast, 'id'> {
         })}
       </p>
     ),
-    icon: <Icon size="big" name="exclamation circle" />
+    icon: <Icon size="big" name="exclamation circle" />,
+    closable: true
   }
 }
 


### PR DESCRIPTION
Add new param `silent` in `executeOrderRequest` saga so that it doesn't show a toast if transaction fails. We are using this as true only when the action was triggered by the authorization modal, as we are already showing the error in the modal so there is no need to show also the toast