### PR TITLE
fix: add nft network to mana buy modal trigger

### DIFF
--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.container.ts
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.container.ts
@@ -1,6 +1,5 @@
 import { connect } from 'react-redux'
 import { Dispatch } from 'redux'
-import { Network } from '@dcl/schemas'
 import { switchNetworkRequest } from 'decentraland-dapps/dist/modules/wallet/actions'
 import { openBuyManaWithFiatModalRequest } from 'decentraland-dapps/dist/modules/gateway/actions'
 import { isSwitchingNetwork } from 'decentraland-dapps/dist/modules/wallet/selectors'
@@ -8,7 +7,11 @@ import { isSwitchingNetwork } from 'decentraland-dapps/dist/modules/wallet/selec
 import { RootState } from '../../../modules/reducer'
 import { getWallet } from '../../../modules/wallet/selectors'
 import { getIsBuyWithCardPage } from '../../../modules/routing/selectors'
-import { MapDispatchProps, MapStateProps } from './BuyWithCryptoModal.types'
+import {
+  MapDispatchProps,
+  MapStateProps,
+  OwnProps
+} from './BuyWithCryptoModal.types'
 import { BuyWithCryptoModal } from './BuyWithCryptoModal'
 
 const mapState = (state: RootState): MapStateProps => {
@@ -19,8 +22,12 @@ const mapState = (state: RootState): MapStateProps => {
   }
 }
 
-const mapDispatch = (dispatch: Dispatch): MapDispatchProps => ({
-  onGetMana: () => dispatch(openBuyManaWithFiatModalRequest(Network.MATIC)),
+const mapDispatch = (
+  dispatch: Dispatch,
+  ownProps: OwnProps
+): MapDispatchProps => ({
+  onGetMana: () =>
+    dispatch(openBuyManaWithFiatModalRequest(ownProps.metadata.asset.network)),
   onSwitchNetwork: chainId => dispatch(switchNetworkRequest(chainId))
 })
 

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.tsx
@@ -310,7 +310,7 @@ export const BuyWithCryptoModal = (props: Props) => {
               canBuy = canPayForGas && balance > Number(fromAmount)
               if (!canBuy) {
                 setInsufficientToken(
-                  !canPayForGas ? routeFeeCost.token : selectedToken,
+                  balance < Number(fromAmount) ? selectedToken : routeFeeCost.token
                 )
               }
             }
@@ -536,6 +536,7 @@ export const BuyWithCryptoModal = (props: Props) => {
         abortControllerRef.current = new AbortController()
         analytics.track(events.CROSS_CHAIN_TOKEN_SELECTION, {
           selectedToken,
+          category: asset.category
         })
       } else {
         setSelectedChain(Number(selectedOption.chainId) as ChainId)


### PR DESCRIPTION
This PR fixes:
- Add logic to buy the MANA of the network which the NFT belongs
- Show insufficient selected token first instead of the gas one.
![image](https://github.com/decentraland/marketplace/assets/8763687/e30b8d3a-f4cd-466c-8db9-e6597eeb43ae)


![image](https://github.com/decentraland/marketplace/assets/8763687/24b3d0f1-2577-4e32-9e60-6abca1fcb4b8)
