### PR TITLE
fix: Refresh item ids after changing List view + avoid double pushes

### DIFF
--- a/webapp/src/components/ListPage/ListPage.tsx
+++ b/webapp/src/components/ListPage/ListPage.tsx
@@ -45,20 +45,21 @@ import {
 
 const LIST_NOT_FOUND = 'list was not found'
 
-const ListPage = ({
-  isConnecting,
-  wallet,
-  listId,
-  list,
-  isLoading,
-  error,
-  onFetchList,
-  onBack,
-  onEditList,
-  onDeleteList,
-  onShareList,
-  isListV1Enabled
-}: Props) => {
+const ListPage = (props: Props) => {
+  const {
+    isConnecting,
+    wallet,
+    listId,
+    list,
+    isLoading,
+    error,
+    onFetchList,
+    onBack,
+    onEditList,
+    onDeleteList,
+    onShareList,
+    isListV1Enabled
+  } = props
   const hasFetchedOnce = useRef(false)
   const { pathname, search } = useLocation()
 
@@ -149,7 +150,8 @@ const ListPage = ({
     <PageLayout activeTab={NavigationTab.MY_LISTS}>
       {isLoading || isConnecting ? (
         <Loader active size="massive" data-testid={LOADER_TEST_ID} />
-      ) : list ? (
+      ) : null}
+      {!isLoading && !isConnecting && listId && list && !error ? (
         <div data-testid={LIST_CONTAINER_TEST_ID} className={styles.container}>
           <Header className={styles.header} size="large">
             {(!isPublicView || list.id === DEFAULT_FAVORITES_LIST_ID) &&
@@ -282,9 +284,8 @@ const ListPage = ({
             )}
           </div>
         </div>
-      ) : (
-        error && renderErrorView()
-      )}
+      ) : null}
+      {!isLoading && !isConnecting && error && renderErrorView()}
     </PageLayout>
   )
 }

--- a/webapp/src/components/ListsPage/ListCard/ListCard.tsx
+++ b/webapp/src/components/ListsPage/ListCard/ListCard.tsx
@@ -7,6 +7,8 @@ import { DEFAULT_FAVORITES_LIST_ID } from '../../../modules/vendor/decentraland/
 import { AssetType } from '../../../modules/asset/types'
 import { Section } from '../../../modules/vendor/decentraland'
 import { View } from '../../../modules/ui/types'
+import { VendorName } from '../../../modules/vendor'
+import { SortBy } from '../../../modules/routing/types'
 import { AssetImage } from '../../AssetImage'
 import { PrivateTag } from '../../PrivateTag'
 import { Props } from './ListCard.types'
@@ -33,7 +35,9 @@ const ListCard = (props: Props) => {
         assetType: AssetType.ITEM,
         page: 1,
         section: Section.LISTS,
-        view: View.LISTS
+        view: View.LISTS,
+        vendor: VendorName.DECENTRALAND,
+        sortBy: SortBy.NEWEST
       })}
       className={styles.card}
     >

--- a/webapp/src/components/Modals/ShareListModal/ShareListModal.tsx
+++ b/webapp/src/components/Modals/ShareListModal/ShareListModal.tsx
@@ -11,6 +11,8 @@ import { config } from '../../../config'
 import copyText from '../../../lib/copyText'
 import { useTimer } from '../../../lib/timer'
 import * as events from '../../../utils/events'
+import { VendorName } from '../../../modules/vendor'
+import { SortBy } from '../../../modules/routing/types'
 import { ListCard } from '../../ListsPage/ListCard'
 import { Props } from './ShareListModal.types'
 import styles from './ShareListModal.module.css'
@@ -29,7 +31,9 @@ const ShareListModal = (props: Props) => {
     assetType: AssetType.ITEM,
     page: 1,
     section: Section.LISTS,
-    view: View.LISTS
+    view: View.LISTS,
+    vendor: VendorName.DECENTRALAND,
+    sortBy: SortBy.NEWEST
   })
 
   const handleClose = useCallback(() => {

--- a/webapp/src/modules/favorites/selectors.ts
+++ b/webapp/src/modules/favorites/selectors.ts
@@ -79,6 +79,7 @@ export const isPickingOrUnpicking = (state: RootState, itemId: string) =>
 
 export const getList = (state: RootState, id: string): List | null =>
   getLists(state)[id] ?? null
+
 export const getPreviewListItems = (state: RootState, id: string): Item[] =>
   getLists(state)
     [id]?.previewOfItemIds?.map(itemId => getItems(state)[itemId])

--- a/webapp/src/modules/routing/selectors.ts
+++ b/webapp/src/modules/routing/selectors.ts
@@ -431,11 +431,11 @@ export const getCurrentLocationAddress = createSelector<
   getPathName,
   getWalletAddress,
   getAccountAddress,
-  (pathname, walletAddess, accountAddress) => {
+  (pathname, walletAddress, accountAddress) => {
     let address: string | undefined
 
     if (pathname === locations.currentAccount()) {
-      address = walletAddess
+      address = walletAddress
     } else {
       address = accountAddress
     }

--- a/webapp/src/modules/toast/toasts.tsx
+++ b/webapp/src/modules/toast/toasts.tsx
@@ -23,6 +23,8 @@ import {
   ListOfLists,
   UpdateOrCreateList
 } from '../vendor/decentraland/favorites/types'
+import { SortBy } from '../routing/types'
+import { VendorName } from '../vendor'
 import { toastDispatchableActionsChannel } from './utils'
 import {
   BulkPickUnpickMessageType,
@@ -331,7 +333,9 @@ function buildBulkPickItemBodyMessage(
                 assetType: AssetType.ITEM,
                 page: 1,
                 section: Section.LISTS,
-                view: View.LISTS
+                view: View.LISTS,
+                vendor: VendorName.DECENTRALAND,
+                sortBy: SortBy.NEWEST
               })}
             >
               {lists[0]?.name ?? ''}
@@ -345,7 +349,9 @@ function buildBulkPickItemBodyMessage(
                 assetType: AssetType.ITEM,
                 page: 1,
                 section: Section.LISTS,
-                view: View.LISTS
+                view: View.LISTS,
+                vendor: VendorName.DECENTRALAND,
+                sortBy: SortBy.NEWEST
               })}
             >
               {lists[1]?.name ?? ''}

--- a/webapp/src/modules/ui/browse/reducer.ts
+++ b/webapp/src/modules/ui/browse/reducer.ts
@@ -5,8 +5,10 @@ import {
   CreateListSuccessAction,
   DELETE_LIST_SUCCESS,
   DeleteListSuccessAction,
+  FETCH_FAVORITED_ITEMS_REQUEST,
   FETCH_FAVORITED_ITEMS_SUCCESS,
   FETCH_LISTS_SUCCESS,
+  FetchFavoritedItemsRequestAction,
   FetchFavoritedItemsSuccessAction,
   FetchListsSuccessAction,
   UNDO_UNPICKING_ITEM_AS_FAVORITE_SUCCESS,
@@ -60,6 +62,7 @@ type UIReducerAction =
   | BrowseAction
   | FetchItemsRequestAction
   | FetchItemsSuccessAction
+  | FetchFavoritedItemsRequestAction
   | FetchFavoritedItemsSuccessAction
   | UnpickItemAsFavoriteSuccessAction
   | UndoUnpickingItemAsFavoriteSuccessAction
@@ -184,6 +187,14 @@ export function browseReducer(
           }
       }
     }
+
+    case FETCH_FAVORITED_ITEMS_REQUEST:
+      return {
+        ...state,
+        itemIds: isLoadingMoreResults(state, action.payload.options.page)
+          ? state.itemIds
+          : []
+      }
 
     case FETCH_FAVORITED_ITEMS_SUCCESS:
       const {


### PR DESCRIPTION
Closes #1810 
Closes #1844 