### PR TITLE
feat: add logic to track both chains txs

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -28,7 +28,7 @@
         "decentraland-connect": "^6.2.0",
         "decentraland-crypto-fetch": "^1.0.3",
         "decentraland-dapps": "^18.5.0",
-        "decentraland-transactions": "^2.1.2",
+        "decentraland-transactions": "^2.2.0",
         "decentraland-ui": "^5.8.0",
         "ethers": "^5.6.8",
         "graphql": "^14.7.0",
@@ -11343,9 +11343,9 @@
       }
     },
     "node_modules/decentraland-transactions": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-2.1.2.tgz",
-      "integrity": "sha512-vc1PCFKIwLo+RBBegLqNYAqAY5dEjSln6utSsmatMG7jn4UJDVYkJqscUNhYnz6OC2BgFXcdbDkJiUr0ImQE3w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-2.2.0.tgz",
+      "integrity": "sha512-+QYkvg4UvFmoE90upJY4WRhHKSmp5gKNIaTEHWQhk/5jJ/Gv40bLAEaaQxA2uWS9n/lt2q4rKlR/1tf07f/ibA==",
       "dependencies": {
         "@0xsquid/sdk": "^2.8.9",
         "@0xsquid/squid-types": "^0.1.51",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -23,7 +23,7 @@
     "decentraland-connect": "^6.2.0",
     "decentraland-crypto-fetch": "^1.0.3",
     "decentraland-dapps": "^18.5.0",
-    "decentraland-transactions": "^2.1.2",
+    "decentraland-transactions": "^2.2.0",
     "decentraland-ui": "^5.8.0",
     "ethers": "^5.6.8",
     "graphql": "^14.7.0",

--- a/webapp/src/components/SuccessPage/SuccessPage.container.ts
+++ b/webapp/src/components/SuccessPage/SuccessPage.container.ts
@@ -14,12 +14,22 @@ import { SuccessPage } from './SuccessPage'
 
 const mapState = (state: RootState): MapStateProps => {
   const search = new URLSearchParams(getSearch(state))
+  const isCrossChain = search.get('isCrossChain') === 'true'
   const transaction = getTransaction(state, search.get('txHash') || '')
+  const destinationTx = isCrossChain
+    ? getTransaction(state, search.get('destinationTxHash') || '')
+    : null
   const address = getAddress(state)
+  const isLoadingTx = Boolean(
+    transaction && transaction.status !== TransactionStatus.CONFIRMED
+  )
+  const isDestinationTxLoading = Boolean(
+    destinationTx && destinationTx.status !== TransactionStatus.CONFIRMED
+  )
   return {
-    isLoading: Boolean(
-      transaction && transaction.status !== TransactionStatus.CONFIRMED
-    ),
+    isLoading: isCrossChain
+      ? isLoadingTx || isDestinationTxLoading
+      : isLoadingTx,
     mintedTokenId: getTokenIdFromLogs(
       ChainId.MATIC_MUMBAI,
       transaction?.receipt?.logs

--- a/webapp/src/modules/item/actions.ts
+++ b/webapp/src/modules/item/actions.ts
@@ -114,6 +114,7 @@ export type BuyItemSuccessAction = ReturnType<typeof buyItemSuccess>
 export type BuyItemFailureAction = ReturnType<typeof buyItemFailure>
 
 // Buy Item Cross Chain
+export const TRACK_CROSS_CHAIN_TX_REQUEST = '[Request] Track Buy item cross-chain tx'
 export const BUY_ITEM_CROSS_CHAIN_REQUEST = '[Request] Buy item cross-chain'
 export const BUY_ITEM_CROSS_CHAIN_SUCCESS = '[Success] Buy item cross-chain'
 export const BUY_ITEM_CROSS_CHAIN_FAILURE = '[Failure] Buy item cross-chain'
@@ -140,6 +141,14 @@ export const buyItemCrossChainSuccess = (
       name: getAssetName(item),
       price: formatWeiMANA(order?.price ?? item.price)
     })
+  })
+
+  export const trackCrossChainTx = (
+  chainId: ChainId,
+  txHash: string,
+) =>
+  action(TRACK_CROSS_CHAIN_TX_REQUEST, {
+    ...buildTransactionWithReceiptPayload(chainId, txHash )
   })
 
 export const buyItemCrossChainFailure = (

--- a/webapp/src/modules/item/sagas.ts
+++ b/webapp/src/modules/item/sagas.ts
@@ -309,7 +309,6 @@ export function* itemSaga(getIdentity: () => AuthIdentity | undefined) {
       let status: StatusResponse | undefined
       const crossChainProvider = new AxelarProvider(config.get('SQUID_API_URL'))
       const destinationChain = Number(route.route.params.toChain) as ChainId
-      console.log('destinationChain: ', destinationChain)
       while (!status || !status?.toChain?.transactionId) {
         // wrapping in try-catch since it throws an error if the tx is not found (the first seconds after triggering it)
         try {

--- a/webapp/src/modules/item/sagas.ts
+++ b/webapp/src/modules/item/sagas.ts
@@ -1,18 +1,19 @@
 import { matchPath } from 'react-router-dom'
-import { getLocation } from 'connected-react-router'
+import { getLocation, push } from 'connected-react-router'
 import { SagaIterator } from 'redux-saga'
 import { put, takeEvery } from '@redux-saga/core/effects'
 import {
   call,
   cancel,
   cancelled,
+  delay,
   fork,
   race,
   select,
   take
 } from 'redux-saga/effects'
 import { ethers } from 'ethers'
-import { Item } from '@dcl/schemas'
+import { ChainId, Item } from '@dcl/schemas'
 import { getConnectedProvider } from 'decentraland-dapps/dist/lib/eth'
 import { ContractName, getContract } from 'decentraland-transactions'
 import { Provider } from 'decentraland-connect'
@@ -26,7 +27,10 @@ import {
 import { isNFTPurchase } from 'decentraland-dapps/dist/modules/gateway/utils'
 import { PurchaseStatus } from 'decentraland-dapps/dist/modules/gateway/types'
 import { isErrorWithMessage } from '../../lib/error'
-import { AxelarProvider } from 'decentraland-transactions/crossChain'
+import {
+  AxelarProvider,
+  StatusResponse
+} from 'decentraland-transactions/crossChain'
 import { config } from '../../config'
 import { ItemAPI } from '../vendor/decentraland/item/api'
 import { getWallet } from '../wallet/selectors'
@@ -74,9 +78,13 @@ import {
   BuyItemCrossChainRequestAction,
   BUY_ITEM_CROSS_CHAIN_REQUEST,
   buyItemCrossChainSuccess,
-  buyItemCrossChainFailure
+  buyItemCrossChainFailure,
+  BUY_ITEM_CROSS_CHAIN_SUCCESS,
+  BuyItemCrossChainSuccessAction,
+  trackCrossChainTx
 } from './actions'
 import { getData as getItems } from './selectors'
+import { AssetType } from '../asset/types'
 import { getItem } from './utils'
 
 export const NFT_SERVER_URL = config.get('NFT_SERVER_URL')!
@@ -103,6 +111,7 @@ export function* itemSaga(getIdentity: () => AuthIdentity | undefined) {
   yield takeEvery(FETCH_TRENDING_ITEMS_REQUEST, handleFetchTrendingItemsRequest)
   yield takeEvery(BUY_ITEM_REQUEST, handleBuyItem)
   yield takeEvery(BUY_ITEM_CROSS_CHAIN_REQUEST, handleBuyItemCrossChain)
+  yield takeEvery(BUY_ITEM_CROSS_CHAIN_SUCCESS, handleBuyItemCrossChainSuccess)
   yield takeEvery(BUY_ITEM_WITH_CARD_REQUEST, handleBuyItemWithCardRequest)
   yield takeEvery(SET_PURCHASE, handleSetItemPurchaseWithCard)
   yield takeEvery(FETCH_ITEM_REQUEST, handleFetchItemRequest)
@@ -288,6 +297,54 @@ export function* itemSaga(getIdentity: () => AuthIdentity | undefined) {
     }
   }
 
+  function* handleBuyItemCrossChainSuccess(
+    action: BuyItemCrossChainSuccessAction
+  ) {
+    const { route, item, order, txHash } = action.payload
+    // if it's an actual cross-chain interaction, we need to get the tx hash in the destination chain
+    if (
+      route.requestId &&
+      route.route.params.fromChain !== route.route.params.toChain
+    ) {
+      let status: StatusResponse | undefined
+      const crossChainProvider = new AxelarProvider(config.get('SQUID_API_URL'))
+      const destinationChain = Number(route.route.params.toChain) as ChainId
+      console.log('destinationChain: ', destinationChain)
+      while (!status || !status?.toChain?.transactionId) {
+        // wrapping in try-catch since it throws an error if the tx is not found (the first seconds after triggering it)
+        try {
+          status = yield call(
+            [crossChainProvider, 'getStatus'],
+            route.requestId,
+            txHash
+          )
+        } catch (error) {
+          console.error('error: ', error)
+        }
+        yield delay(1000)
+      }
+      if (status?.toChain?.transactionId) {
+        yield put(
+          trackCrossChainTx(destinationChain, status?.toChain?.transactionId)
+        )
+        yield put(
+          push(
+            locations.success({
+              txHash,
+              destinationTxHash: status?.toChain?.transactionId,
+              tokenId: item.itemId,
+              assetType: order ? AssetType.NFT : AssetType.ITEM,
+              contractAddress: order
+                ? order.contractAddress
+                : item.contractAddress,
+              isCrossChain: ('route' in action.payload).toString()
+            })
+          )
+        )
+      }
+    }
+  }
+
   function* handleBuyItemCrossChain(action: BuyItemCrossChainRequestAction) {
     const { item, route, order } = action.payload
     try {
@@ -303,7 +360,7 @@ export function* itemSaga(getIdentity: () => AuthIdentity | undefined) {
         const crossChainProvider = new AxelarProvider(
           config.get('SQUID_API_URL')
         )
-        const txRespose: ethers.providers.TransactionReceipt = yield call(
+        const txResponse: ethers.providers.TransactionReceipt = yield call(
           [crossChainProvider, 'executeRoute'],
           route,
           provider
@@ -312,8 +369,8 @@ export function* itemSaga(getIdentity: () => AuthIdentity | undefined) {
         yield put(
           buyItemCrossChainSuccess(
             route,
-            item.chainId,
-            txRespose.transactionHash,
+            Number(route.route.params.fromChain),
+            txResponse.transactionHash,
             item,
             order
           )

--- a/webapp/src/modules/routing/locations.ts
+++ b/webapp/src/modules/routing/locations.ts
@@ -132,6 +132,8 @@ export const locations = {
     assetType: string
     contractAddress: string
     subdomain?: string
+    isCrossChain?: string
+    destinationTxHash?: string
   }) =>
     `/success${
       searchOptions ? `?${new URLSearchParams(searchOptions).toString()}` : ''


### PR DESCRIPTION
This PR adds the logic to:
- Track both txs when is a reall cross-chain purchase (not only cross-token)