### PR TITLE
fix: Don't refetch required permissions

### DIFF
--- a/webapp/src/components/AssetPage/RequiredPermissions/RequiredPermissions.container.ts
+++ b/webapp/src/components/AssetPage/RequiredPermissions/RequiredPermissions.container.ts
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux'
-import { getAssetData, getRequiredPermissions, isFetchingRequiredPermissions } from '../../../modules/asset/selectors'
+import { getAssetData, getError, getRequiredPermissions, isFetchingRequiredPermissions } from '../../../modules/asset/selectors'
 import { RootState } from '../../../modules/reducer'
-import { fetchSmartWearableRequiredPermissionsRequest } from '../../../modules/asset/actions'
+import { clearAssetError, fetchSmartWearableRequiredPermissionsRequest } from '../../../modules/asset/actions'
 import { Asset } from '../../../modules/asset/types'
 import RequiredPermissions from './RequiredPermissions'
 import { OwnProps, MapStateProps, MapDispatchProps, MapDispatch } from './RequiredPermissions.types'
@@ -12,11 +12,13 @@ const mapState = (state: RootState, ownProps: OwnProps): MapStateProps => {
   return {
     isLoading: isFetchingRequiredPermissions(state, id),
     hasFetched: 'requiredPermissions' in getAssetData(state, id),
+    error: getError(state) ?? undefined,
     requiredPermissions: getRequiredPermissions(state, id)
   }
 }
 
 const mapDispatchProps = (dispatch: MapDispatch): MapDispatchProps => ({
+  onClearError: () => dispatch(clearAssetError()),
   onFetchRequiredPermissions: (asset: Asset) => dispatch(fetchSmartWearableRequiredPermissionsRequest(asset))
 })
 

--- a/webapp/src/components/AssetPage/RequiredPermissions/RequiredPermissions.spec.tsx
+++ b/webapp/src/components/AssetPage/RequiredPermissions/RequiredPermissions.spec.tsx
@@ -14,7 +14,9 @@ function renderRequiredPermissions(props: Partial<Props> = {}) {
       asset={asset}
       isLoading={false}
       hasFetched={true}
+      error={undefined}
       requiredPermissions={[]}
+      onClearError={jest.fn()}
       onFetchRequiredPermissions={jest.fn()}
       {...props}
     />
@@ -53,6 +55,45 @@ describe('when the permissions were fetched and the array is not empty', () => {
     const { getByText } = renderRequiredPermissions({ requiredPermissions })
     requiredPermissions.forEach(requiredPermission => {
       expect(getByText(t(`smart_wearable.required_permission.${requiredPermission.toLowerCase()}`))).toBeInTheDocument()
+    })
+  })
+})
+
+describe('when there is an error', () => {
+  it('should render the error message', () => {
+    const { getByText } = renderRequiredPermissions({ error: 'An error' })
+    expect(getByText('An error')).toBeInTheDocument()
+  })
+})
+
+describe('when the component is unmounted', () => {
+  let onClearError: jest.Mock
+  let error: string | undefined
+
+  beforeEach(() => {
+    onClearError = jest.fn()
+  })
+
+  describe("and there's an error", () => {
+    beforeEach(() => {
+      error = 'An error'
+    })
+
+    it('should clear the error', () => {
+      const { unmount } = renderRequiredPermissions({ error, onClearError })
+      unmount()
+      expect(onClearError).toHaveBeenCalled()
+    })
+  })
+  describe("and there's no error", () => {
+    beforeEach(() => {
+      error = undefined
+    })
+
+    it('should not clear the error', () => {
+      const { unmount } = renderRequiredPermissions({ error, onClearError })
+      unmount()
+      expect(onClearError).not.toHaveBeenCalled()
     })
   })
 })

--- a/webapp/src/components/AssetPage/RequiredPermissions/RequiredPermissions.tsx
+++ b/webapp/src/components/AssetPage/RequiredPermissions/RequiredPermissions.tsx
@@ -6,11 +6,28 @@ import { Props } from './RequiredPermissions.types'
 import styles from './RequiredPermissions.module.css'
 
 const RequiredPermissions = (props: Props) => {
-  const { asset, isLoading, hasFetched, requiredPermissions, onFetchRequiredPermissions } = props
+  const { asset, isLoading, hasFetched, requiredPermissions, error, onFetchRequiredPermissions, onClearError } = props
 
   useEffect(() => {
-    if (requiredPermissions.length === 0 && !isLoading && !hasFetched) onFetchRequiredPermissions(asset)
-  }, [asset, isLoading, hasFetched, onFetchRequiredPermissions, requiredPermissions.length])
+    if (requiredPermissions.length === 0 && !isLoading && !hasFetched && !error) onFetchRequiredPermissions(asset)
+
+    return () => {
+      if (error) {
+        onClearError()
+      }
+    }
+  }, [asset, isLoading, hasFetched, onFetchRequiredPermissions, onClearError, error, requiredPermissions.length])
+
+  if (error) {
+    return (
+      <Stats title="" className={styles.RequiredPermissions}>
+        <Header sub className={styles.title}>
+          {t('smart_wearable.required_permission.error_title')}
+        </Header>
+        <div className={styles.container}>{error}</div>
+      </Stats>
+    )
+  }
 
   return requiredPermissions.length > 0 ? (
     <Stats title="" className={styles.RequiredPermissions}>

--- a/webapp/src/components/AssetPage/RequiredPermissions/RequiredPermissions.types.ts
+++ b/webapp/src/components/AssetPage/RequiredPermissions/RequiredPermissions.types.ts
@@ -1,16 +1,18 @@
 import { Dispatch } from 'redux'
 import { Asset } from '../../../modules/asset/types'
-import { FetchSmartWearableRequiredPermissionsRequestAction } from '../../../modules/asset/actions'
+import { ClearAssetError, FetchSmartWearableRequiredPermissionsRequestAction } from '../../../modules/asset/actions'
 
 export type Props = {
   asset: Asset
+  error?: string
   requiredPermissions: string[]
   isLoading: boolean
   hasFetched: boolean
+  onClearError: () => void
   onFetchRequiredPermissions: (asset: Asset) => void
 }
 
 export type OwnProps = Pick<Props, 'asset'>
-export type MapStateProps = Pick<Props, 'requiredPermissions' | 'isLoading' | 'hasFetched'>
-export type MapDispatchProps = Pick<Props, 'onFetchRequiredPermissions'>
-export type MapDispatch = Dispatch<FetchSmartWearableRequiredPermissionsRequestAction>
+export type MapStateProps = Pick<Props, 'requiredPermissions' | 'isLoading' | 'hasFetched' | 'error'>
+export type MapDispatchProps = Pick<Props, 'onFetchRequiredPermissions' | 'onClearError'>
+export type MapDispatch = Dispatch<FetchSmartWearableRequiredPermissionsRequestAction | ClearAssetError>

--- a/webapp/src/modules/asset/actions.spec.ts
+++ b/webapp/src/modules/asset/actions.spec.ts
@@ -11,7 +11,9 @@ import {
   FETCH_SMART_WEARABLE_VIDEO_HASH_SUCCESS,
   fetchSmartWearableVideoHashFailure,
   fetchSmartWearableVideoHashRequest,
-  fetchSmartWearableVideoHashSuccess
+  fetchSmartWearableVideoHashSuccess,
+  clearAssetError,
+  CLEAR_ASSET_ERROR
 } from './actions'
 import { Asset } from './types'
 
@@ -85,6 +87,16 @@ describe('when creating the action to signal a failure smart wearable video hash
       type: FETCH_SMART_WEARABLE_VIDEO_HASH_FAILURE,
       meta: undefined,
       payload: { asset, error: anErrorMessage }
+    })
+  })
+})
+
+describe('when creating the action to signal the clearing of errors', () => {
+  it('should return an object representing the action', () => {
+    expect(clearAssetError()).toEqual({
+      type: CLEAR_ASSET_ERROR,
+      meta: undefined,
+      payload: undefined
     })
   })
 })

--- a/webapp/src/modules/asset/actions.ts
+++ b/webapp/src/modules/asset/actions.ts
@@ -41,3 +41,9 @@ export const fetchSmartWearableVideoHashFailure = (asset: Asset, error: string) 
 export type FetchSmartWearableVideoHashRequestAction = ReturnType<typeof fetchSmartWearableVideoHashRequest>
 export type FetchSmartWearableVideoHashSuccessAction = ReturnType<typeof fetchSmartWearableVideoHashSuccess>
 export type FetchSmartWearableVideoHashFailureAction = ReturnType<typeof fetchSmartWearableVideoHashFailure>
+
+// Clear error
+export const CLEAR_ASSET_ERROR = '[Clear error] Assets'
+export const clearAssetError = () => action(CLEAR_ASSET_ERROR)
+
+export type ClearAssetError = ReturnType<typeof clearAssetError>

--- a/webapp/src/modules/asset/reducer.spec.ts
+++ b/webapp/src/modules/asset/reducer.spec.ts
@@ -2,6 +2,7 @@ import { loadingReducer } from 'decentraland-dapps/dist/modules/loading/reducer'
 import {
   FETCH_SMART_WEARABLE_REQUIRED_PERMISSIONS_SUCCESS,
   FETCH_SMART_WEARABLE_VIDEO_HASH_SUCCESS,
+  clearAssetError,
   fetchSmartWearableRequiredPermissionsFailure,
   fetchSmartWearableRequiredPermissionsRequest,
   fetchSmartWearableRequiredPermissionsSuccess,
@@ -126,6 +127,20 @@ describe.each([
       ...INITIAL_STATE,
       loading: [],
       data: { ...initialState.data, [asset.id]: expectedData }
+    })
+  })
+})
+
+describe('when reducing the CLEAR_ASSET_ERROR action', () => {
+  it('should return a state with the error cleared', () => {
+    const initialState = {
+      ...INITIAL_STATE,
+      error: anErrorMessage
+    }
+
+    expect(assetReducer(initialState, clearAssetError())).toEqual({
+      ...initialState,
+      error: null
     })
   })
 })

--- a/webapp/src/modules/asset/reducer.ts
+++ b/webapp/src/modules/asset/reducer.ts
@@ -11,7 +11,9 @@ import {
   FETCH_SMART_WEARABLE_VIDEO_HASH_SUCCESS,
   FetchSmartWearableVideoHashFailureAction,
   FetchSmartWearableVideoHashRequestAction,
-  FetchSmartWearableVideoHashSuccessAction
+  FetchSmartWearableVideoHashSuccessAction,
+  ClearAssetError,
+  CLEAR_ASSET_ERROR
 } from './actions'
 import { AssetData } from './types'
 
@@ -34,6 +36,7 @@ type AssetReducerAction =
   | FetchSmartWearableVideoHashRequestAction
   | FetchSmartWearableRequiredPermissionsSuccessAction
   | FetchSmartWearableVideoHashSuccessAction
+  | ClearAssetError
 
 export function assetReducer(state = INITIAL_STATE, action: AssetReducerAction): AssetState {
   switch (action.type) {
@@ -81,6 +84,13 @@ export function assetReducer(state = INITIAL_STATE, action: AssetReducerAction):
         ...state,
         loading: loadingReducer(state.loading, action),
         error
+      }
+    }
+
+    case CLEAR_ASSET_ERROR: {
+      return {
+        ...state,
+        error: null
       }
     }
 

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -753,6 +753,7 @@
   "smart_wearable": {
     "play_showcase": "Play showcase video",
     "required_permission": {
+      "error_title": "Error loading permissions",
       "title": "This wearable requires the following {count, plural, one {permission} other {permissions}}",
       "tooltip_info": "To use this Wearable, you must grant it the following permissions to experience the Wearable's full effect. {learn_more}",
       "allow_to_move_player_inside_scene": "Move player",

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -740,6 +740,7 @@
   "smart_wearable": {
     "play_showcase": "Reproducir vista previa",
     "required_permission": {
+      "error_title": "Error cargando permisos",
       "title": "Esta vestimenta inteligente requiere {count, plural, one {el siguiente permiso} other {los siguientes permisos}}",
       "tooltip_info": "Para usar esta vestimenta interactiva, debe otorgarle los siguientes permisos para experimentar el efecto completo de la misma. {learn_more}",
       "allow_to_move_player_inside_scene": "Mover jugador",

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -743,6 +743,7 @@
   "smart_wearable": {
     "play_showcase": "播放展示视频",
     "required_permission": {
+      "error_title": "加载权限时出错",
       "title": "此可穿戴设备需要以下 {count,plural, one {permission} other {permissions}}",
       "tooltip_info": "要使用该穿戴设备，您必须授予其以下权限才能体验该穿戴设备的全部效果。{learn_more}",
       "allow_to_move_player_inside_scene": "移动玩家",

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -2,7 +2,7 @@ import { NodeGlobalsPolyfillPlugin } from '@esbuild-plugins/node-globals-polyfil
 import { NodeModulesPolyfillPlugin } from '@esbuild-plugins/node-modules-polyfill'
 import react from '@vitejs/plugin-react-swc'
 import rollupNodePolyFill from 'rollup-plugin-polyfill-node'
-import { defineConfig, loadEnv, splitVendorChunkPlugin } from 'vite'
+import { defineConfig, UserConfig, loadEnv, splitVendorChunkPlugin } from 'vite'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {
@@ -68,5 +68,5 @@ export default defineConfig(({ command, mode }) => {
       sourcemap: true
     },
     ...(command === 'build' ? { base: envVariables.VITE_BASE_URL } : undefined)
-  } as unknown
+  } as unknown as UserConfig
 })

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -14,8 +14,7 @@ export default defineConfig(({ command, mode }) => {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       'process.env': {
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        VITE_DCL_DEFAULT_ENV:
-          envVariables.VITE_DCL_DEFAULT_ENV,
+        VITE_DCL_DEFAULT_ENV: envVariables.VITE_DCL_DEFAULT_ENV,
         VITE_BASE_URL: envVariables.VITE_BASE_URL
       },
       global: {}
@@ -69,5 +68,5 @@ export default defineConfig(({ command, mode }) => {
       sourcemap: true
     },
     ...(command === 'build' ? { base: envVariables.VITE_BASE_URL } : undefined)
-  } as any
+  } as unknown
 })


### PR DESCRIPTION
This PR prevents the re-fetching of the smart items required permissions if it fails.