### PR TITLE
feat: add mechanism to fetch all ens that match the creator search

### DIFF
--- a/webapp/src/modules/account/utils.spec.ts
+++ b/webapp/src/modules/account/utils.spec.ts
@@ -1,3 +1,4 @@
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Account, Avatar, Profile } from '@dcl/schemas'
 import {
   enhanceCreatorName,
@@ -100,7 +101,9 @@ describe('when enhancing creator name', () => {
     })
     it('should enhance the name and add the profile name at the end', () => {
       enhanceCreatorName(creator, ens, search)
-      expect(creator.name).toEqual('aName (currently anotherName)')
+      expect(creator.name).toEqual(
+        `aName (${t('global.currently')} anotherName)`
+      )
     })
   })
   describe('when the creator name contains the search', () => {

--- a/webapp/src/modules/account/utils.spec.ts
+++ b/webapp/src/modules/account/utils.spec.ts
@@ -1,12 +1,12 @@
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Account, Avatar, Profile } from '@dcl/schemas'
+import { NFTResult } from '../vendor/decentraland'
 import {
   enhanceCreatorName,
   fromProfilesToCreators,
   sumAccountMetrics
 } from './utils'
 import { CreatorAccount } from './types'
-import { NFTResult } from '../vendor/decentraland'
 
 describe('when summing account metrics', () => {
   it('should return an account metric with its values added from the provided account metrics', () => {

--- a/webapp/src/modules/account/utils.spec.ts
+++ b/webapp/src/modules/account/utils.spec.ts
@@ -1,5 +1,11 @@
 import { Account, Avatar, Profile } from '@dcl/schemas'
-import { fromProfilesToCreators, sumAccountMetrics } from './utils'
+import {
+  enhanceCreatorName,
+  fromProfilesToCreators,
+  sumAccountMetrics
+} from './utils'
+import { CreatorAccount } from './types'
+import { NFTResult } from '../vendor/decentraland'
 
 describe('when summing account metrics', () => {
   it('should return an account metric with its values added from the provided account metrics', () => {
@@ -65,5 +71,42 @@ describe('when transforming profiles and accounts objects to creators entities',
         collections: collectionsAmount
       }
     ])
+  })
+})
+
+describe('when enhancing creator name', () => {
+  let creator: CreatorAccount
+  let ens: NFTResult[]
+  let search: string
+  beforeEach(() => {
+    creator = {
+      name: 'aName',
+      address: 'anAddress',
+      collections: 1
+    }
+    ens = [
+      {
+        nft: {
+          owner: creator.address,
+          name: 'aName'
+        }
+      } as NFTResult
+    ]
+    search = 'aName'
+  })
+  describe('when the creator name does not contain the search', () => {
+    beforeEach(() => {
+      creator.name = 'anotherName'
+    })
+    it('should enhance the name and add the profile name at the end', () => {
+      enhanceCreatorName(creator, ens, search)
+      expect(creator.name).toEqual('aName (currently anotherName)')
+    })
+  })
+  describe('when the creator name contains the search', () => {
+    it('should not change the creator name', () => {
+      enhanceCreatorName(creator, ens, search)
+      expect(creator.name).toEqual('aName')
+    })
   })
 })

--- a/webapp/src/modules/account/utils.ts
+++ b/webapp/src/modules/account/utils.ts
@@ -1,4 +1,5 @@
 import { Account, Profile } from '@dcl/schemas'
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { ethers } from 'ethers'
 import { NFTResult } from '../vendor/decentraland'
 import { AccountMetrics, CreatorAccount } from './types'
@@ -48,7 +49,9 @@ export function enhanceCreatorName(
         nft.nft.name.toLowerCase().includes(search.toLocaleLowerCase())
     )
     if (ensThatMatch) {
-      creator.name = `${ensThatMatch.nft.name} (currently ${creator.name})`
+      creator.name = `${ensThatMatch.nft.name} (${t('global.currently')} ${
+        creator.name
+      })`
     }
   }
 }

--- a/webapp/src/modules/account/utils.ts
+++ b/webapp/src/modules/account/utils.ts
@@ -1,5 +1,6 @@
 import { Account, Profile } from '@dcl/schemas'
 import { ethers } from 'ethers'
+import { NFTResult } from '../vendor/decentraland'
 import { AccountMetrics, CreatorAccount } from './types'
 
 export function sumAccountMetrics(a: AccountMetrics, b: AccountMetrics) {
@@ -33,4 +34,21 @@ export function fromProfilesToCreators(
         )?.collections || 0
     }))
     .filter(account => account.collections > 0)
+}
+
+export function enhanceCreatorName(
+  creator: CreatorAccount,
+  ens: NFTResult[],
+  search: string
+) {
+  if (!creator.name.toLocaleLowerCase().includes(search.toLocaleLowerCase())) {
+    const ensThatMatch = ens.find(
+      nft =>
+        nft.nft.owner === creator.address &&
+        nft.nft.name.toLowerCase().includes(search.toLocaleLowerCase())
+    )
+    if (ensThatMatch) {
+      creator.name = `${ensThatMatch.nft.name} (currently ${creator.name})`
+    }
+  }
 }

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -61,7 +61,8 @@
     "unknown_error": "Unknown error",
     "the_parcel": "the Parcel",
     "the_estate": "the Estate",
-    "discord_server": "Discord Server"
+    "discord_server": "Discord Server",
+    "currently": "currently"
   },
   "address": {
     "invalid_address": "That's not a valid address",

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -59,7 +59,8 @@
     "unknown_error": "Error desconocido",
     "the_parcel": "La Parcela",
     "the_estate": "El Estate",
-    "discord_server": "Servidor de Discord"
+    "discord_server": "Servidor de Discord",
+    "currently": "actualmente"
   },
   "address": {
     "invalid_address": "Dirección inválida",

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -59,7 +59,8 @@
     "unknown_error": "不明错误",
     "the_parcel": "地块",
     "the_estate": "产业",
-    "discord_server": "Discord 服务器"
+    "discord_server": "Discord 服务器",
+    "currently": "现在"
   },
   "address": {
     "invalid_address": "这不是一个有效的地址",


### PR DESCRIPTION
This PR also adds the label `$name (currently $actualName)`  in case there is a match of the ENS but they have another ENS set in their profile. Like the following image:
`kj` is the search term. There is a match with `rickJames` but in their profile they have `Jessie` now, so we need to clarify why `Jessie` is shown.

<img width="269" alt="image" src="https://github.com/decentraland/marketplace/assets/8763687/cadcc504-afe9-44c0-9127-0a5673101347">


Closes #1735 
