### PR TITLE
fix: End bulk sagas when closing the modal or failing the creation of a list

### DIFF
--- a/webapp/src/modules/favorites/sagas.spec.ts
+++ b/webapp/src/modules/favorites/sagas.spec.ts
@@ -23,6 +23,7 @@ import { locations } from '../routing/locations'
 import { SortDirection } from '../routing/types'
 import { CatalogAPI } from '../vendor/decentraland/catalog/api'
 import {
+  BULK_PICK_SUCCESS,
   CREATE_LIST_FAILURE,
   CREATE_LIST_SUCCESS,
   bulkPickUnpickCancel,
@@ -1382,6 +1383,22 @@ describe('when handling the request to start the picks and unpicks in bulk proce
     })
   })
 
+  describe('and the user picks or unpicks in bulk without trying to create a new list', () => {
+    it('should end the saga without dispatching a bulk request', () => {
+      return expectSaga(favoritesSaga, getIdentity)
+        .provide([
+          [select(getAddress), address],
+          [call(getAccountIdentity), Promise.resolve()],
+          [take(BULK_PICK_SUCCESS), { payload: { list: newList } }]
+        ])
+        .put(openModal('SaveToListModal', { item }))
+        .not.put(closeModal('SaveToListModal'))
+        .not.put(bulkPickUnpickRequest(item, [newList], []))
+        .dispatch(bulkPickUnpickStart(item))
+        .run({ silenceTimeout: true })
+    })
+  })
+
   describe('and the user tries to create a new list', () => {
     describe('and the creation of the list succeeds', () => {
       it('should dispatch an action signaling the pick item in bulk request for the created list', () => {
@@ -1396,22 +1413,6 @@ describe('when handling the request to start the picks and unpicks in bulk proce
           .put(openModal('SaveToListModal', { item }))
           .put(closeModal('SaveToListModal'))
           .put(bulkPickUnpickRequest(item, [newList], []))
-          .dispatch(bulkPickUnpickStart(item))
-          .run({ silenceTimeout: true })
-      })
-    })
-
-    describe('and the creation of the list fails', () => {
-      it('should dispatch an action signaling the cancel of the pick item in bulk process', () => {
-        return expectSaga(favoritesSaga, getIdentity)
-          .provide([
-            [select(getAddress), address],
-            [call(getAccountIdentity), Promise.resolve()],
-            [take(CREATE_LIST_FAILURE), {}],
-            [put(bulkPickUnpickRequest(item, [newList], [])), undefined]
-          ])
-          .put(openModal('SaveToListModal', { item }))
-          .not.put(bulkPickUnpickRequest(item, [newList], []))
           .dispatch(bulkPickUnpickStart(item))
           .run({ silenceTimeout: true })
       })

--- a/webapp/src/modules/favorites/sagas.ts
+++ b/webapp/src/modules/favorites/sagas.ts
@@ -459,10 +459,12 @@ export function* favoritesSaga(getIdentity: () => AuthIdentity | undefined) {
         listCreationSuccess
       }: {
         listCreationSuccess: CreateListSuccessAction
+        picksInBulkRequest: BulkPickUnpickRequestAction
         modalClosed: CloseModalAction
       } = yield race({
         listCreationSuccess: take(CREATE_LIST_SUCCESS),
-        modalClosed: take([CLOSE_MODAL, BULK_PICK_REQUEST])
+        picksInBulkRequest: take(BULK_PICK_REQUEST),
+        modalClosed: take(CLOSE_MODAL)
       })
 
       if (listCreationSuccess) {

--- a/webapp/src/modules/favorites/sagas.ts
+++ b/webapp/src/modules/favorites/sagas.ts
@@ -481,7 +481,6 @@ export function* favoritesSaga(getIdentity: () => AuthIdentity | undefined) {
 
         yield put(bulkPickUnpickRequest(item, [pickedList], []))
       }
-      console.log('end sagas')
     } catch (error) {
       yield put(
         bulkPickUnpickCancel(

--- a/webapp/src/modules/favorites/sagas.ts
+++ b/webapp/src/modules/favorites/sagas.ts
@@ -76,9 +76,7 @@ import {
   BulkPickUnpickStartAction,
   bulkPickUnpickCancel,
   CreateListSuccessAction,
-  CreateListFailureAction,
   CREATE_LIST_SUCCESS,
-  CREATE_LIST_FAILURE,
   bulkPickUnpickRequest,
   DELETE_LIST_SUCCESS
 } from './actions'
@@ -425,7 +423,6 @@ export function* favoritesSaga(getIdentity: () => AuthIdentity | undefined) {
 
   function* handleBulkPickStart(action: BulkPickUnpickStartAction) {
     const { item } = action.payload
-
     try {
       const address: string = yield select(getAddress)
 
@@ -462,12 +459,10 @@ export function* favoritesSaga(getIdentity: () => AuthIdentity | undefined) {
         listCreationSuccess
       }: {
         listCreationSuccess: CreateListSuccessAction
-        listCreationFailure: CreateListFailureAction
         modalClosed: CloseModalAction
       } = yield race({
         listCreationSuccess: take(CREATE_LIST_SUCCESS),
-        listCreationFailure: take(CREATE_LIST_FAILURE),
-        modalClosed: take(CLOSE_MODAL)
+        modalClosed: take([CLOSE_MODAL, BULK_PICK_REQUEST])
       })
 
       if (listCreationSuccess) {
@@ -484,6 +479,7 @@ export function* favoritesSaga(getIdentity: () => AuthIdentity | undefined) {
 
         yield put(bulkPickUnpickRequest(item, [pickedList], []))
       }
+      console.log('end sagas')
     } catch (error) {
       yield put(
         bulkPickUnpickCancel(


### PR DESCRIPTION
This PR changes the actions that were being raced in the `handleBulkPickStart` saga.
The race now handles the `BULK_PICK_REQUEST` action that would occur when the users picked some lists without creating one, ending the saga. Without handling this action, the saga would hang and, whenever any of the other actions occurred, it would continue all of them.

Closes #1868