### PR TITLE
fix: do not fetch assets if they are in the store

### DIFF
--- a/webapp/src/components/AssetBrowse/AssetBrowse.tsx
+++ b/webapp/src/components/AssetBrowse/AssetBrowse.tsx
@@ -56,11 +56,11 @@ const AssetBrowse = (props: Props) => {
   const location = useLocation()
   const history = useHistory()
   // Prevent fetching more than once while browsing
-  const latestLocation = visitedLocations[visitedLocations.length - 2]
+  const lastLocation = visitedLocations[visitedLocations.length - 2]
   const [hasFetched, setHasFetched] = useState(
     history.action === 'POP' &&
-      latestLocation?.pathname === location.pathname &&
-      latestLocation?.search === location.search
+      lastLocation?.pathname === location.pathname &&
+      lastLocation?.search === location.search
   )
   const isCurrentAccount = view === View.CURRENT_ACCOUNT
   const isAccountOrCurrentAccount = view === View.ACCOUNT || isCurrentAccount

--- a/webapp/src/components/AssetBrowse/AssetBrowse.tsx
+++ b/webapp/src/components/AssetBrowse/AssetBrowse.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useEffect, useState } from 'react'
-import { matchPath } from 'react-router-dom'
+import { matchPath, useHistory, useLocation } from 'react-router-dom'
 import classNames from 'classnames'
 import { Container, Mobile, NotMobile, Page, Tabs } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
@@ -53,8 +53,15 @@ const AssetBrowse = (props: Props) => {
     isMapViewFiltersEnabled
   } = props
 
+  const location = useLocation()
+  const history = useHistory()
   // Prevent fetching more than once while browsing
-  const [hasFetched, setHasFetched] = useState(false)
+  const latestLocation = visitedLocations[visitedLocations.length - 2]
+  const [hasFetched, setHasFetched] = useState(
+    history.action === 'POP' &&
+      latestLocation?.pathname === location.pathname &&
+      latestLocation?.search === location.search
+  )
   const isCurrentAccount = view === View.CURRENT_ACCOUNT
   const isAccountOrCurrentAccount = view === View.ACCOUNT || isCurrentAccount
   const [showOwnedLandOnMap, setShowOwnedLandOnMap] = useState(true)

--- a/webapp/src/components/AssetList/AssetList.tsx
+++ b/webapp/src/components/AssetList/AssetList.tsx
@@ -45,7 +45,7 @@ const AssetList = (props: Props) => {
     }
     // only run effect on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [assets])
+  }, [])
 
   const handleLoadMore = useCallback(
     newPage => {

--- a/webapp/src/components/AssetList/AssetList.tsx
+++ b/webapp/src/components/AssetList/AssetList.tsx
@@ -45,7 +45,7 @@ const AssetList = (props: Props) => {
     }
     // only run effect on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [assets])
 
   const handleLoadMore = useCallback(
     newPage => {

--- a/webapp/src/components/CollectionProvider/CollectionProvider.container.ts
+++ b/webapp/src/components/CollectionProvider/CollectionProvider.container.ts
@@ -12,7 +12,7 @@ import {
   isFetchingCollection,
   getError as getCollectionError
 } from '../../modules/collection/selectors'
-import { fetchItemsRequest } from '../../modules/item/actions'
+import { fetchCollectionItemsRequest } from '../../modules/item/actions'
 import {
   getItemsByContractAddress,
   isFetchingItemsOfCollection
@@ -46,11 +46,9 @@ const mapDispatch = (
     dispatch(fetchSingleCollectionRequest(contractAddress)),
   onFetchCollectionItems: (collection: Collection) =>
     dispatch(
-      fetchItemsRequest({
-        filters: {
-          first: collection.size,
-          contractAddresses: [collection.contractAddress]
-        }
+      fetchCollectionItemsRequest({
+        first: collection.size,
+        contractAddresses: [collection.contractAddress]
       })
     )
 })

--- a/webapp/src/modules/collection/sagas.spec.ts
+++ b/webapp/src/modules/collection/sagas.spec.ts
@@ -1,7 +1,7 @@
 import { select } from '@redux-saga/core/effects'
 import { expectSaga } from 'redux-saga-test-plan'
 import { call } from 'redux-saga-test-plan/matchers'
-import { fetchItemsRequest } from '../item/actions'
+import { fetchCollectionItemsRequest } from '../item/actions'
 import { getItemsByContractAddress } from '../item/selectors'
 import { collectionAPI } from '../vendor/decentraland'
 import {
@@ -52,7 +52,7 @@ describe('when handling a fetch collections request', () => {
     })
   })
   describe('when should fetch items argument is true', () => {
-    it('should put a fetch items request action for each collection', () => {
+    it('should put a fetch collection items request action for each collection', () => {
       const filters = {}
       const contractAddress1 = 'contract address 1'
       const contractAddress2 = 'contract address 2'
@@ -94,14 +94,16 @@ describe('when handling a fetch collections request', () => {
           .put(fetchCollectionsSuccess(collections as any, 100))
           // Fetches items for contract address 2 because sizes are different
           .put(
-            fetchItemsRequest({
-              filters: { contractAddresses: [contractAddress2], first: size }
+            fetchCollectionItemsRequest({
+              contractAddresses: [contractAddress2],
+              first: size
             })
           )
           // Fetches items for contract address 3 because there are no items for that collection stored
           .put(
-            fetchItemsRequest({
-              filters: { contractAddresses: [contractAddress3], first: size }
+            fetchCollectionItemsRequest({
+              contractAddresses: [contractAddress3],
+              first: size
             })
           )
           .dispatch(fetchCollectionsRequest(filters, true))

--- a/webapp/src/modules/collection/sagas.ts
+++ b/webapp/src/modules/collection/sagas.ts
@@ -1,7 +1,7 @@
 import { call, takeEvery, put, select } from '@redux-saga/core/effects'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { isErrorWithMessage } from '../../lib/error'
-import { fetchItemsRequest } from '../item/actions'
+import { fetchCollectionItemsRequest } from '../item/actions'
 import { getItemsByContractAddress } from '../item/selectors'
 import { collectionAPI } from '../vendor/decentraland'
 import { CollectionResponse } from '../vendor/decentraland/collection/types'
@@ -47,11 +47,9 @@ export function* handleFetchCollectionsRequest(
 
         if (!items || items.length !== collection.size) {
           yield put(
-            fetchItemsRequest({
-              filters: {
-                first: collection.size,
-                contractAddresses: [collection.contractAddress]
-              }
+            fetchCollectionItemsRequest({
+              first: collection.size,
+              contractAddresses: [collection.contractAddress]
             })
           )
         }
@@ -97,11 +95,9 @@ export function* handleFetchSingleCollectionRequest(
 
       if (!items || items.length !== collection.size) {
         yield put(
-          fetchItemsRequest({
-            filters: {
-              first: collection.size,
-              contractAddresses: [collection.contractAddress]
-            }
+          fetchCollectionItemsRequest({
+            first: collection.size,
+            contractAddresses: [collection.contractAddress]
           })
         )
       }

--- a/webapp/src/modules/item/actions.spec.ts
+++ b/webapp/src/modules/item/actions.spec.ts
@@ -32,7 +32,13 @@ import {
   FETCH_ITEMS_FAILURE,
   FETCH_ITEMS_REQUEST,
   FETCH_ITEMS_SUCCESS,
-  FETCH_TRENDING_ITEMS_REQUEST
+  FETCH_TRENDING_ITEMS_REQUEST,
+  fetchCollectionItemsRequest,
+  FETCH_COLLECTION_ITEMS_REQUEST,
+  fetchCollectionItemsSuccess,
+  FETCH_COLLECTION_ITEMS_SUCCESS,
+  fetchCollectionItemsFailure,
+  FETCH_COLLECTION_ITEMS_FAILURE
 } from './actions'
 
 const itemBrowseOptions = {
@@ -197,6 +203,39 @@ describe('when creating the action to fetch the trending items request', () => {
       type: FETCH_TRENDING_ITEMS_REQUEST,
       meta: undefined,
       payload: { size }
+    })
+  })
+})
+
+describe('when creating the action to signal the start of the collection items request', () => {
+  let first: number
+  let contractAddresses: string[]
+  it('should return an object representing the action', () => {
+    expect(fetchCollectionItemsRequest({ first, contractAddresses })).toEqual({
+      type: FETCH_COLLECTION_ITEMS_REQUEST,
+      meta: undefined,
+      payload: { first, contractAddresses }
+    })
+  })
+})
+
+describe('when creating the action to signal a success in the collection items request', () => {
+  const items = [{} as Item]
+  it('should return an object representing the action', () => {
+    expect(fetchCollectionItemsSuccess(items)).toEqual({
+      type: FETCH_COLLECTION_ITEMS_SUCCESS,
+      meta: undefined,
+      payload: { items }
+    })
+  })
+})
+
+describe('when creating the action to signal a failure in the collection items request', () => {
+  it('should return an object representing the action', () => {
+    expect(fetchCollectionItemsFailure(anErrorMessage)).toEqual({
+      type: FETCH_COLLECTION_ITEMS_FAILURE,
+      meta: undefined,
+      payload: { error: anErrorMessage }
     })
   })
 })

--- a/webapp/src/modules/item/actions.ts
+++ b/webapp/src/modules/item/actions.ts
@@ -1,4 +1,4 @@
-import { ChainId, Item } from '@dcl/schemas'
+import { ChainId, Item, ItemFilters } from '@dcl/schemas'
 import { NFTPurchase } from 'decentraland-dapps/dist/modules/gateway/types'
 import {
   buildTransactionPayload,
@@ -55,6 +55,32 @@ export type FetchTrendingItemsSuccessAction = ReturnType<
 >
 export type FetchTrendingItemsFailureAction = ReturnType<
   typeof fetchTrendingItemsFailure
+>
+
+// Fetch Collection Items
+
+export const FETCH_COLLECTION_ITEMS_REQUEST = '[Request] Fetch Collection Items'
+export const FETCH_COLLECTION_ITEMS_SUCCESS = '[Success] Fetch Collection Items'
+export const FETCH_COLLECTION_ITEMS_FAILURE = '[Failure] Fetch Collection Items'
+
+export const fetchCollectionItemsRequest = (
+  options: Pick<ItemFilters, 'first' | 'contractAddresses'>
+) => action(FETCH_COLLECTION_ITEMS_REQUEST, options)
+
+export const fetchCollectionItemsSuccess = (items: Item[]) =>
+  action(FETCH_COLLECTION_ITEMS_SUCCESS, { items })
+
+export const fetchCollectionItemsFailure = (error: string) =>
+  action(FETCH_COLLECTION_ITEMS_FAILURE, { error })
+
+export type FetchCollectionItemsRequestAction = ReturnType<
+  typeof fetchCollectionItemsRequest
+>
+export type FetchCollectionItemsSuccessAction = ReturnType<
+  typeof fetchCollectionItemsSuccess
+>
+export type FetchCollectionItemsFailureAction = ReturnType<
+  typeof fetchCollectionItemsFailure
 >
 
 // Buy Item

--- a/webapp/src/modules/item/reducer.spec.ts
+++ b/webapp/src/modules/item/reducer.spec.ts
@@ -19,8 +19,12 @@ import {
   buyItemWithCardFailure,
   buyItemWithCardRequest,
   buyItemWithCardSuccess,
+  FETCH_COLLECTION_ITEMS_SUCCESS,
   FETCH_ITEM_SUCCESS,
   FETCH_TRENDING_ITEMS_SUCCESS,
+  fetchCollectionItemsFailure,
+  fetchCollectionItemsRequest,
+  fetchCollectionItemsSuccess,
   fetchItemFailure,
   fetchItemRequest,
   fetchItemsFailure,
@@ -79,6 +83,7 @@ const trendingItemsBatchSize = 20
 const requestActions = [
   fetchTrendingItemsRequest(trendingItemsBatchSize),
   fetchItemsRequest(itemBrowseOptions),
+  fetchCollectionItemsRequest({ contractAddresses: [], first: 10 }),
   fetchItemRequest(item.contractAddress, item.itemId),
   buyItemRequest(item),
   buyItemWithCardRequest(item),
@@ -114,6 +119,10 @@ const failureActions = [
   {
     request: fetchItemsRequest(itemBrowseOptions),
     failure: fetchItemsFailure(anErrorMessage, itemBrowseOptions)
+  },
+  {
+    request: fetchCollectionItemsRequest({ contractAddresses: [], first: 10 }),
+    failure: fetchCollectionItemsFailure(anErrorMessage)
   },
   {
     request: fetchItemRequest(item.contractAddress, item.itemId),
@@ -192,6 +201,11 @@ describe('when reducing the successful action of fetching items', () => {
 })
 
 describe.each([
+  [
+    FETCH_COLLECTION_ITEMS_SUCCESS,
+    fetchCollectionItemsRequest({ contractAddresses: [], first: 10 }),
+    fetchCollectionItemsSuccess([item])
+  ],
   [
     FETCH_ITEM_SUCCESS,
     fetchItemRequest(item.contractAddress, item.itemId),

--- a/webapp/src/modules/item/reducer.ts
+++ b/webapp/src/modules/item/reducer.ts
@@ -38,7 +38,13 @@ import {
   BuyItemWithCardFailureAction,
   BuyItemWithCardRequestAction,
   BuyItemWithCardSuccessAction,
-  BUY_ITEM_WITH_CARD_FAILURE
+  BUY_ITEM_WITH_CARD_FAILURE,
+  FETCH_COLLECTION_ITEMS_SUCCESS,
+  FetchCollectionItemsRequestAction,
+  FetchCollectionItemsSuccessAction,
+  FetchCollectionItemsFailureAction,
+  FETCH_COLLECTION_ITEMS_REQUEST,
+  FETCH_COLLECTION_ITEMS_FAILURE
 } from './actions'
 
 export type ItemState = {
@@ -70,6 +76,9 @@ type ItemReducerAction =
   | BuyItemWithCardRequestAction
   | BuyItemWithCardSuccessAction
   | BuyItemWithCardFailureAction
+  | FetchCollectionItemsRequestAction
+  | FetchCollectionItemsSuccessAction
+  | FetchCollectionItemsFailureAction
 
 export function itemReducer(
   state = INITIAL_STATE,
@@ -82,6 +91,7 @@ export function itemReducer(
     case BUY_ITEM_WITH_CARD_SUCCESS:
     case FETCH_ITEMS_REQUEST:
     case FETCH_TRENDING_ITEMS_REQUEST:
+    case FETCH_COLLECTION_ITEMS_REQUEST:
     case FETCH_ITEM_REQUEST: {
       return {
         ...state,
@@ -90,6 +100,7 @@ export function itemReducer(
     }
     case FETCH_TRENDING_ITEMS_SUCCESS:
     case FETCH_FAVORITED_ITEMS_SUCCESS:
+    case FETCH_COLLECTION_ITEMS_SUCCESS:
     case FETCH_ITEMS_SUCCESS: {
       const { items } = action.payload
       return {
@@ -122,6 +133,7 @@ export function itemReducer(
 
     case BUY_ITEM_FAILURE:
     case BUY_ITEM_WITH_CARD_FAILURE:
+    case FETCH_COLLECTION_ITEMS_FAILURE:
     case FETCH_ITEMS_FAILURE:
     case FETCH_TRENDING_ITEMS_FAILURE:
     case FETCH_ITEM_FAILURE: {

--- a/webapp/src/modules/item/sagas.spec.ts
+++ b/webapp/src/modules/item/sagas.spec.ts
@@ -37,7 +37,10 @@ import {
   buyItemWithCardRequest,
   buyItemWithCardFailure,
   buyItemWithCardSuccess,
-  FETCH_ITEM_FAILURE
+  FETCH_ITEM_FAILURE,
+  fetchCollectionItemsRequest,
+  fetchCollectionItemsSuccess,
+  fetchCollectionItemsFailure
 } from './actions'
 import { itemSaga } from './sagas'
 import { getData as getItems } from './selectors'
@@ -348,6 +351,40 @@ describe('when handling the set purchase action', () => {
             .run({ silenceTimeout: true })
         })
       })
+    })
+  })
+})
+
+describe('when handling the fetch collections items request action', () => {
+  describe('when the request is successful', () => {
+    const fetchResult = { data: [item] }
+
+    it('should dispatch a successful action with the fetched items', () => {
+      return expectSaga(itemSaga, getIdentity)
+        .provide([
+          [matchers.call.fn(CatalogAPI.prototype.get), fetchResult],
+          [matchers.call.fn(waitForWalletConnectionIfConnecting), undefined]
+        ])
+        .put(fetchCollectionItemsSuccess(fetchResult.data))
+        .dispatch(
+          fetchCollectionItemsRequest({ contractAddresses: [], first: 10 })
+        )
+        .run({ silenceTimeout: true })
+    })
+  })
+
+  describe('when the request fails', () => {
+    it('should dispatching a failing action with the error and the options', () => {
+      return expectSaga(itemSaga, getIdentity)
+        .provide([
+          [matchers.call.fn(CatalogAPI.prototype.get), Promise.reject(anError)],
+          [matchers.call.fn(waitForWalletConnectionIfConnecting), undefined]
+        ])
+        .put(fetchCollectionItemsFailure(anError.message))
+        .dispatch(
+          fetchCollectionItemsRequest({ contractAddresses: [], first: 10 })
+        )
+        .run({ silenceTimeout: true })
     })
   })
 })

--- a/webapp/src/modules/item/sagas.spec.ts
+++ b/webapp/src/modules/item/sagas.spec.ts
@@ -361,10 +361,7 @@ describe('when handling the fetch collections items request action', () => {
 
     it('should dispatch a successful action with the fetched items', () => {
       return expectSaga(itemSaga, getIdentity)
-        .provide([
-          [matchers.call.fn(CatalogAPI.prototype.get), fetchResult],
-          [matchers.call.fn(waitForWalletConnectionIfConnecting), undefined]
-        ])
+        .provide([[matchers.call.fn(ItemAPI.prototype.get), fetchResult]])
         .put(fetchCollectionItemsSuccess(fetchResult.data))
         .dispatch(
           fetchCollectionItemsRequest({ contractAddresses: [], first: 10 })
@@ -377,8 +374,7 @@ describe('when handling the fetch collections items request action', () => {
     it('should dispatching a failing action with the error and the options', () => {
       return expectSaga(itemSaga, getIdentity)
         .provide([
-          [matchers.call.fn(CatalogAPI.prototype.get), Promise.reject(anError)],
-          [matchers.call.fn(waitForWalletConnectionIfConnecting), undefined]
+          [matchers.call.fn(ItemAPI.prototype.get), Promise.reject(anError)]
         ])
         .put(fetchCollectionItemsFailure(anError.message))
         .dispatch(

--- a/webapp/src/modules/item/sagas.spec.ts
+++ b/webapp/src/modules/item/sagas.spec.ts
@@ -362,6 +362,10 @@ describe('when handling the fetch collections items request action', () => {
     it('should dispatch a successful action with the fetched items', () => {
       return expectSaga(itemSaga, getIdentity)
         .provide([[matchers.call.fn(ItemAPI.prototype.get), fetchResult]])
+        .call.like({
+          fn: ItemAPI.prototype.get,
+          args: [{ first: 10, contractAddresses: [] }]
+        })
         .put(fetchCollectionItemsSuccess(fetchResult.data))
         .dispatch(
           fetchCollectionItemsRequest({ contractAddresses: [], first: 10 })
@@ -371,7 +375,7 @@ describe('when handling the fetch collections items request action', () => {
   })
 
   describe('when the request fails', () => {
-    it('should dispatching a failing action with the error and the options', () => {
+    it('should dispatch a failing action with the error and the options', () => {
       return expectSaga(itemSaga, getIdentity)
         .provide([
           [matchers.call.fn(ItemAPI.prototype.get), Promise.reject(anError)]
@@ -421,7 +425,7 @@ describe('when handling the fetch items request action', () => {
   })
 
   describe('when the request fails', () => {
-    it('should dispatching a failing action with the error and the options', () => {
+    it('should dispatch a failing action with the error and the options', () => {
       return expectSaga(itemSaga, getIdentity)
         .provide([
           [matchers.call.fn(CatalogAPI.prototype.get), Promise.reject(anError)],

--- a/webapp/src/modules/item/sagas.ts
+++ b/webapp/src/modules/item/sagas.ts
@@ -45,7 +45,11 @@ import {
   FetchItemSuccessAction,
   FETCH_ITEM_FAILURE,
   FETCH_ITEM_SUCCESS,
-  fetchItemRequest
+  fetchItemRequest,
+  FetchCollectionItemsRequestAction,
+  fetchCollectionItemsSuccess,
+  fetchCollectionItemsFailure,
+  FETCH_COLLECTION_ITEMS_REQUEST
 } from './actions'
 import { getData as getItems } from './selectors'
 import { getItem } from './utils'
@@ -62,6 +66,10 @@ export function* itemSaga(getIdentity: () => AuthIdentity | undefined) {
   const catalogAPI = new CatalogAPI(NFT_SERVER_URL, API_OPTS)
 
   yield takeEvery(FETCH_ITEMS_REQUEST, handleFetchItemsRequest)
+  yield takeEvery(
+    FETCH_COLLECTION_ITEMS_REQUEST,
+    handleFetchCollectionItemsRequest
+  )
   yield takeEvery(FETCH_TRENDING_ITEMS_REQUEST, handleFetchTrendingItemsRequest)
   yield takeEvery(BUY_ITEM_REQUEST, handleBuyItem)
   yield takeEvery(BUY_ITEM_WITH_CARD_REQUEST, handleBuyItemWithCardRequest)
@@ -92,6 +100,25 @@ export function* itemSaga(getIdentity: () => AuthIdentity | undefined) {
     } catch (error) {
       yield put(
         fetchTrendingItemsFailure(
+          isErrorWithMessage(error) ? error.message : t('global.unknown_error')
+        )
+      )
+    }
+  }
+
+  function* handleFetchCollectionItemsRequest(
+    action: FetchCollectionItemsRequestAction
+  ) {
+    const { contractAddresses, first } = action.payload
+    try {
+      const { data }: { data: Item[]; total: number } = yield call(
+        [itemAPI, 'get'],
+        { first, contractAddresses }
+      )
+      yield put(fetchCollectionItemsSuccess(data))
+    } catch (error) {
+      yield put(
+        fetchCollectionItemsFailure(
           isErrorWithMessage(error) ? error.message : t('global.unknown_error')
         )
       )

--- a/webapp/src/modules/routing/sagas.spec.ts
+++ b/webapp/src/modules/routing/sagas.spec.ts
@@ -15,7 +15,6 @@ import {
 } from 'connected-react-router'
 import { expectSaga } from 'redux-saga-test-plan'
 import { call, select } from 'redux-saga/effects'
-import { locations } from './locations'
 import { AssetStatusFilter } from '../../utils/filters'
 import { AssetType } from '../asset/types'
 import { getData as getEventData } from '../event/selectors'
@@ -27,6 +26,7 @@ import { PAGE_SIZE } from '../vendor/api'
 import { View } from '../ui/types'
 import { VendorName } from '../vendor'
 import { Section } from '../vendor/decentraland'
+import { locations } from './locations'
 import {
   browse,
   clearFilters,
@@ -1160,7 +1160,32 @@ describe('when handling the location change action', () => {
     }
   })
   describe('and the location action is a POP, meaning going back', () => {
+    describe("and the current pathname doesn't match the browse", () => {
+      beforeEach(() => {
+        locationChangeAction.payload.location.pathname = 'anotherPathName'
+      })
+      it('should not call the fetchAssetFromRoute', () => {
+        return expectSaga(routingSaga)
+          .provide([
+            [
+              select(getLatestVisitedLocation),
+              {
+                pathname: locations.browse()
+              }
+            ],
+            [select(getCurrentBrowseOptions), browseOptions],
+            [select(getSection), Section.WEARABLES],
+            [select(getPage), 1]
+          ])
+          .not.put(fetchAssetsFromRouteAction(browseOptions))
+          .dispatch(locationChangeAction)
+          .run({ silenceTimeout: true })
+      })
+    })
     describe('and its coming from the browse', () => {
+      beforeEach(() => {
+        locationChangeAction.payload.location.pathname = locations.browse()
+      })
       it('should dispatch the fetchAssetFromRoute action', () => {
         return expectSaga(routingSaga)
           .provide([

--- a/webapp/src/modules/routing/sagas.ts
+++ b/webapp/src/modules/routing/sagas.ts
@@ -8,6 +8,7 @@ import {
   race,
   spawn
 } from 'redux-saga/effects'
+import { matchPath } from 'react-router-dom'
 import {
   push,
   getLocation,
@@ -43,7 +44,8 @@ import {
   getMaxPrice,
   getMinPrice,
   getStatus,
-  getEmotePlayMode
+  getEmotePlayMode,
+  getLatestVisitedLocation
 } from '../routing/selectors'
 import {
   fetchNFTRequest,
@@ -143,8 +145,16 @@ export function* routingSaga() {
 function* handleLocationChange(action: LocationChangeAction) {
   // Re-triggers fetchAssetsFromRoute action when the user goes back
   if (action.payload.action === 'POP') {
-    const options: BrowseOptions = yield select(getCurrentBrowseOptions)
-    yield put(fetchAssetsFromRouteAction(options))
+    const latestVisitedLocation: ReturnType<typeof getLocation> = yield select(
+      getLatestVisitedLocation
+    )
+    const isComingFromBrowse = !!matchPath(latestVisitedLocation?.pathname, {
+      path: locations.browse()
+    })
+    if (isComingFromBrowse) {
+      const options: BrowseOptions = yield select(getCurrentBrowseOptions)
+      yield put(fetchAssetsFromRouteAction(options))
+    }
   }
 }
 

--- a/webapp/src/modules/routing/sagas.ts
+++ b/webapp/src/modules/routing/sagas.ts
@@ -144,7 +144,10 @@ export function* routingSaga() {
 
 function* handleLocationChange(action: LocationChangeAction) {
   // Re-triggers fetchAssetsFromRoute action when the user goes back
-  if (action.payload.action === 'POP') {
+  if (
+    action.payload.action === 'POP' &&
+    matchPath(action.payload.location.pathname, { path: locations.browse() })
+  ) {
     const latestVisitedLocation: ReturnType<typeof getLocation> = yield select(
       getLatestVisitedLocation
     )

--- a/webapp/src/modules/routing/selectors.spec.ts
+++ b/webapp/src/modules/routing/selectors.spec.ts
@@ -40,7 +40,7 @@ describe('when getting the latest visited location', () => {
     })
   })
 
-  describe('and there is a previos location', () => {
+  describe('and there is a previous location', () => {
     let prevLocation: RouterLocation<unknown>
     beforeEach(() => {
       prevLocation = {

--- a/webapp/src/modules/routing/selectors.spec.ts
+++ b/webapp/src/modules/routing/selectors.spec.ts
@@ -1,3 +1,4 @@
+import { RouterLocation } from 'connected-react-router'
 import {
   EmotePlayMode,
   GenderFilterOption,
@@ -28,8 +29,34 @@ import {
   getViewAsGuest,
   getSortByOptions,
   getStatus,
-  hasFiltersEnabled
+  hasFiltersEnabled,
+  getLatestVisitedLocation
 } from './selectors'
+
+describe('when getting the latest visited location', () => {
+  describe('and there is no previous location', () => {
+    it('should return undefined', () => {
+      expect(getLatestVisitedLocation.resultFunc([])).toBe(undefined)
+    })
+  })
+
+  describe('and there is a previos location', () => {
+    let prevLocation: RouterLocation<unknown>
+    beforeEach(() => {
+      prevLocation = {
+        pathname: '/browse'
+      } as RouterLocation<unknown>
+    })
+    it('should return the location', () => {
+      expect(
+        getLatestVisitedLocation.resultFunc([
+          { ...prevLocation, pathname: 'an oldest location' },
+          prevLocation
+        ])
+      ).toBe(prevLocation)
+    })
+  })
+})
 
 describe('when getting if the are filters set', () => {
   describe('when the search filter is set', () => {

--- a/webapp/src/modules/routing/selectors.ts
+++ b/webapp/src/modules/routing/selectors.ts
@@ -36,6 +36,15 @@ export const getState = (state: RootState) => state.routing
 export const getVisitedLocations = (state: RootState) =>
   getState(state).visitedLocations
 
+export const getLatestVisitedLocation = createSelector<
+  RootState,
+  ReturnType<typeof getLocation>[],
+  ReturnType<typeof getLocation>
+>(
+  getVisitedLocations,
+  visitedLocations => visitedLocations[visitedLocations.length - 1]
+)
+
 const getPathName = createSelector<
   RootState,
   ReturnType<typeof getLocation>,

--- a/webapp/src/modules/ui/browse/reducer.spec.ts
+++ b/webapp/src/modules/ui/browse/reducer.spec.ts
@@ -35,14 +35,29 @@ describe('when reducing the action of setting a view', () => {
     page: 1
   }
 
-  it('should set the view and reset the state and empty the itemIds, nftIds, count and page', () => {
-    expect(browseReducer(initialState, setView(View.LISTS))).toEqual({
-      ...initialState,
-      view: View.LISTS,
-      itemIds: [],
-      nftIds: [],
-      count: undefined,
-      page: undefined
+  describe('and the payload view is the same as the state current one', () => {
+    it('should set the view and reset the state and empty the itemIds, nftIds, count and page', () => {
+      expect(browseReducer(initialState, setView(View.MARKET))).toEqual({
+        ...initialState,
+        view: View.MARKET,
+        itemIds: [],
+        nftIds: [],
+        count: undefined,
+        page: undefined
+      })
+    })
+  })
+
+  describe('and the payload view is different then the state current one', () => {
+    it('should set the view and reset the state and empty the itemIds, nftIds, count and page', () => {
+      expect(browseReducer(initialState, setView(View.LISTS))).toEqual({
+        ...initialState,
+        view: View.LISTS,
+        itemIds: [],
+        nftIds: [],
+        count: undefined,
+        page: undefined
+      })
     })
   })
 })

--- a/webapp/src/modules/ui/browse/reducer.spec.ts
+++ b/webapp/src/modules/ui/browse/reducer.spec.ts
@@ -36,15 +36,10 @@ describe('when reducing the action of setting a view', () => {
   }
 
   describe('and the payload view is the same as the state current one', () => {
-    it('should set the view and reset the state and empty the itemIds, nftIds, count and page', () => {
-      expect(browseReducer(initialState, setView(View.MARKET))).toEqual({
-        ...initialState,
-        view: View.MARKET,
-        itemIds: [],
-        nftIds: [],
-        count: undefined,
-        page: undefined
-      })
+    it('should return the same state', () => {
+      expect(browseReducer(initialState, setView(View.MARKET))).toEqual(
+        initialState
+      )
     })
   })
 

--- a/webapp/src/modules/ui/browse/reducer.ts
+++ b/webapp/src/modules/ui/browse/reducer.ts
@@ -71,6 +71,9 @@ export function browseReducer(
 ): BrowseUIState {
   switch (action.type) {
     case SET_VIEW: {
+      if (action.payload.view === state.view) {
+        return state
+      }
       return {
         ...state,
         view: action.payload.view,


### PR DESCRIPTION
Since the data is already in the store going back from the detail to the /browse again, we don't need to fetch it again. This PR avoids the re-fetch of the items.
The `fetchItemsRequest` is triggered in the detail page to get the collection items and it resets the `ui` state so I had to either:
- pass a flag to avoid reseting the `ui` state (so it doesn't fetch again the items)
- create a new action that doesn't override the `ui`. (fetching collection items for the detail shouldn't update the `ui`)