### PR TITLE
feat: add default wearables back

### DIFF
--- a/webapp/src/components/AssetImage/AssetImage.tsx
+++ b/webapp/src/components/AssetImage/AssetImage.tsx
@@ -353,7 +353,6 @@ const AssetImage = (props: Props) => {
               emote={isTryingOnEnabled ? previewEmote : undefined}
               onLoad={handleLoad}
               onError={handleError}
-              disableDefaultWearables
               {...wearablePreviewProps}
               dev={config.is(Env.DEVELOPMENT)}
             />
@@ -559,7 +558,6 @@ const AssetImage = (props: Props) => {
               onLoad={handleLoad}
               onError={handleError}
               dev={config.is(Env.DEVELOPMENT)}
-              disableDefaultWearables
             />
             {isAvailableForMint && !isOwnerOfNFT ? (
               <AvailableForMintPopup


### PR DESCRIPTION
Remove `disableDefaultWearables` property as the usecase was already added on the wearable-preview side and this is causing emotes for not logged in users to appear without any clothes