### PR TITLE
fix: Allow list cards to grow up to the 100% of the available space

### DIFF
--- a/webapp/src/components/ListsPage/ListCard/ListCard.module.css
+++ b/webapp/src/components/ListsPage/ListCard/ListCard.module.css
@@ -1,6 +1,6 @@
 :global(.ui.card).card {
   height: 240px;
-  width: 320px;
+  width: 100%;
   margin: 0px;
 }
 


### PR DESCRIPTION
Closes #1858 