### PR TITLE
fix: Remove download content check

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -23,7 +23,7 @@
         "classnames": "^2.3.1",
         "connected-react-router": "^6.9.1",
         "date-fns": "^2.23.0",
-        "dcl-catalyst-client": "^21.2.0",
+        "dcl-catalyst-client": "^21.6.0",
         "dcl-catalyst-commons": "^9.0.1",
         "decentraland-connect": "^6.2.0",
         "decentraland-crypto-fetch": "^1.0.3",
@@ -8524,9 +8524,9 @@
       }
     },
     "node_modules/dcl-catalyst-client": {
-      "version": "21.5.5",
-      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-21.5.5.tgz",
-      "integrity": "sha512-VXIypnUl4czyo+vTH0L082YgTqA5fKu/1Y5yusZ7bhuUs/uxgNsGSc35blqjUY67GaG4R7XaSOwn6jA3dzxPfg==",
+      "version": "21.6.0",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-21.6.0.tgz",
+      "integrity": "sha512-PF0knURpIVc9POai5zH20VPzzuY6v/IKU6mP98Scjy5w9T5kHvVW7b7xcq0CR2DaZcUfwScBgI/3B+EZWRqImg==",
       "dependencies": {
         "@dcl/catalyst-contracts": "^4.0.2",
         "@dcl/crypto": "^3.4.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -18,7 +18,7 @@
     "classnames": "^2.3.1",
     "connected-react-router": "^6.9.1",
     "date-fns": "^2.23.0",
-    "dcl-catalyst-client": "^21.2.0",
+    "dcl-catalyst-client": "^21.6.0",
     "dcl-catalyst-commons": "^9.0.1",
     "decentraland-connect": "^6.2.0",
     "decentraland-crypto-fetch": "^1.0.3",

--- a/webapp/src/lib/asset.ts
+++ b/webapp/src/lib/asset.ts
@@ -21,7 +21,7 @@ export const getSmartWearableSceneContent = async (urn: string): Promise<Record<
     const scene = wearableEntity[0].content?.find(entity => entity.file.endsWith(SCENE_PATH))
 
     if (scene) {
-      const wearableScene = await contentClient.downloadContent(scene.hash)
+      const wearableScene = await contentClient.downloadContent(scene.hash, { avoidChecks: true })
 
       const enc = new TextDecoder('utf-8')
       const data = new Uint8Array(wearableScene)


### PR DESCRIPTION
This PR removes the download content check when downloading content from the Catalyst. This is a temporary fix for the real issue, which is that the hashing library is built in some way that crypto is loaded as the node crypto package, which fails.