### PR TITLE
fix: emote 2.0 filter pills

### DIFF
--- a/webapp/src/modules/routing/selectors.ts
+++ b/webapp/src/modules/routing/selectors.ts
@@ -623,7 +623,9 @@ export const hasFiltersEnabled = createSelector<
     creators,
     rentalDays,
     status,
-    onlySmart
+    onlySmart,
+    emoteHasGeometry,
+    emoteHasSound
   } = browseOptions
   const isLand = isLandSection(section as Section)
 
@@ -665,6 +667,8 @@ export const hasFiltersEnabled = createSelector<
     !!minPrice ||
     !!maxPrice ||
     hasNotOnSaleFilter ||
+    emoteHasSound ||
+    emoteHasGeometry ||
     (!!status && status !== AssetStatusFilter.ON_SALE)
   )
 })

--- a/webapp/src/modules/routing/utils.ts
+++ b/webapp/src/modules/routing/utils.ts
@@ -121,7 +121,9 @@ export function getClearedBrowseOptions(
     'adjacentToRoad',
     'creators',
     'rentalDays',
-    'status'
+    'status',
+    'emoteHasSound',
+    'emoteHasGeometry'
   ]
 
   const clearedBrowseOptions = fillWithUndefined


### PR DESCRIPTION
Fix pills not appearing when the only filter is by props or sound
Fix "Clear all filters" so that it removes emoteHasSound and emoteHasGeometry properties from filters too