### PR TITLE
fix: Refactor fetching SW required permissions

### DIFF
--- a/webapp/src/components/AssetPage/RequiredPermissions/RequiredPermissions.container.ts
+++ b/webapp/src/components/AssetPage/RequiredPermissions/RequiredPermissions.container.ts
@@ -20,15 +20,16 @@ import {
 } from './RequiredPermissions.types'
 
 const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
-  const { id } = ownProps.asset
+  // Smart Wearables should always have a urn
+  const urn = ownProps.asset.urn as string
 
   return {
     isLoading: isLoadingType(
       getLoading(state),
       FETCH_SMART_WEARABLE_REQUIRED_PERMISSIONS_REQUEST
     ),
-    hasFetched: id in getData(state),
-    requiredPermissions: getRequiredPermissions(state, id)
+    hasFetched: urn in getData(state),
+    requiredPermissions: getRequiredPermissions(state, urn)
   }
 }
 

--- a/webapp/src/modules/asset/reducer.spec.ts
+++ b/webapp/src/modules/asset/reducer.spec.ts
@@ -17,7 +17,8 @@ const asset = {
     wearable: {
       isSmart: true
     }
-  }
+  },
+  urn: 'aUrn'
 } as Asset
 
 const anErrorMessage = 'An error'
@@ -102,7 +103,7 @@ describe.each([
     expect(assetReducer(initialState, successAction)).toEqual({
       ...INITIAL_STATE,
       loading: [],
-      data: { ...initialState.data, [asset.id]: [] }
+      data: { ...initialState.data, [asset.urn as string]: [] }
     })
   })
 })

--- a/webapp/src/modules/asset/reducer.ts
+++ b/webapp/src/modules/asset/reducer.ts
@@ -45,12 +45,13 @@ export function assetReducer(
 
     case FETCH_SMART_WEARABLE_REQUIRED_PERMISSIONS_SUCCESS: {
       const { asset, requiredPermissions } = action.payload
+      const urn = asset.urn as string // Smart Wearables should always have a urn
       return {
         ...state,
         loading: loadingReducer(state.loading, action),
         data: {
           ...state.data,
-          [asset.id]: requiredPermissions
+          [urn]: requiredPermissions
         },
         error: null
       }

--- a/webapp/src/modules/asset/selectors.spec.ts
+++ b/webapp/src/modules/asset/selectors.spec.ts
@@ -51,10 +51,10 @@ describe('when getting the loading state of the state', () => {
 })
 
 describe('when getting if the required permissions are being fetched', () => {
-  let id: string
+  let urn: string
 
   beforeEach(() => {
-    id = 'anAssetId'
+    urn = 'anAssetUrn'
     state.asset.loading = []
   })
 
@@ -64,7 +64,7 @@ describe('when getting if the required permissions are being fetched', () => {
     })
 
     it('should return false', () => {
-      expect(isFetchingRequiredPermissions(state, id)).toBe(false)
+      expect(isFetchingRequiredPermissions(state, urn)).toBe(false)
     })
   })
 
@@ -72,40 +72,40 @@ describe('when getting if the required permissions are being fetched', () => {
     beforeEach(() => {
       state.asset.loading = [
         fetchSmartWearableRequiredPermissionsRequest({
-          id: 'anotherItemId'
+          urn: 'anotherItemUrn'
         } as Asset)
       ]
     })
 
     it('should return false', () => {
-      expect(isFetchingRequiredPermissions(state, id)).toBe(false)
+      expect(isFetchingRequiredPermissions(state, urn)).toBe(false)
     })
   })
 
   describe('and it is being fetched', () => {
     beforeEach(() => {
       state.asset.loading.push(
-        fetchSmartWearableRequiredPermissionsRequest({ id } as Asset)
+        fetchSmartWearableRequiredPermissionsRequest({ urn } as Asset)
       )
     })
 
     it('should return true', () => {
-      expect(isFetchingRequiredPermissions(state, id)).toBe(true)
+      expect(isFetchingRequiredPermissions(state, urn)).toBe(true)
     })
   })
 })
 
 describe('when getting the required permissions of an asset', () => {
-  let id: string
+  let urn: string
   let requiredPermissions: string[]
 
   beforeEach(() => {
-    id = 'anAssetId'
+    urn = 'anAssetUrn'
   })
 
   describe('and there are no required permissions related to that asset', () => {
     it('should return the them ', () => {
-      expect(getRequiredPermissions(state, id)).toEqual([])
+      expect(getRequiredPermissions(state, urn)).toEqual([])
     })
   })
 
@@ -113,12 +113,12 @@ describe('when getting the required permissions of an asset', () => {
     beforeEach(() => {
       requiredPermissions = ['aPermission']
       state.asset.data = {
-        [id]: requiredPermissions
+        [urn]: requiredPermissions
       }
     })
 
     it('should return the them ', () => {
-      expect(getRequiredPermissions(state, id)).toEqual(state.asset.data[id])
+      expect(getRequiredPermissions(state, urn)).toEqual(state.asset.data[urn])
     })
   })
 })

--- a/webapp/src/modules/asset/selectors.ts
+++ b/webapp/src/modules/asset/selectors.ts
@@ -6,12 +6,13 @@ export const getData = (state: RootState) => getState(state).data
 export const getError = (state: RootState) => getState(state).error
 export const getLoading = (state: RootState) => getState(state).loading
 
-export const isFetchingRequiredPermissions = (state: RootState, id: string) =>
+export const isFetchingRequiredPermissions = (state: RootState, urn: string) =>
   getLoading(state).find(
     action =>
       action.type === FETCH_SMART_WEARABLE_REQUIRED_PERMISSIONS_REQUEST &&
-      action.payload.asset.id === id
+      action.payload.asset.urn === urn
   ) !== undefined
 
-export const getRequiredPermissions = (state: RootState, id: string) =>
-  getData(state)[id] || []
+export const getRequiredPermissions = (state: RootState, urn: string) => {
+  return getData(state)[urn] || []
+}

--- a/webapp/src/modules/asset/selectors.ts
+++ b/webapp/src/modules/asset/selectors.ts
@@ -13,6 +13,5 @@ export const isFetchingRequiredPermissions = (state: RootState, urn: string) =>
       action.payload.asset.urn === urn
   ) !== undefined
 
-export const getRequiredPermissions = (state: RootState, urn: string) => {
-  return getData(state)[urn] || []
-}
+export const getRequiredPermissions = (state: RootState, urn: string) =>
+  getData(state)[urn] || []


### PR DESCRIPTION
This PR refactors fetching SW requiredPermissions to use the urn instead of the item/token id