### PR TITLE
fix: add sagas logic to cancel ongoing fetch items request effects

### DIFF
--- a/webapp/src/modules/item/actions.ts
+++ b/webapp/src/modules/item/actions.ts
@@ -14,6 +14,7 @@ import { ItemBrowseOptions } from './types'
 export const FETCH_ITEMS_REQUEST = '[Request] Fetch Items'
 export const FETCH_ITEMS_SUCCESS = '[Success] Fetch Items'
 export const FETCH_ITEMS_FAILURE = '[Failure] Fetch Items'
+export const FETCH_ITEMS_CANCELLED_ERROR_MESSAGE = '[Cancelled] Fetch Items'
 
 export const fetchItemsRequest = (options: ItemBrowseOptions) =>
   action(FETCH_ITEMS_REQUEST, options)

--- a/webapp/src/modules/item/sagas.spec.ts
+++ b/webapp/src/modules/item/sagas.spec.ts
@@ -1,7 +1,8 @@
+import { getLocation } from 'connected-react-router'
 import { expectSaga } from 'redux-saga-test-plan'
 import * as matchers from 'redux-saga-test-plan/matchers'
 import { call, select, take } from 'redux-saga/effects'
-import { ChainId, Item, Network } from '@dcl/schemas'
+import { ChainId, Item, Network, Rarity } from '@dcl/schemas'
 import { sendTransaction } from 'decentraland-dapps/dist/modules/wallet/utils'
 import { setPurchase } from 'decentraland-dapps/dist/modules/gateway/actions'
 import { TradeType } from 'decentraland-dapps/dist/modules/gateway/transak/types'
@@ -11,6 +12,7 @@ import {
   PurchaseStatus
 } from 'decentraland-dapps/dist/modules/gateway/types'
 import { NetworkGatewayType } from 'decentraland-ui'
+import { locations } from '../routing/locations'
 import { getWallet } from '../wallet/selectors'
 import { View } from '../ui/types'
 import { ItemAPI } from '../vendor/decentraland/item/api'
@@ -40,11 +42,13 @@ import {
   FETCH_ITEM_FAILURE,
   fetchCollectionItemsRequest,
   fetchCollectionItemsSuccess,
-  fetchCollectionItemsFailure
+  fetchCollectionItemsFailure,
+  FETCH_ITEMS_CANCELLED_ERROR_MESSAGE
 } from './actions'
 import { itemSaga } from './sagas'
 import { getData as getItems } from './selectors'
 import { getItem } from './utils'
+import { ItemBrowseOptions } from './types'
 
 const item = {
   itemId: 'anItemId',
@@ -62,7 +66,7 @@ const txHash =
 
 const anError = new Error('An error occured')
 
-const itemBrowseOptions = {
+const itemBrowseOptions: ItemBrowseOptions = {
   view: View.MARKET,
   page: 0,
   filters: {}
@@ -391,6 +395,7 @@ describe('when handling the fetch collections items request action', () => {
 
 describe('when handling the fetch items request action', () => {
   describe('when the request is successful', () => {
+    let pathname: string
     let dateNowSpy: jest.SpyInstance
     const nowTimestamp = 1487076708000
     const fetchResult = { data: [item], total: 1 }
@@ -405,22 +410,93 @@ describe('when handling the fetch items request action', () => {
       dateNowSpy.mockRestore()
     })
 
-    it('should dispatch a successful action with the fetched items', () => {
-      return expectSaga(itemSaga, getIdentity)
-        .provide([
-          [matchers.call.fn(CatalogAPI.prototype.get), fetchResult],
-          [matchers.call.fn(waitForWalletConnectionIfConnecting), undefined]
-        ])
-        .put(
-          fetchItemsSuccess(
-            fetchResult.data,
-            fetchResult.total,
-            itemBrowseOptions,
-            nowTimestamp
+    describe('and its dispatched from the browse path', () => {
+      beforeEach(() => {
+        pathname = locations.browse()
+      })
+      describe('and there is an ongoing fetch item request', () => {
+        let originalBrowseOptions = itemBrowseOptions
+        let newBrowseOptions: ItemBrowseOptions = {
+          ...itemBrowseOptions,
+          filters: { ...itemBrowseOptions.filters, rarities: [Rarity.COMMON] }
+        }
+        it('should dispatch a successful action with the fetched items and cancel the ongoing one', () => {
+          return expectSaga(itemSaga, getIdentity)
+            .provide([
+              [
+                matchers.call.fn(waitForWalletConnectionIfConnecting),
+                undefined
+              ],
+              [select(getLocation), { pathname }],
+              {
+                call(effect, next) {
+                  if (
+                    effect.fn === CatalogAPI.prototype.get &&
+                    effect.args[0] === originalBrowseOptions.filters
+                  ) {
+                    // Add a setTimeout so it gives time to get it cancelled
+                    return new Promise(res =>
+                      setTimeout(() => res(fetchResult), 1000)
+                    )
+                  }
+                  if (
+                    effect.fn === CatalogAPI.prototype.get &&
+                    effect.args[0] === newBrowseOptions.filters
+                  ) {
+                    // Mock without timeout
+                    return fetchResult
+                  }
+                  return next()
+                }
+              }
+            ])
+            .call.like({
+              fn: CatalogAPI.prototype.get,
+              args: [newBrowseOptions.filters]
+            })
+            .put(
+              fetchItemsFailure(
+                FETCH_ITEMS_CANCELLED_ERROR_MESSAGE,
+                originalBrowseOptions
+              )
+            )
+            .put(
+              fetchItemsSuccess(
+                fetchResult.data,
+                fetchResult.total,
+                newBrowseOptions,
+                nowTimestamp
+              )
+            )
+            .dispatch(fetchItemsRequest(originalBrowseOptions))
+            .dispatch(fetchItemsRequest(newBrowseOptions))
+            .run({ silenceTimeout: true })
+        })
+      })
+    })
+
+    describe('and its dispatches from a path that is not the browse', () => {
+      beforeEach(() => {
+        pathname = locations.root()
+      })
+      it('should dispatch a successful action with the fetched items', () => {
+        return expectSaga(itemSaga, getIdentity)
+          .provide([
+            [matchers.call.fn(CatalogAPI.prototype.get), fetchResult],
+            [matchers.call.fn(waitForWalletConnectionIfConnecting), undefined],
+            [select(getLocation), { pathname }]
+          ])
+          .put(
+            fetchItemsSuccess(
+              fetchResult.data,
+              fetchResult.total,
+              itemBrowseOptions,
+              nowTimestamp
+            )
           )
-        )
-        .dispatch(fetchItemsRequest(itemBrowseOptions))
-        .run({ silenceTimeout: true })
+          .dispatch(fetchItemsRequest(itemBrowseOptions))
+          .run({ silenceTimeout: true })
+      })
     })
   })
 
@@ -428,6 +504,7 @@ describe('when handling the fetch items request action', () => {
     it('should dispatch a failing action with the error and the options', () => {
       return expectSaga(itemSaga, getIdentity)
         .provide([
+          [select(getLocation), { pathname: '' }],
           [matchers.call.fn(CatalogAPI.prototype.get), Promise.reject(anError)],
           [matchers.call.fn(waitForWalletConnectionIfConnecting), undefined]
         ])

--- a/webapp/src/modules/item/sagas.ts
+++ b/webapp/src/modules/item/sagas.ts
@@ -1,6 +1,17 @@
+import { matchPath } from 'react-router-dom'
+import { getLocation } from 'connected-react-router'
+import { SagaIterator } from 'redux-saga'
 import { Item } from '@dcl/schemas'
 import { put, takeEvery } from '@redux-saga/core/effects'
-import { call, race, select, take } from 'redux-saga/effects'
+import {
+  call,
+  cancel,
+  cancelled,
+  fork,
+  race,
+  select,
+  take
+} from 'redux-saga/effects'
 import { ContractName, getContract } from 'decentraland-transactions'
 import { AuthIdentity } from 'decentraland-crypto-fetch'
 import { sendTransaction } from 'decentraland-dapps/dist/modules/wallet/utils'
@@ -20,6 +31,7 @@ import { isCatalogView } from '../routing/utils'
 import { waitForWalletConnectionIfConnecting } from '../wallet/utils'
 import { retryParams } from '../vendor/decentraland/utils'
 import { CatalogAPI } from '../vendor/decentraland/catalog/api'
+import { locations } from '../routing/locations'
 import {
   buyItemFailure,
   BuyItemRequestAction,
@@ -49,7 +61,8 @@ import {
   FetchCollectionItemsRequestAction,
   fetchCollectionItemsSuccess,
   fetchCollectionItemsFailure,
-  FETCH_COLLECTION_ITEMS_REQUEST
+  FETCH_COLLECTION_ITEMS_REQUEST,
+  FETCH_ITEMS_CANCELLED_ERROR_MESSAGE
 } from './actions'
 import { getData as getItems } from './selectors'
 import { getItem } from './utils'
@@ -65,7 +78,7 @@ export function* itemSaga(getIdentity: () => AuthIdentity | undefined) {
   const itemAPI = new ItemAPI(NFT_SERVER_URL, API_OPTS)
   const catalogAPI = new CatalogAPI(NFT_SERVER_URL, API_OPTS)
 
-  yield takeEvery(FETCH_ITEMS_REQUEST, handleFetchItemsRequest)
+  yield fork(handleOneFetchItemsRequestAtOnce)
   yield takeEvery(
     FETCH_COLLECTION_ITEMS_REQUEST,
     handleFetchCollectionItemsRequest
@@ -75,6 +88,26 @@ export function* itemSaga(getIdentity: () => AuthIdentity | undefined) {
   yield takeEvery(BUY_ITEM_WITH_CARD_REQUEST, handleBuyItemWithCardRequest)
   yield takeEvery(SET_PURCHASE, handleSetItemPurchaseWithCard)
   yield takeEvery(FETCH_ITEM_REQUEST, handleFetchItemRequest)
+
+  // to avoid race conditions, just one fetch items request is handled at once in the browse page
+  function* handleOneFetchItemsRequestAtOnce(): SagaIterator {
+    let task
+
+    while (true) {
+      const action: FetchItemsRequestAction = yield take(FETCH_ITEMS_REQUEST)
+      const {
+        pathname: currentPathname
+      }: ReturnType<typeof getLocation> = yield select(getLocation)
+
+      // if we have a task running in the browse path, we cancel the previous one
+      if (matchPath(currentPathname, { path: locations.browse() })) {
+        if (task && task.isRunning()) {
+          yield cancel(task)
+        }
+      }
+      task = yield fork(handleFetchItemsRequest, action)
+    }
+  }
 
   function* handleFetchTrendingItemsRequest(
     action: FetchTrendingItemsRequestAction
@@ -125,7 +158,9 @@ export function* itemSaga(getIdentity: () => AuthIdentity | undefined) {
     }
   }
 
-  function* handleFetchItemsRequest(action: FetchItemsRequestAction) {
+  function* handleFetchItemsRequest(
+    action: FetchItemsRequestAction
+  ): SagaIterator {
     const { filters, view } = action.payload
 
     // If the wallet is getting connected, wait until it finishes to fetch the items so it can fetch them with authentication
@@ -145,6 +180,13 @@ export function* itemSaga(getIdentity: () => AuthIdentity | undefined) {
           action.payload
         )
       )
+    } finally {
+      if (yield cancelled()) {
+        // if cancelled, we dispatch a failure action so it cleans the loading state
+        yield put(
+          fetchItemsFailure(FETCH_ITEMS_CANCELLED_ERROR_MESSAGE, action.payload)
+        )
+      }
     }
   }
 

--- a/webapp/src/modules/toast/sagas.ts
+++ b/webapp/src/modules/toast/sagas.ts
@@ -13,6 +13,7 @@ import {
 } from '../rental/actions'
 import {
   BUY_ITEM_WITH_CARD_FAILURE,
+  FETCH_ITEMS_CANCELLED_ERROR_MESSAGE,
   FETCH_ITEMS_FAILURE,
   FetchItemsFailureAction
 } from '../item/actions'
@@ -169,5 +170,7 @@ function* handleFetchAssetsFailure(
   action: FetchItemsFailureAction | FetchNFTsFailureAction
 ) {
   const { error } = action.payload
-  yield put(showToast(getFetchAssetsFailureToast(error), 'bottom right'))
+  if (error !== FETCH_ITEMS_CANCELLED_ERROR_MESSAGE) {
+    yield put(showToast(getFetchAssetsFailureToast(error), 'bottom right'))
+  }
 }

--- a/webapp/src/modules/ui/browse/reducer.spec.ts
+++ b/webapp/src/modules/ui/browse/reducer.spec.ts
@@ -360,20 +360,6 @@ describe('when reducing the fetch NFTs success action', () => {
   })
 })
 
-describe('when reducing the success action of fetching trending items', () => {
-  const initialState: BrowseUIState = { ...INITIAL_STATE }
-  const item = { id: 'itemId1' } as Item
-
-  it('should return a state with the ids of the trending items', () => {
-    expect(
-      browseReducer(initialState, fetchTrendingItemsSuccess([item]))
-    ).toEqual({
-      ...initialState,
-      itemIds: [item.id]
-    })
-  })
-})
-
 describe('when reducing the success action of fetching favorited items', () => {
   let initialState: BrowseUIState
   let browseOptions: ItemBrowseOptions

--- a/webapp/src/modules/ui/browse/reducer.ts
+++ b/webapp/src/modules/ui/browse/reducer.ts
@@ -15,10 +15,8 @@ import {
 import {
   FetchItemsRequestAction,
   FetchItemsSuccessAction,
-  FetchTrendingItemsSuccessAction,
   FETCH_ITEMS_REQUEST,
-  FETCH_ITEMS_SUCCESS,
-  FETCH_TRENDING_ITEMS_SUCCESS
+  FETCH_ITEMS_SUCCESS
 } from '../../item/actions'
 import {
   FetchNFTsRequestAction,
@@ -58,7 +56,6 @@ type UIReducerAction =
   | FetchNFTsRequestAction
   | FetchNFTsSuccessAction
   | BrowseAction
-  | FetchTrendingItemsSuccessAction
   | FetchItemsRequestAction
   | FetchItemsSuccessAction
   | FetchFavoritedItemsSuccessAction
@@ -173,12 +170,6 @@ export function browseReducer(
           }
       }
     }
-
-    case FETCH_TRENDING_ITEMS_SUCCESS:
-      return {
-        ...state,
-        itemIds: action.payload.items.map(item => item.id)
-      }
 
     case FETCH_FAVORITED_ITEMS_SUCCESS:
       const {


### PR DESCRIPTION
PR description
The `/browse` page can have multiple race-conditions when applying filters when there are ongoing requests that haven't been fullfiled yet. In order to avoid them, we need to cancel the ongoing fetch item requests effects.

Closes #1758

copilot:summary