### PR TITLE
fix: User menu lists doesn't redirect to my lists

### DIFF
--- a/webapp/src/components/UserMenu/UserMenu.container.ts
+++ b/webapp/src/components/UserMenu/UserMenu.container.ts
@@ -6,6 +6,7 @@ import {
   isConnecting
 } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { getTransactions } from '../../modules/transaction/selectors'
+import { getIsListsV1Enabled } from '../../modules/features/selectors'
 import { locations } from '../../modules/routing/locations'
 import { RootState } from '../../modules/reducer'
 import UserMenu from './UserMenu'
@@ -16,7 +17,8 @@ const mapState = (state: RootState): MapStateProps => {
     isSignedIn: isConnected(state),
     isSigningIn: isConnecting(state),
     isActivity: getLocation(state).pathname === locations.activity(),
-    hasActivity: getTransactions(state).some(tx => isPending(tx.status))
+    hasActivity: getTransactions(state).some(tx => isPending(tx.status)),
+    isListV1Enabled: getIsListsV1Enabled(state)
   }
 }
 
@@ -24,7 +26,8 @@ const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
   onClickActivity: () => dispatch(push(locations.activity())),
   onClickSettings: () => dispatch(push(locations.settings())),
   onClickMyAssets: () => dispatch(push(locations.defaultCurrentAccount())),
-  onClickMyLists: () => dispatch(push(locations.defaultList()))
+  onClickMyLists: () => dispatch(push(locations.defaultList())),
+  onClickMyListsV1: () => dispatch(push(locations.lists()))
 })
 
 export default connect(mapState, mapDispatch)(UserMenu)

--- a/webapp/src/components/UserMenu/UserMenu.tsx
+++ b/webapp/src/components/UserMenu/UserMenu.tsx
@@ -5,7 +5,13 @@ import { Icon } from 'decentraland-ui'
 import { Props } from './UserMenu.types'
 
 const UserMenu = (props: Props) => {
-  const { onClickMyAssets, onClickMyLists, ...baseProps } = props
+  const {
+    onClickMyAssets,
+    onClickMyLists,
+    isListV1Enabled,
+    onClickMyListsV1,
+    ...baseProps
+  } = props
 
   const menuItems = useMemo(
     () => (
@@ -14,13 +20,17 @@ const UserMenu = (props: Props) => {
           <Icon name="briefcase"></Icon>
           {t('user_menu.my_assets')}
         </li>
-        <li onClick={onClickMyLists} role="button" data-testid="my-lists">
+        <li
+          onClick={isListV1Enabled ? onClickMyListsV1 : onClickMyLists}
+          role="button"
+          data-testid="my-lists"
+        >
           <Icon name="bookmark"></Icon>
           {t('user_menu.my_lists')}
         </li>
       </>
     ),
-    [onClickMyAssets, onClickMyLists]
+    [isListV1Enabled, onClickMyAssets, onClickMyLists, onClickMyListsV1]
   )
 
   return <BaseUserMenu {...baseProps} menuItems={menuItems} />

--- a/webapp/src/components/UserMenu/UserMenu.types.ts
+++ b/webapp/src/components/UserMenu/UserMenu.types.ts
@@ -5,14 +5,24 @@ import { UserMenuProps } from 'decentraland-ui'
 export type Props = Partial<UserMenuProps> & {
   onClickMyAssets: () => void
   onClickMyLists: () => void
+  onClickMyListsV1: () => void
+  isListV1Enabled: boolean
 }
 
 export type MapStateProps = Pick<
   Props,
-  'isSignedIn' | 'isSigningIn' | 'isActivity' | 'hasActivity'
+  | 'isSignedIn'
+  | 'isSigningIn'
+  | 'isActivity'
+  | 'hasActivity'
+  | 'isListV1Enabled'
 >
 export type MapDispatchProps = Pick<
   Props,
-  'onClickActivity' | 'onClickSettings' | 'onClickMyAssets' | 'onClickMyLists'
+  | 'onClickActivity'
+  | 'onClickSettings'
+  | 'onClickMyAssets'
+  | 'onClickMyLists'
+  | 'onClickMyListsV1'
 >
 export type MapDispatch = Dispatch<CallHistoryMethodAction>


### PR DESCRIPTION
This PR changes the `UserMenu` component so the user gets redirected to the `My Lists` page after clicking on it.
Closes #1828 