### PR TITLE
fix: wait for identity success action before fetching catalog

### DIFF
--- a/webapp/src/modules/item/sagas.spec.ts
+++ b/webapp/src/modules/item/sagas.spec.ts
@@ -3,6 +3,7 @@ import { expectSaga } from 'redux-saga-test-plan'
 import * as matchers from 'redux-saga-test-plan/matchers'
 import { call, select, take } from 'redux-saga/effects'
 import { ChainId, Item, Network, Rarity } from '@dcl/schemas'
+import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { sendTransaction } from 'decentraland-dapps/dist/modules/wallet/utils'
 import { setPurchase } from 'decentraland-dapps/dist/modules/gateway/actions'
 import { TradeType } from 'decentraland-dapps/dist/modules/gateway/transak/types'
@@ -47,7 +48,7 @@ import {
   fetchCollectionItemsFailure,
   FETCH_ITEMS_CANCELLED_ERROR_MESSAGE
 } from './actions'
-import { itemSaga } from './sagas'
+import { CANCEL_FETCH_ITEMS, itemSaga } from './sagas'
 import { getData as getItems } from './selectors'
 import { getItem } from './utils'
 import { ItemBrowseOptions } from './types'
@@ -418,62 +419,128 @@ describe('when handling the fetch items request action', () => {
         pathname = locations.browse()
       })
       describe('and there is an ongoing fetch item request', () => {
+        let wallet: Wallet | undefined
         let originalBrowseOptions = itemBrowseOptions
         let newBrowseOptions: ItemBrowseOptions = {
           ...itemBrowseOptions,
           filters: { ...itemBrowseOptions.filters, rarities: [Rarity.COMMON] }
         }
-        it('should dispatch a successful action with the fetched items and cancel the ongoing one', () => {
-          return expectSaga(itemSaga, getIdentity)
-            .provide([
-              [
-                matchers.call.fn(waitForWalletConnectionIfConnecting),
-                undefined
-              ],
-              [matchers.call.fn(waitForFeatureFlagsToBeLoaded), undefined],
-              [select(getIsMarketplaceServerEnabled), true],
-              [select(getLocation), { pathname }],
-              {
-                call(effect, next) {
-                  if (
-                    effect.fn === CatalogAPI.prototype.get &&
-                    effect.args[0] === originalBrowseOptions.filters
-                  ) {
-                    // Add a setTimeout so it gives time to get it cancelled
-                    return new Promise(() => {})
+        describe('and there is a wallet connected', () => {
+          beforeEach(() => {
+            wallet = {} as Wallet
+          })
+
+          it('should dispatch a successful action with the fetched items and cancel the ongoing one', () => {
+            return expectSaga(itemSaga, getIdentity)
+              .provide([
+                [
+                  matchers.call.fn(waitForWalletConnectionIfConnecting),
+                  undefined
+                ],
+                [matchers.call.fn(waitForFeatureFlagsToBeLoaded), undefined],
+                [select(getWallet), wallet],
+                [select(getIsMarketplaceServerEnabled), true],
+                [select(getLocation), { pathname }],
+                {
+                  call(effect, next) {
+                    if (
+                      effect.fn === CatalogAPI.prototype.get &&
+                      effect.args[0] === originalBrowseOptions.filters
+                    ) {
+                      // Add a setTimeout so it gives time to get it cancelled
+                      return new Promise(() => {})
+                    }
+                    if (
+                      effect.fn === CatalogAPI.prototype.get &&
+                      effect.args[0] === newBrowseOptions.filters
+                    ) {
+                      // Mock without timeout
+                      return fetchResult
+                    }
+                    return next()
                   }
-                  if (
-                    effect.fn === CatalogAPI.prototype.get &&
-                    effect.args[0] === newBrowseOptions.filters
-                  ) {
-                    // Mock without timeout
-                    return fetchResult
-                  }
-                  return next()
                 }
-              }
-            ])
-            .call.like({
-              fn: CatalogAPI.prototype.get,
-              args: [newBrowseOptions.filters]
-            })
-            .put(
-              fetchItemsFailure(
-                FETCH_ITEMS_CANCELLED_ERROR_MESSAGE,
-                originalBrowseOptions
+              ])
+              .call.like({
+                fn: CatalogAPI.prototype.get,
+                args: [newBrowseOptions.filters]
+              })
+              .put(
+                fetchItemsFailure(
+                  FETCH_ITEMS_CANCELLED_ERROR_MESSAGE,
+                  originalBrowseOptions
+                )
               )
-            )
-            .put(
-              fetchItemsSuccess(
-                fetchResult.data,
-                fetchResult.total,
-                newBrowseOptions,
-                nowTimestamp
+              .put(
+                fetchItemsSuccess(
+                  fetchResult.data,
+                  fetchResult.total,
+                  newBrowseOptions,
+                  nowTimestamp
+                )
               )
-            )
-            .dispatch(fetchItemsRequest(originalBrowseOptions))
-            .dispatch(fetchItemsRequest(newBrowseOptions))
-            .run({ silenceTimeout: true })
+              .dispatch(fetchItemsRequest(originalBrowseOptions))
+              .dispatch({ type: CANCEL_FETCH_ITEMS })
+              .dispatch(fetchItemsRequest(newBrowseOptions))
+              .run({ silenceTimeout: true })
+          })
+        })
+
+        describe('and there is no wallet connected', () => {
+          it('should dispatch a successful action with the fetched items and cancel the ongoing one', () => {
+            return expectSaga(itemSaga, getIdentity)
+              .provide([
+                [
+                  matchers.call.fn(waitForWalletConnectionIfConnecting),
+                  undefined
+                ],
+                [matchers.call.fn(waitForFeatureFlagsToBeLoaded), undefined],
+                [select(getWallet), wallet],
+                [select(getIsMarketplaceServerEnabled), true],
+                [select(getLocation), { pathname }],
+                {
+                  call(effect, next) {
+                    if (
+                      effect.fn === CatalogAPI.prototype.get &&
+                      effect.args[0] === originalBrowseOptions.filters
+                    ) {
+                      // Add a setTimeout so it gives time to get it cancelled
+                      return new Promise(() => {})
+                    }
+                    if (
+                      effect.fn === CatalogAPI.prototype.get &&
+                      effect.args[0] === newBrowseOptions.filters
+                    ) {
+                      // Mock without timeout
+                      return fetchResult
+                    }
+                    return next()
+                  }
+                }
+              ])
+              .call.like({
+                fn: CatalogAPI.prototype.get,
+                args: [newBrowseOptions.filters]
+              })
+              .put(
+                fetchItemsFailure(
+                  FETCH_ITEMS_CANCELLED_ERROR_MESSAGE,
+                  originalBrowseOptions
+                )
+              )
+              .put(
+                fetchItemsSuccess(
+                  fetchResult.data,
+                  fetchResult.total,
+                  newBrowseOptions,
+                  nowTimestamp
+                )
+              )
+              .dispatch(fetchItemsRequest(originalBrowseOptions))
+              .dispatch({ type: CANCEL_FETCH_ITEMS })
+              .dispatch(fetchItemsRequest(newBrowseOptions))
+              .run({ silenceTimeout: true })
+          })
         })
       })
     })
@@ -488,6 +555,7 @@ describe('when handling the fetch items request action', () => {
             [matchers.call.fn(CatalogAPI.prototype.get), fetchResult],
             [matchers.call.fn(waitForWalletConnectionIfConnecting), undefined],
             [matchers.call.fn(waitForFeatureFlagsToBeLoaded), undefined],
+            [select(getWallet), undefined],
             [select(getLocation), { pathname }],
             [select(getIsMarketplaceServerEnabled), false]
           ])
@@ -511,6 +579,7 @@ describe('when handling the fetch items request action', () => {
         .provide([
           [select(getLocation), { pathname: '' }],
           [select(getIsMarketplaceServerEnabled), true],
+          [select(getWallet), undefined],
           [matchers.call.fn(CatalogAPI.prototype.get), Promise.reject(anError)],
           [matchers.call.fn(waitForWalletConnectionIfConnecting), undefined],
           [matchers.call.fn(waitForFeatureFlagsToBeLoaded), undefined]


### PR DESCRIPTION
- This PR fixes the race condition given by the fact that the `getIdentity` fn is not sync, so it can happen that the Fetch Items Request is triggered before getting the identity, so it gets triggered without being signed.