### PR TITLE
fix: Expand the only smart section by default in the current account sidebar

### DIFF
--- a/webapp/src/components/AccountSidebar/CurrentAccountSidebar/CurrentAccountSidebar.tsx
+++ b/webapp/src/components/AccountSidebar/CurrentAccountSidebar/CurrentAccountSidebar.tsx
@@ -84,7 +84,7 @@ const CurrentAccountSidebar = ({ section, onBrowse }: Props) => {
       <AssetFilters
         defaultCollapsed={{
           [AssetFilter.Status]: true,
-          [AssetFilter.OnlySmart]: true,
+          [AssetFilter.OnlySmart]: false,
           [AssetFilter.Rarity]: true,
           [AssetFilter.Price]: true,
           [AssetFilter.Collection]: true,


### PR DESCRIPTION
Previous:
![image](https://github.com/decentraland/marketplace/assets/31735779/cfee0db7-389e-47af-8c61-f67e96c010e4)

Now:
<img width="1205" alt="image" src="https://github.com/decentraland/marketplace/assets/31735779/ed2f5bf0-9e32-41ee-b6fc-5ff2609f62a7">

