### PR TITLE
fix: Show SmartWearables video showcase

### DIFF
--- a/webapp/src/components/AssetImage/AssetImage.tsx
+++ b/webapp/src/components/AssetImage/AssetImage.tsx
@@ -125,7 +125,11 @@ const AssetImage = (props: Props) => {
     async (action: ControlOptionAction) => {
       const ZOOM_DELTA = 0.03
 
-      if (ControlOptionAction.PLAY_SMART_WEARABLE_VIDEO_SHOWCASE && asset) {
+      if (
+        ControlOptionAction.PLAY_SMART_WEARABLE_VIDEO_SHOWCASE &&
+        asset &&
+        asset.data.wearable?.isSmart
+      ) {
         return onPlaySmartWearableVideoShowcase(asset)
       }
 


### PR DESCRIPTION
This PR fixes the button `Play Emote` opening the VideoShowcase modal

Error:
https://github.com/decentraland/marketplace/assets/3170051/4b61433f-2ca2-48fb-83e8-375fb8613f8e

Fix:
https://github.com/decentraland/marketplace/assets/3170051/cd201d2d-14a9-476c-86fd-0117b5c193cd

