### PR TITLE
fix: Remove sourcemap generation for now

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -82,7 +82,7 @@
   "scripts": {
     "start": "react-app-rewired start",
     "prebuild": "node scripts/prebuild.js",
-    "build": "CI=false react-scripts build && npm run sentry:sourcemaps",
+    "build": "CI=false react-scripts build",
     "test": "react-app-rewired test",
     "test:coverage": "npm run test -- --coverage",
     "eject": "react-app-rewired eject",


### PR DESCRIPTION
We are not using the source maps in Sentry yet. I removed the generation from the build script and I'll work on it later.