### PR TITLE
fix: Can't select section to load in My Assets

### DIFF
--- a/webapp/src/components/AssetBrowse/AssetBrowse.tsx
+++ b/webapp/src/components/AssetBrowse/AssetBrowse.tsx
@@ -270,7 +270,7 @@ const AssetBrowse = (props: Props) => {
                   key={key}
                   active={section === value}
                   onClick={
-                    section === Sections.decentraland.COLLECTIONS
+                    value === Sections.decentraland.COLLECTIONS
                       ? () =>
                           changeFilter(
                             'section',


### PR DESCRIPTION
This PR fixes an issue that prevented users from selecting a section in the My Assets page while on mobile.