### PR TITLE
fix: Container width and navbar full-width

### DIFF
--- a/webapp/src/components/HomePage/Slideshow/Slideshow.css
+++ b/webapp/src/components/HomePage/Slideshow/Slideshow.css
@@ -21,7 +21,7 @@
 }
 
 .Slideshow .assets.full-width {
-  justify-content: center;
+  justify-content: space-between;
 }
 
 /* Hide scrollbar for Chrome, Safari and Opera */
@@ -183,7 +183,7 @@
     flex-direction: row;
     align-items: center;
   }
-  
+
   .Slideshow .ItemsSection {
     display: flex;
     align-items: center;

--- a/webapp/src/index.css
+++ b/webapp/src/index.css
@@ -38,7 +38,8 @@ code {
 .AssetBrowse .ui.container,
 .Navigation .ui.container,
 .dcl.navbar.fullscreen .ui.container,
-.dcl.footer.ui.container {
+.dcl.footer.ui.container,
+.dui-navbar2 > .ui.container {
   width: 100vw;
   box-sizing: border-box;
   max-width: 100% !important;
@@ -54,6 +55,7 @@ code {
 
 .ui.container {
   width: 100%;
+  max-width: 1360px !important;
 }
 
 .dcl.toast .toast-info .body .ui.basic.button.no-padding {


### PR DESCRIPTION
This PR fixes the space between components in ultra-wide screens.

The `max-width` was removed from the containers in this previous [PR](https://github.com/decentraland/marketplace/pull/2090/files#diff-53c401ad1b9e0890ce8feea1af4aa5003516508ae4b2da8e9b3e7ad14518df0aL57)

bug:
![image](https://github.com/decentraland/marketplace/assets/3170051/ae44f8d4-b82e-4a32-8eb8-7a7d32b6d83f)

fixed:
<img width="1728" alt="image" src="https://github.com/decentraland/marketplace/assets/3170051/b5458746-1e38-4a14-a5bb-a223b9e50779">

Fixes: https://github.com/decentraland/dapps-issues/issues/119