### PR TITLE
fix: Claim Name button styles

### DIFF
--- a/webapp/src/components/ClaimYourName/ClaimYourName.module.css
+++ b/webapp/src/components/ClaimYourName/ClaimYourName.module.css
@@ -46,8 +46,14 @@
   background: #242129;
   border-radius: 14.482757568359375px;
   display: flex;
+  justify-content: space-between;
   align-items: center;
   padding: 0 33px 0 15px;
+}
+
+.imgTitleAndTextContainer {
+  display: flex;
+  align-items: center;
 }
 
 .img {

--- a/webapp/src/components/ClaimYourName/ClaimYourName.tsx
+++ b/webapp/src/components/ClaimYourName/ClaimYourName.tsx
@@ -16,20 +16,22 @@ const ClaimYourName = () => {
   return (
     <div className={styles.gradient}>
       <div className={styles.container}>
-        <img
-          className={styles.img}
-          src={claimYourOwnNameImg}
-          alt="Claim your own name"
-        ></img>
-        <div>
-          <h4 className={styles.title}>{t('claim_your_own_name.title')}</h4>
-          <div className={styles.text}>
-            <T
-              id="claim_your_own_name.text"
-              values={{
-                mana: <Mana size="small">100</Mana>
-              }}
-            />
+        <div className={styles.imgTitleAndTextContainer}>
+          <img
+            className={styles.img}
+            src={claimYourOwnNameImg}
+            alt="Claim your own name"
+          ></img>
+          <div>
+            <h4 className={styles.title}>{t('claim_your_own_name.title')}</h4>
+            <div className={styles.text}>
+              <T
+                id="claim_your_own_name.text"
+                values={{
+                  mana: <Mana size="small">100</Mana>
+                }}
+              />
+            </div>
           </div>
         </div>
         <Button


### PR DESCRIPTION
The claim name button looked like this on bigger screens:

<img width="1486" alt="Screenshot 2023-09-15 at 00 51 23" src="https://github.com/decentraland/marketplace/assets/24811313/74077359-7787-4365-b991-c307eb8d52fe">

Fixed it to look like this:

<img width="1480" alt="Screenshot 2023-09-15 at 00 50 20" src="https://github.com/decentraland/marketplace/assets/24811313/1e337438-4a7d-4318-8b7a-87370d27d9b4">
