### PR TITLE
feat: Protect routes

### DIFF
--- a/webapp/src/components/ActivityPage/ActivityPage.tsx
+++ b/webapp/src/components/ActivityPage/ActivityPage.tsx
@@ -1,9 +1,7 @@
 import React, { useCallback, useState } from 'react'
-import { Link } from 'react-router-dom'
 import { Page, Header, Button, Modal } from 'decentraland-ui'
-import { t, T } from 'decentraland-dapps/dist/modules/translation/utils'
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 
-import { locations } from '../../modules/routing/locations'
 import { Navigation } from '../Navigation'
 import { Row } from '../Layout/Row'
 import { Column } from '../Layout/Column'
@@ -35,24 +33,7 @@ const ActivityPage = (props: Props) => {
 
   let content = null
 
-  if (!address) {
-    content = (
-      <div className="center">
-        <p>
-          {
-            <T
-              id="wallet.sign_in_required"
-              values={{
-                sign_in: (
-                  <Link to={locations.signIn(locations.activity())}>{t('wallet.sign_in')}</Link>
-                )
-              }}
-            />
-          }
-        </p>
-      </div>
-    )
-  } else if (transactions.length === 0) {
+  if (transactions.length === 0) {
     content = (
       <div className="center">
         <p>{t('activity_page.empty')}</p>

--- a/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
+++ b/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
@@ -46,7 +46,6 @@ const NotFound = () => (
   </div>
 )
 
-// This page should be ideally provided by a protected router
 const Unauthorized = () => (
   <div className={styles.center}>
     <p className="secondary-text">{t('global.unauthorized')}&hellip;</p>
@@ -54,7 +53,7 @@ const Unauthorized = () => (
 )
 
 export const ManageAssetPage = (props: Props) => {
-  const { onBack, wallet, isConnecting } = props
+  const { onBack, wallet } = props
 
   const handleOpenInBuilder = useCallback((asset: NFT) => {
     window.location.replace(
@@ -82,10 +81,9 @@ export const ManageAssetPage = (props: Props) => {
               {(asset, order, rental, isLoading) => (
                 <>
                   <Back className="back" absolute onClick={onBack} />
-                  {isLoading || isConnecting ? <Loading /> : null}
+                  {isLoading ? <Loading /> : null}
                   {!isLoading && !asset ? <NotFound /> : null}
-                  {!isConnecting &&
-                  !isLoading &&
+                  {!isLoading &&
                   asset &&
                   wallet &&
                   isOwnedBy(asset, wallet, rental ?? undefined) ? (

--- a/webapp/src/components/Routes/Routes.tsx
+++ b/webapp/src/components/Routes/Routes.tsx
@@ -59,20 +59,32 @@ const Routes = ({ inMaintenance }: Props) => {
         />
         <Route exact path={locations.account()} component={AccountPage} />
         <ProtectedRoute exact path={locations.lists()} component={ListsPage} />
-        <Route exact path={locations.list()} component={ListPage} />
+        <ProtectedRoute exact path={locations.list()} component={ListPage} />
         <Route exact path={locations.signIn()} component={SignInPage} />
-        <Route exact path={locations.sell()} component={SellPage} />
-        <Route exact path={locations.bid()} component={BidPage} />
-        <Route exact path={locations.cancel()} component={CancelSalePage} />
-        <Route exact path={locations.transfer()} component={TransferPage} />
+        <ProtectedRoute exact path={locations.sell()} component={SellPage} />
+        <ProtectedRoute exact path={locations.bid()} component={BidPage} />
+        <ProtectedRoute
+          exact
+          path={locations.cancel()}
+          component={CancelSalePage}
+        />
+        <ProtectedRoute
+          exact
+          path={locations.transfer()}
+          component={TransferPage}
+        />
         <Route exact path={locations.collection()} component={CollectionPage} />
-        <Route exact path={locations.manage()} component={ManageAssetPage} />
-        <Route
+        <ProtectedRoute
+          exact
+          path={locations.manage()}
+          component={ManageAssetPage}
+        />
+        <ProtectedRoute
           exact
           path={locations.buy(AssetType.NFT)}
           component={() => <BuyPage type={AssetType.NFT} />}
         />
-        <Route
+        <ProtectedRoute
           exact
           path={locations.buy(AssetType.ITEM)}
           component={() => <BuyPage type={AssetType.ITEM} />}
@@ -101,8 +113,16 @@ const Routes = ({ inMaintenance }: Props) => {
           path={locations.item()}
           component={() => <AssetPage type={AssetType.ITEM} />}
         />
-        <Route exact path={locations.settings()} component={SettingsPage} />
-        <Route exact path={locations.activity()} component={ActivityPage} />
+        <ProtectedRoute
+          exact
+          path={locations.settings()}
+          component={SettingsPage}
+        />
+        <ProtectedRoute
+          exact
+          path={locations.activity()}
+          component={ActivityPage}
+        />
         <Route exact path={locations.root()} component={HomePage} />
         <Route exact path={locations.parcel()} component={LegacyNFTPage} />
         <Route exact path={locations.estate()} component={LegacyNFTPage} />

--- a/webapp/src/components/SettingsPage/SettingsPage.tsx
+++ b/webapp/src/components/SettingsPage/SettingsPage.tsx
@@ -7,7 +7,6 @@ import { AuthorizationType } from 'decentraland-dapps/dist/modules/authorization
 import { Page, Grid, Blockie, Loader, Form } from 'decentraland-ui'
 import { ContractName } from 'decentraland-transactions'
 
-import { locations } from '../../modules/routing/locations'
 import { shortenAddress } from '../../modules/wallet/utils'
 import { Navbar } from '../Navbar'
 import { Navigation } from '../Navigation'
@@ -16,9 +15,7 @@ import { getContractNames } from '../../modules/vendor'
 import { useTimer } from '../../lib/timer'
 import { Props } from './SettingsPage.types'
 import copyText from '../../lib/copyText'
-
 import './SettingsPage.css'
-import { useLocation } from 'react-router-dom'
 
 const SettingsPage = (props: Props) => {
   const {
@@ -28,27 +25,12 @@ const SettingsPage = (props: Props) => {
     hasError,
     hasFetchedContracts,
     getContract,
-    onNavigate,
     onFetchContracts
   } = props
 
   const [hasCopiedText, setHasCopiedAddress] = useTimer(1200)
-  const {pathname, search} = useLocation()
 
   useEffect(() => {
-    if (!wallet) {
-      onNavigate(locations.signIn(`${pathname}${search}`))
-    }
-  }, [wallet, onNavigate, pathname, search])
-
-  useEffect(() => {
-    // When this condition is met, the previous useEffect will redirect to the sign in page.
-    // However without checking here as well, the contracts will be fetched unnecessarily on the redirect as well
-    // causing an extra call.
-    if (!wallet) {
-      return
-    }
-
     // Only fetch the contracts if they were not already fetched.
     // hasFetchedContracts is reset to false whenever the connected account changes.
     if (!hasFetchedContracts && !isLoading) {


### PR DESCRIPTION
This PR uses the `ProtectedRoute` in the routes that require the page to be loaded with a wallet.
This protected route not only prevents the user from loading a page when there's no connected wallet but also automatically sets the `redirect` parameter so the user gets redirected automatically where it was when logging in.