### PR TITLE
fix: naming convention rule accept PascalCase

### DIFF
--- a/webapp/.eslintrc.cjs
+++ b/webapp/.eslintrc.cjs
@@ -12,7 +12,13 @@ module.exports = {
       extends: ['plugin:@typescript-eslint/recommended', 'plugin:@typescript-eslint/recommended-requiring-type-checking', 'prettier'],
       rules: {
         '@typescript-eslint/no-unsafe-return': 'off', // TODO: migrate code progressively to remove this line. https://typescript-eslint.io/rules/no-unsafe-return
-        '@typescript-eslint/naming-convention': 'off', // TODO: migrate code progressively to remove this line. https://typescript-eslint.io/rules/naming-convention/
+        '@typescript-eslint/naming-convention': [
+          'error',
+          {
+            selector: 'function',
+            format: ['PascalCase', 'camelCase']
+          }
+        ],
         '@typescript-eslint/ban-ts-comment': 'off', // TODO: migrate code progressively to remove this line. https://typescript-eslint.io/rules/ban-ts-comment
         '@typescript-eslint/no-unsafe-assignment': 'off', // TODO: migrate code progressively to remove this line. https://typescript-eslint.io/rules/no-unsafe-assignment/
         '@typescript-eslint/no-unsafe-call': 'off', // TODO: migrate code progressively to remove this line. https://typescript-eslint.io/rules/no-unsafe-call/

--- a/webapp/src/modules/routing/search.ts
+++ b/webapp/src/modules/routing/search.ts
@@ -446,7 +446,7 @@ export function getURLParamArray<T extends string>(search: string, paramName: st
 // from the URL are parsed from rarities=common_uncommon instead of
 // rarities=common&rarities=uncommon I'll leave it as it is for now to prevent
 // further refactoring but should be changed in the future.
-export function getURLParamArray_nonStandard<T extends string>(search: string, paramName: string, validValues: string[] = []) {
+export function getURLParamArrayNonStandard<T extends string>(search: string, paramName: string, validValues: string[] = []) {
   const param = getURLParam<T>(search, paramName)
   return param === null ? [] : (param.split(SEARCH_ARRAY_PARAM_SEPARATOR).filter(item => validValues.includes(item as T)) as T[])
 }

--- a/webapp/src/modules/routing/selectors.ts
+++ b/webapp/src/modules/routing/selectors.ts
@@ -15,13 +15,7 @@ import { AssetType } from '../asset/types'
 import { getAddress as getWalletAddress } from '../wallet/selectors'
 import { getAddress as getAccountAddress } from '../account/selectors'
 import { isLandSection, isListsSection } from '../ui/utils'
-import {
-  getDefaultOptionsByView,
-  getURLParamArray,
-  getURLParam,
-  getURLParamArray_nonStandard,
-  SEARCH_ARRAY_PARAM_SEPARATOR
-} from './search'
+import { getDefaultOptionsByView, getURLParamArray, getURLParam, getURLParamArrayNonStandard, SEARCH_ARRAY_PARAM_SEPARATOR } from './search'
 import { BrowseOptions, PageName, SortBy, SortByOption } from './types'
 import { locations } from './locations'
 
@@ -235,11 +229,11 @@ export const getIsFullscreen = createSelector<RootState, string, boolean | undef
 )
 
 export const getRarities = createSelector<RootState, string, Rarity[]>(getRouterSearch, search =>
-  getURLParamArray_nonStandard<Rarity>(search, 'rarities', Object.values(Rarity).filter(value => typeof value === 'string') as string[])
+  getURLParamArrayNonStandard<Rarity>(search, 'rarities', Object.values(Rarity).filter(value => typeof value === 'string') as string[])
 )
 
 export const getWearableGenders = createSelector<RootState, string, GenderFilterOption[]>(getRouterSearch, search =>
-  getURLParamArray_nonStandard<GenderFilterOption>(search, 'genders', Object.values(GenderFilterOption))
+  getURLParamArrayNonStandard<GenderFilterOption>(search, 'genders', Object.values(GenderFilterOption))
 )
 
 export const getContracts = createSelector<RootState, string, string[]>(


### PR DESCRIPTION
Add naming-convention rule again, but enable PascalCase for functions so we can follow react convention for functional components