### PR TITLE
feat: refactor the BuyNFTButtons to accept asset fields instead of the entire object

### DIFF
--- a/webapp/src/components/AssetPage/BestBuyingOption/BestBuyingOption.tsx
+++ b/webapp/src/components/AssetPage/BestBuyingOption/BestBuyingOption.tsx
@@ -24,6 +24,7 @@ import noListings from '../../../images/noListings.png'
 import Mana from '../../Mana/Mana'
 import { ManaToFiat } from '../../ManaToFiat'
 import { formatWeiToAssetCard } from '../../AssetCard/utils'
+import { AssetType } from '../../../modules/asset/types'
 import { BuyNFTButtons } from '../SaleActionBox/BuyNFTButtons'
 import { ItemSaleActions } from '../SaleActionBox/ItemSaleActions'
 import { BuyOptions, Props } from './BestBuyingOption.types'
@@ -51,6 +52,7 @@ const BestBuyingOption = ({ asset, tableRef }: Props) => {
   }
 
   useEffect(() => {
+    let cancel = false
     if (asset && !isNFT(asset)) {
       if (asset.available > 0 && asset.isOnSale) {
         setBuyOption(BuyOptions.MINT)
@@ -75,6 +77,7 @@ const BestBuyingOption = ({ asset, tableRef }: Props) => {
           .fetchOrders(params, sortBy)
           .then(response => {
             if (response.data.length > 0) {
+              if (cancel) return
               setBuyOption(BuyOptions.BUY_LISTING)
               setListing({ order: response.data[0], total: response.total })
               bidAPI
@@ -86,19 +89,23 @@ const BestBuyingOption = ({ asset, tableRef }: Props) => {
                   '1'
                 )
                 .then(response => {
+                  if (cancel) return
                   setMostExpensiveBid(response.data[0])
                 })
-                .finally(() => setIsLoading(false))
+                .finally(() => !cancel && setIsLoading(false))
                 .catch(error => {
                   console.error(error)
                 })
             }
           })
-          .finally(() => setIsLoading(false))
+          .finally(() => !cancel && setIsLoading(false))
           .catch(error => {
             console.error(error)
           })
       }
+    }
+    return () => {
+      cancel = true
     }
   }, [asset])
 
@@ -264,7 +271,10 @@ const BestBuyingOption = ({ asset, tableRef }: Props) => {
             </div>
           </div>
           <BuyNFTButtons
-            asset={asset}
+            assetType={AssetType.NFT}
+            contractAddress={asset.contractAddress}
+            network={asset.network}
+            tokenId={listing.order.tokenId}
             buyWithCardClassName={styles.buyWithCardClassName}
           />
           <Button

--- a/webapp/src/components/AssetPage/BuyNFTBox/BuyNFTBox.tsx
+++ b/webapp/src/components/AssetPage/BuyNFTBox/BuyNFTBox.tsx
@@ -9,6 +9,7 @@ import clock from '../../../images/clock.png'
 import makeOffer from '../../../images/makeOffer.png'
 import { locations } from '../../../modules/routing/locations'
 import { bidAPI, orderAPI } from '../../../modules/vendor/decentraland'
+import { AssetType } from '../../../modules/asset/types'
 import { ManaToFiat } from '../../ManaToFiat'
 import { formatWeiToAssetCard } from '../../AssetCard/utils'
 import { BuyNFTButtons } from '../SaleActionBox/BuyNFTButtons'
@@ -116,7 +117,10 @@ const BuyNFTBox = ({ nft, address }: Props) => {
             </div>
           </div>
           <BuyNFTButtons
-            asset={nft}
+            assetType={AssetType.NFT}
+            contractAddress={nft.contractAddress}
+            network={nft.network}
+            tokenId={nft.tokenId}
             buyWithCardClassName={styles.buyWithCardClassName}
           />
           {canBid && (

--- a/webapp/src/components/AssetPage/SaleActionBox/BuyNFTButtons/BuyNFTButtons.tsx
+++ b/webapp/src/components/AssetPage/SaleActionBox/BuyNFTButtons/BuyNFTButtons.tsx
@@ -4,17 +4,20 @@ import { Button, Icon, Mana } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
 
-import { AssetType } from '../../../../modules/asset/types'
-import { isNFT } from '../../../../modules/asset/utils'
 import { locations } from '../../../../modules/routing/locations'
 import * as events from '../../../../utils/events'
 import styles from './BuyNFTButtons.module.css'
 import { Props } from './BuyNFTButtons.types'
 
-const BuyNFTButtons = ({ asset, buyWithCardClassName }: Props) => {
-  const { contractAddress, network } = asset
-  const assetType = isNFT(asset) ? AssetType.NFT : AssetType.ITEM
-  const assetId = isNFT(asset) ? asset.tokenId : asset.itemId
+const BuyNFTButtons = ({
+  assetType,
+  contractAddress,
+  network,
+  tokenId,
+  itemId,
+  buyWithCardClassName
+}: Props) => {
+  const assetId = tokenId || itemId
 
   const analytics = getAnalytics()
 

--- a/webapp/src/components/AssetPage/SaleActionBox/BuyNFTButtons/BuyNFTButtons.types.ts
+++ b/webapp/src/components/AssetPage/SaleActionBox/BuyNFTButtons/BuyNFTButtons.types.ts
@@ -1,8 +1,13 @@
-import { Asset } from '../../../../modules/asset/types'
+import { Network } from '@dcl/schemas'
+import { AssetType } from '../../../../modules/asset/types'
 
 export type Props = {
-  asset: Asset
+  assetType: AssetType
+  contractAddress: string
+  network: Network
+  tokenId?: string
+  itemId?: string
   buyWithCardClassName?: string
 }
 
-export type OwnProps = Pick<Props, 'asset'>
+export type OwnProps = Props

--- a/webapp/src/components/AssetPage/SaleActionBox/ItemSaleActions/ItemSaleActions.tsx
+++ b/webapp/src/components/AssetPage/SaleActionBox/ItemSaleActions/ItemSaleActions.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react'
 import { Button } from 'decentraland-ui'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { getBuilderCollectionDetailUrl } from '../../../../modules/collection/utils'
+import { AssetType } from '../../../../modules/asset/types'
 import { BuyNFTButtons } from '../BuyNFTButtons'
 
 import styles from './ItemSaleActions.module.css'
@@ -46,7 +47,10 @@ const ItemSaleActions = ({ item, wallet, customClassnames }: Props) => {
       ) : (
         canBuy && (
           <BuyNFTButtons
-            asset={item}
+            assetType={AssetType.ITEM}
+            contractAddress={item.contractAddress}
+            network={item.network}
+            itemId={item.itemId}
             buyWithCardClassName={customClassnames?.buyWithCardClassName}
           />
         )

--- a/webapp/src/components/AssetPage/SaleActionBox/NFTSaleActions/NFTSaleActions.tsx
+++ b/webapp/src/components/AssetPage/SaleActionBox/NFTSaleActions/NFTSaleActions.tsx
@@ -5,6 +5,7 @@ import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 
 import { builderUrl } from '../../../../lib/environment'
 import { isOwnedBy } from '../../../../modules/asset/utils'
+import { AssetType } from '../../../../modules/asset/types'
 import { locations } from '../../../../modules/routing/locations'
 import { VendorFactory } from '../../../../modules/vendor'
 import styles from './NFTSaleActions.module.css'
@@ -48,7 +49,12 @@ const NFTSaleActions = ({ bids, nft, order, wallet, onLeavingSite }: Props) => {
           </>
         ) : !isOwner ? (
           <>
-            <BuyNFTButtons asset={nft} />
+            <BuyNFTButtons
+              assetType={AssetType.ITEM}
+              contractAddress={nft.contractAddress}
+              network={nft.network}
+              tokenId={nft.tokenId}
+            />
             {canBid ? (
               <Button
                 as={Link}


### PR DESCRIPTION
Fixes a bug where the NFT can't be bought from the Item detail page because the `asset` passed was the item and not the NFT
Like the following case:
![image](https://github.com/decentraland/marketplace/assets/8763687/ab39c291-f155-4d0d-b9ed-0ecb712ea00b)

The item can't be mint, so the buy with mana button should send the user to the buy NFT flow.