### PR TITLE
feat: Add profile dApp redirection

### DIFF
--- a/webapp/src/components/LinkedProfile/LinkedProfile.container.ts
+++ b/webapp/src/components/LinkedProfile/LinkedProfile.container.ts
@@ -1,0 +1,11 @@
+import { connect } from 'react-redux'
+import { RootState } from '../../modules/reducer'
+import { getIsProfileEnabled } from '../../modules/features/selectors'
+import { MapStateProps } from './LinkedProfile.types'
+import { LinkedProfile } from './LinkedProfile'
+
+const mapState = (state: RootState): MapStateProps => ({
+  isProfileEnabled: getIsProfileEnabled(state)
+})
+
+export default connect(mapState)(LinkedProfile)

--- a/webapp/src/components/LinkedProfile/LinkedProfile.tsx
+++ b/webapp/src/components/LinkedProfile/LinkedProfile.tsx
@@ -1,17 +1,20 @@
 import { Link } from 'react-router-dom'
 import { Profile } from 'decentraland-dapps/dist/containers'
+import { profileUrl } from '../../lib/environment'
 import { locations } from '../../modules/routing/locations'
-import { Props } from './LinkedProfile.types'
+import { Props, RedirectionProps } from './LinkedProfile.types'
 
-export const LinkedProfile = <T extends React.ElementType>(props: Props<T>) => {
-  const { address, className, browseOptions } = props
+export const LinkedProfile = ({ isProfileEnabled, ...props }: Props) => {
+  const { address, browseOptions } = props
+  const redirectionProps: RedirectionProps = isProfileEnabled
+    ? {
+        as: 'a',
+        href: `${profileUrl}/${address}`
+      }
+    : {
+        as: Link,
+        to: locations.account(address, browseOptions)
+      }
 
-  return (
-    <Profile
-      {...props}
-      className={className}
-      as={Link}
-      to={locations.account(address, browseOptions)}
-    />
-  )
+  return <Profile {...props} {...redirectionProps} />
 }

--- a/webapp/src/components/LinkedProfile/LinkedProfile.types.ts
+++ b/webapp/src/components/LinkedProfile/LinkedProfile.types.ts
@@ -1,7 +1,16 @@
 import { ProfileProps } from 'decentraland-ui/dist/components/Profile/Profile'
 import { BrowseOptions } from '../../modules/routing/types'
 
-export type Props<T extends React.ElementType> = ProfileProps<T> & {
+export type Props = ProfileProps<React.ElementType> & {
   className?: string
   browseOptions?: BrowseOptions
+  isProfileEnabled?: boolean
 }
+
+export type RedirectionProps = {
+  as: React.ElementType
+  to?: string
+  href?: string
+}
+
+export type MapStateProps = Pick<Props, 'isProfileEnabled'>

--- a/webapp/src/components/LinkedProfile/index.ts
+++ b/webapp/src/components/LinkedProfile/index.ts
@@ -1,1 +1,3 @@
-export { LinkedProfile } from './LinkedProfile'
+import LinkedProfile from './LinkedProfile.container'
+
+export { LinkedProfile }

--- a/webapp/src/config/env/dev.json
+++ b/webapp/src/config/env/dev.json
@@ -36,5 +36,6 @@
   "ENVIRONMENT": "development",
   "MIN_SALE_VALUE_IN_WEI": "1000000000000000000",
   "EXPLORER_URL": "https://play.decentraland.zone",
-  "MARKETPLACE_URL": "https://market.decentraland.zone"
+  "MARKETPLACE_URL": "https://market.decentraland.zone",
+  "PROFILE_URL": "https://profile.decentraland.zone"
 }

--- a/webapp/src/config/env/prod.json
+++ b/webapp/src/config/env/prod.json
@@ -36,5 +36,6 @@
   "ENVIRONMENT": "production",
   "MIN_SALE_VALUE_IN_WEI": "1000000000000000000",
   "EXPLORER_URL": "https://play.decentraland.org",
-  "MARKETPLACE_URL": "https://market.decentraland.org"
+  "MARKETPLACE_URL": "https://market.decentraland.org",
+  "PROFILE_URL": "https://profile.decentraland.org"
 }

--- a/webapp/src/config/env/stg.json
+++ b/webapp/src/config/env/stg.json
@@ -36,5 +36,6 @@
   "ENVIRONMENT": "staging",
   "MIN_SALE_VALUE_IN_WEI": "1000000000000000000",
   "EXPLORER_URL": "https://play.decentraland.org",
-  "MARKETPLACE_URL": "https://market.decentraland.today"
+  "MARKETPLACE_URL": "https://market.decentraland.today",
+  "PROFILE_URL": "https://profile.decentraland.today"
 }

--- a/webapp/src/lib/environment.ts
+++ b/webapp/src/lib/environment.ts
@@ -3,3 +3,4 @@ import { config } from '../config'
 export const environment = config.get('ENVIRONMENT')!
 export const peerUrl = config.get('PEER_URL')!
 export const builderUrl = config.get('BUILDER_URL')!
+export const profileUrl = config.get('PROFILE_URL')!

--- a/webapp/src/modules/features/selectors.spec.ts
+++ b/webapp/src/modules/features/selectors.spec.ts
@@ -17,6 +17,7 @@ import {
   getIsMapViewFiltersEnabled,
   getIsMarketplaceLaunchPopupEnabled,
   getIsPriceFilterEnabled,
+  getIsProfileEnabled,
   getIsRentalPeriodFilterEnabled,
   getIsRentalPriceFilterChartEnabled,
   isLoadingFeatureFlags
@@ -185,62 +186,69 @@ const waitForInitialLoadingSelectors = [
     name: 'IsRentalPriceFilterChart',
     feature: FeatureName.RENTAL_PRICE_FILTER_CHART,
     selector: getIsRentalPriceFilterChartEnabled
+  },
+  {
+    name: 'IsProfile',
+    app: ApplicationName.DAPPS,
+    feature: FeatureName.PROFILE,
+    selector: getIsProfileEnabled
   }
 ]
 
-waitForInitialLoadingSelectors.forEach(({ name, feature, selector }) =>
-  describe(`when getting if the ${name} feature flag is enabled`, () => {
-    describe('when the initial flags have not been yet loaded', () => {
-      beforeEach(() => {
-        hasLoadedInitialFlagsMock.mockReturnValueOnce(false)
-      })
-
-      it('should return false', () => {
-        const isEnabled = selector(state)
-
-        expect(isEnabled).toBe(false)
-        expect(getIsFeatureEnabledMock).not.toHaveBeenCalled()
-      })
-    })
-
-    describe('when the initial flags have not been yet loaded', () => {
-      beforeEach(() => {
-        hasLoadedInitialFlagsMock.mockReturnValueOnce(true)
-      })
-
-      describe('when the feature is not enabled', () => {
+waitForInitialLoadingSelectors.forEach(
+  ({ name, app = ApplicationName.MARKETPLACE, feature, selector }) =>
+    describe(`when getting if the ${name} feature flag is enabled`, () => {
+      describe('when the initial flags have not been yet loaded', () => {
         beforeEach(() => {
-          getIsFeatureEnabledMock.mockReturnValueOnce(false)
+          hasLoadedInitialFlagsMock.mockReturnValueOnce(false)
         })
 
         it('should return false', () => {
           const isEnabled = selector(state)
 
           expect(isEnabled).toBe(false)
-          expect(getIsFeatureEnabledMock).toHaveBeenCalledWith(
-            state,
-            ApplicationName.MARKETPLACE,
-            feature
-          )
+          expect(getIsFeatureEnabledMock).not.toHaveBeenCalled()
         })
       })
 
-      describe('when the feature is enabled', () => {
+      describe('when the initial flags have not been yet loaded', () => {
         beforeEach(() => {
-          getIsFeatureEnabledMock.mockReturnValueOnce(true)
+          hasLoadedInitialFlagsMock.mockReturnValueOnce(true)
         })
 
-        it('should return true', () => {
-          const isEnabled = selector(state)
+        describe('when the feature is not enabled', () => {
+          beforeEach(() => {
+            getIsFeatureEnabledMock.mockReturnValueOnce(false)
+          })
 
-          expect(isEnabled).toBe(true)
-          expect(getIsFeatureEnabledMock).toHaveBeenCalledWith(
-            state,
-            ApplicationName.MARKETPLACE,
-            feature
-          )
+          it('should return false', () => {
+            const isEnabled = selector(state)
+
+            expect(isEnabled).toBe(false)
+            expect(getIsFeatureEnabledMock).toHaveBeenCalledWith(
+              state,
+              app,
+              feature
+            )
+          })
+        })
+
+        describe('when the feature is enabled', () => {
+          beforeEach(() => {
+            getIsFeatureEnabledMock.mockReturnValueOnce(true)
+          })
+
+          it('should return true', () => {
+            const isEnabled = selector(state)
+
+            expect(isEnabled).toBe(true)
+            expect(getIsFeatureEnabledMock).toHaveBeenCalledWith(
+              state,
+              app,
+              feature
+            )
+          })
         })
       })
     })
-  })
 )

--- a/webapp/src/modules/features/selectors.ts
+++ b/webapp/src/modules/features/selectors.ts
@@ -173,3 +173,14 @@ export const getIsHandsCategoryFTUEnabled = (state: RootState) => {
   }
   return false
 }
+
+export const getIsProfileEnabled = (state: RootState) => {
+  if (hasLoadedInitialFlags(state)) {
+    return getIsFeatureEnabled(
+      state,
+      ApplicationName.DAPPS,
+      FeatureName.PROFILE
+    )
+  }
+  return false
+}

--- a/webapp/src/modules/features/types.ts
+++ b/webapp/src/modules/features/types.ts
@@ -14,5 +14,6 @@ export enum FeatureName {
   MAP_VIEW_FILTERS = 'map-view-filters',
   RENTAL_PRICE_FILTER_CHART = 'rental-price-fitler-chart',
   HANDS_CATEGORY = 'hands-category',
-  HANDS_CATEGORY_FTU = 'hands-category-ftu'
+  HANDS_CATEGORY_FTU = 'hands-category-ftu',
+  PROFILE = 'profile'
 }

--- a/webapp/src/modules/sagas.ts
+++ b/webapp/src/modules/sagas.ts
@@ -94,7 +94,11 @@ export function* rootSaga(getIdentity: () => AuthIdentity | undefined) {
     marketplaceAnalyticsSagas(),
     featuresSaga({
       polling: {
-        apps: [ApplicationName.MARKETPLACE, ApplicationName.BUILDER],
+        apps: [
+          ApplicationName.MARKETPLACE,
+          ApplicationName.BUILDER,
+          ApplicationName.DAPPS
+        ],
         delay: 60000 /** 60 seconds */
       }
     }),


### PR DESCRIPTION
This PR updates the LinkedProfile component to redirect to the profile dApp when the FF: `dapps-profile` is enabled.

Closes https://github.com/decentraland/profile/issues/73