### PR TITLE
fix: Pagination not storing the current page

### DIFF
--- a/webapp/src/modules/ui/browse/reducer.spec.ts
+++ b/webapp/src/modules/ui/browse/reducer.spec.ts
@@ -7,11 +7,7 @@ import {
   fetchListsSuccess,
   deleteListSuccess
 } from '../../favorites/actions'
-import {
-  fetchItemsRequest,
-  fetchItemsSuccess,
-  fetchTrendingItemsSuccess
-} from '../../item/actions'
+import { fetchItemsRequest, fetchItemsSuccess } from '../../item/actions'
 import { ItemBrowseOptions } from '../../item/types'
 import { fetchNFTsRequest, fetchNFTsSuccess } from '../../nft/actions'
 import { NFT, NFTsFetchOptions } from '../../nft/types'
@@ -796,6 +792,7 @@ describe('when reducing the action of the success of getting the lists', () => {
       ).toEqual({
         ...initialState,
         listIds: ['aListId', 'anotherListId'],
+        page: 2,
         count: 2
       })
     })
@@ -825,6 +822,7 @@ describe('when reducing the action of the success of getting the lists', () => {
       ).toEqual({
         ...initialState,
         listIds: ['anotherListId'],
+        page: 1,
         count: 1
       })
     })

--- a/webapp/src/modules/ui/browse/reducer.ts
+++ b/webapp/src/modules/ui/browse/reducer.ts
@@ -253,6 +253,7 @@ export function browseReducer(
       return {
         ...state,
         listIds,
+        page,
         count: total
       }
     }


### PR DESCRIPTION
This PR fixes the lists pagination that was caused because of the store not saving the current pagination.