### PR TITLE
feat: Split bulk picks and unpicks

### DIFF
--- a/webapp/src/components/Modals/ShareListModal/ShareListModal.tsx
+++ b/webapp/src/components/Modals/ShareListModal/ShareListModal.tsx
@@ -42,9 +42,10 @@ const ShareListModal = (props: Props) => {
 
   const handleCopyLink = useCallback(() => {
     const url = `${MARKETPLACE_URL}${listLink}`
-    getAnalytics().track(events.COPY_LINK_TO_SHARE_LIST, {
+    getAnalytics().track(events.SHARE_LIST, {
       list,
-      url
+      url,
+      type: events.SHARE_LIST_TYPE.COPY_LINK
     })
     copyText(url, setHasCopied)
   }, [list, listLink, setHasCopied])
@@ -54,9 +55,10 @@ const ShareListModal = (props: Props) => {
       const url = `${twitterLink}${encodeURIComponent(
         `${t('share_list_modal.twitter_message')}${MARKETPLACE_URL}${listLink}`
       )}`
-      getAnalytics().track(events.SHARE_LIST_ON_TWITTER, {
+      getAnalytics().track(events.SHARE_LIST, {
         list,
-        url
+        url,
+        type: events.SHARE_LIST_TYPE.TWITTER
       })
       window.open(url, '_blank')
       e.currentTarget.blur()

--- a/webapp/src/modules/analytics/track.ts
+++ b/webapp/src/modules/analytics/track.ts
@@ -76,10 +76,6 @@ import {
 import { PurchaseStatus } from 'decentraland-dapps/dist/modules/gateway/types'
 import * as events from '../../utils/events'
 import {
-  BULK_PICK_FAILURE,
-  BULK_PICK_SUCCESS,
-  BulkPickUnpickFailureAction,
-  BulkPickUnpickSuccessAction,
   CREATE_LIST_FAILURE,
   CREATE_LIST_SUCCESS,
   CreateListFailureAction,
@@ -90,18 +86,26 @@ import {
   DeleteListSuccessAction,
   PICK_ITEM_AS_FAVORITE_FAILURE,
   PICK_ITEM_AS_FAVORITE_SUCCESS,
+  PICK_ITEM_FAILURE,
+  PICK_ITEM_SUCCESS,
   PickItemAsFavoriteFailureAction,
   PickItemAsFavoriteSuccessAction,
+  PickItemFailureAction,
+  PickItemSuccessAction,
   UNDO_UNPICKING_ITEM_AS_FAVORITE_FAILURE,
   UNDO_UNPICKING_ITEM_AS_FAVORITE_SUCCESS,
   UNPICK_ITEM_AS_FAVORITE_FAILURE,
   UNPICK_ITEM_AS_FAVORITE_SUCCESS,
+  UNPICK_ITEM_FAILURE,
+  UNPICK_ITEM_SUCCESS,
   UPDATE_LIST_FAILURE,
   UPDATE_LIST_SUCCESS,
   UndoUnpickingItemAsFavoriteFailureAction,
   UndoUnpickingItemAsFavoriteSuccessAction,
   UnpickItemAsFavoriteFailureAction,
   UnpickItemAsFavoriteSuccessAction,
+  UnpickItemFailureAction,
+  UnpickItemSuccessAction,
   UpdateListFailureAction,
   UpdateListSuccessAction
 } from '../favorites/actions'
@@ -406,23 +410,40 @@ track<UndoUnpickingItemAsFavoriteFailureAction>(
   })
 )
 
-track<BulkPickUnpickSuccessAction>(
-  BULK_PICK_SUCCESS,
-  events.BULK_PICK,
-  ({ payload: { item, pickedFor, unpickedFrom } }) => ({
+track<PickItemSuccessAction>(
+  PICK_ITEM_SUCCESS,
+  events.PICK_ITEM,
+  ({ payload: { item, listId } }) => ({
     item,
-    pickedFor,
-    unpickedFrom
+    listId
   })
 )
 
-track<BulkPickUnpickFailureAction>(
-  BULK_PICK_FAILURE,
-  events.BULK_PICK,
-  ({ payload: { item, pickedFor, unpickedFrom, error } }) => ({
+track<PickItemFailureAction>(
+  PICK_ITEM_FAILURE,
+  events.PICK_ITEM,
+  ({ payload: { item, listId, error } }) => ({
     item,
-    pickedFor,
-    unpickedFrom,
+    listId,
+    error
+  })
+)
+
+track<UnpickItemSuccessAction>(
+  UNPICK_ITEM_SUCCESS,
+  events.UNPICK_ITEM,
+  ({ payload: { item, listId } }) => ({
+    item,
+    listId
+  })
+)
+
+track<UnpickItemFailureAction>(
+  UNPICK_ITEM_FAILURE,
+  events.UNPICK_ITEM,
+  ({ payload: { item, listId, error } }) => ({
+    item,
+    listId,
     error
   })
 )

--- a/webapp/src/modules/favorites/actions.ts
+++ b/webapp/src/modules/favorites/actions.ts
@@ -321,3 +321,41 @@ export type BulkPickUnpickFailureAction = ReturnType<
 >
 
 export type BulkPickUnpickCancelAction = ReturnType<typeof bulkPickUnpickCancel>
+
+// Actions to track bulk picks and unpicks
+
+export const PICK_ITEM_SUCCESS = '[Tracking] Pick item success'
+export const PICK_ITEM_FAILURE = '[Tracking] Pick item failure'
+export const UNPICK_ITEM_SUCCESS = '[Tracking] Unpick item success'
+export const UNPICK_ITEM_FAILURE = '[Tracking] Unpick item failure'
+
+export const pickItemSuccess = (item: Item, listId: string) =>
+  action(PICK_ITEM_SUCCESS, {
+    item,
+    listId
+  })
+
+export const pickItemFailure = (item: Item, listId: string, error: string) =>
+  action(PICK_ITEM_FAILURE, {
+    item,
+    listId,
+    error
+  })
+
+export const unpickItemSuccess = (item: Item, listId: string) =>
+  action(UNPICK_ITEM_SUCCESS, {
+    item,
+    listId
+  })
+
+export const unpickItemFailure = (item: Item, listId: string, error: string) =>
+  action(UNPICK_ITEM_FAILURE, {
+    item,
+    listId,
+    error
+  })
+
+export type PickItemSuccessAction = ReturnType<typeof pickItemSuccess>
+export type PickItemFailureAction = ReturnType<typeof pickItemFailure>
+export type UnpickItemSuccessAction = ReturnType<typeof unpickItemSuccess>
+export type UnpickItemFailureAction = ReturnType<typeof unpickItemFailure>

--- a/webapp/src/modules/favorites/sagas.spec.ts
+++ b/webapp/src/modules/favorites/sagas.spec.ts
@@ -51,12 +51,16 @@ import {
   pickItemAsFavoriteFailure,
   pickItemAsFavoriteRequest,
   pickItemAsFavoriteSuccess,
+  pickItemFailure,
+  pickItemSuccess,
   undoUnpickingItemAsFavoriteFailure,
   undoUnpickingItemAsFavoriteRequest,
   undoUnpickingItemAsFavoriteSuccess,
   unpickItemAsFavoriteFailure,
   unpickItemAsFavoriteRequest,
   unpickItemAsFavoriteSuccess,
+  unpickItemFailure,
+  unpickItemSuccess,
   updateListFailure,
   updateListRequest,
   updateListSuccess
@@ -1536,5 +1540,67 @@ describe('when handling the request to perform picks and unpicks in bulk', () =>
         .dispatch(bulkPickUnpickRequest(item, [fstList], [sndList]))
         .run({ silenceTimeout: true })
     })
+  })
+})
+
+describe('when handling the success of the bulk pick and unpick process', () => {
+  let fstList: ListOfLists
+  let sndList: ListOfLists
+
+  beforeEach(() => {
+    fstList = {
+      id: 'anId',
+      name: 'aName',
+      itemsCount: 1,
+      previewOfItemIds: ['anItemId'],
+      isPrivate: true
+    }
+    sndList = {
+      id: 'anotherId',
+      name: 'anotherName',
+      itemsCount: 2,
+      previewOfItemIds: ['anotherItemId'],
+      isPrivate: true
+    }
+  })
+
+  it('should dispatch a pick success action and an unpick success action for each picked or unpicked lists', () => {
+    return expectSaga(favoritesSaga, getIdentity)
+      .put(pickItemSuccess(item, fstList.id))
+      .put(unpickItemSuccess(item, sndList.id))
+      .dispatch(bulkPickUnpickSuccess(item, [fstList], [sndList], true, true))
+      .run({ silenceTimeout: true })
+  })
+})
+
+describe('when handling the failure of the bulk pick and unpick process', () => {
+  let error: string
+  let fstList: ListOfLists
+  let sndList: ListOfLists
+
+  beforeEach(() => {
+    error = 'An error occurred'
+    fstList = {
+      id: 'anId',
+      name: 'aName',
+      itemsCount: 1,
+      previewOfItemIds: ['anItemId'],
+      isPrivate: true
+    }
+    sndList = {
+      id: 'anotherId',
+      name: 'anotherName',
+      itemsCount: 2,
+      previewOfItemIds: ['anotherItemId'],
+      isPrivate: true
+    }
+  })
+
+  it('should dispatch a pick failure action and an unpick success action for each picked or unpicked lists', () => {
+    return expectSaga(favoritesSaga, getIdentity)
+      .put(pickItemFailure(item, fstList.id, error))
+      .put(unpickItemFailure(item, sndList.id, error))
+      .dispatch(bulkPickUnpickFailure(item, [fstList], [sndList], error))
+      .run({ silenceTimeout: true })
   })
 })

--- a/webapp/src/utils/events.ts
+++ b/webapp/src/utils/events.ts
@@ -64,5 +64,8 @@ export const UPDATE_LIST = 'Update List'
 export const DELETE_LIST = 'Delete List'
 
 export const OPEN_SHARE_LIST_MODAL = 'Open share list modal'
-export const COPY_LINK_TO_SHARE_LIST = 'Copy link to share list'
-export const SHARE_LIST_ON_TWITTER = 'Share list on Twitter'
+export const SHARE_LIST = 'Share list'
+export enum SHARE_LIST_TYPE {
+  COPY_LINK = 'Copy link',
+  TWITTER = 'Twitter'
+}


### PR DESCRIPTION
This PR takes the bulk picks and unpicks and translates them into smaller actions which will get tracked. It also simplifies the `SHARE_LIST` event so it holds the type of sharing that it was used (twitter, link copied).

Closes #1804