### PR TITLE
fix: add timeout when MM active method hangs

### DIFF
--- a/webapp/src/modules/wallet/utils.spec.ts
+++ b/webapp/src/modules/wallet/utils.spec.ts
@@ -64,9 +64,8 @@ describe('when waiting for the wallet to connect', () => {
       return expectSaga(waitForWalletConnectionAndIdentityIfConnecting)
         .provide([
           [select(isConnecting), true],
-          [delay(WAIT_FOR_WALLET_CONNECTION_TIMEOUT + 1), void 0]
+          [delay(WAIT_FOR_WALLET_CONNECTION_TIMEOUT), void 0]
         ])
-        .delay(WAIT_FOR_WALLET_CONNECTION_TIMEOUT + 1) // Simulate a delay longer than the timeout
         .run()
     })
   })

--- a/webapp/src/modules/wallet/utils.spec.ts
+++ b/webapp/src/modules/wallet/utils.spec.ts
@@ -58,4 +58,13 @@ describe('when waiting for the wallet to connect', () => {
         .run()
     })
   })
+
+  describe('and the wallet connection times out', () => {
+    it('should finish waiting after the timeout', () => {
+      return expectSaga(waitForWalletConnectionAndIdentityIfConnecting)
+        .provide([[select(isConnecting), true]])
+        .delay(10000) // Simulate a delay longer than the timeout
+        .run()
+    })
+  })
 })

--- a/webapp/src/modules/wallet/utils.spec.ts
+++ b/webapp/src/modules/wallet/utils.spec.ts
@@ -1,4 +1,4 @@
-import { select } from 'redux-saga/effects'
+import { delay, select } from 'redux-saga/effects'
 import { expectSaga } from 'redux-saga-test-plan'
 import {
   CONNECT_WALLET_FAILURE,
@@ -8,7 +8,7 @@ import {
 } from 'decentraland-dapps/dist/modules/wallet/actions'
 import { isConnecting } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
-import { formatBalance, waitForWalletConnectionAndIdentityIfConnecting } from './utils'
+import { WAIT_FOR_WALLET_CONNECTION_TIMEOUT, formatBalance, waitForWalletConnectionAndIdentityIfConnecting } from './utils'
 
 describe('when formatting the balance', () => {
   describe('and the number is 0', () => {
@@ -62,8 +62,11 @@ describe('when waiting for the wallet to connect', () => {
   describe('and the wallet connection times out', () => {
     it('should finish waiting after the timeout', () => {
       return expectSaga(waitForWalletConnectionAndIdentityIfConnecting)
-        .provide([[select(isConnecting), true]])
-        .delay(10000) // Simulate a delay longer than the timeout
+        .provide([
+          [select(isConnecting), true],
+          [delay(WAIT_FOR_WALLET_CONNECTION_TIMEOUT + 1), void 0]
+        ])
+        .delay(WAIT_FOR_WALLET_CONNECTION_TIMEOUT + 1) // Simulate a delay longer than the timeout
         .run()
     })
   })

--- a/webapp/src/modules/wallet/utils.ts
+++ b/webapp/src/modules/wallet/utils.ts
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers'
-import { race, select, take } from 'redux-saga/effects'
+import { delay, race, select, take } from 'redux-saga/effects'
 import { getConnectedProvider } from 'decentraland-dapps/dist/lib/eth'
 import {
   CONNECT_WALLET_FAILURE,
@@ -13,6 +13,7 @@ import { config } from '../../config'
 import { GENERATE_IDENTITY_FAILURE, GENERATE_IDENTITY_SUCCESS } from '../identity/actions'
 
 export const TRANSACTIONS_API_URL = config.get('TRANSACTIONS_API_URL')
+const WAIT_FOR_WALLET_CONNECTION_TIMEOUT = 10000
 
 export function shortenAddress(address: string) {
   if (address) {
@@ -47,10 +48,12 @@ export function formatBalance(balance: number) {
 export function* waitForWalletConnectionAndIdentityIfConnecting() {
   const isConnectingToWallet = (yield select(isConnecting)) as ReturnType<typeof isConnecting>
   if (isConnectingToWallet) {
-    const { success } = (yield race({
+    const { success, timeout } = (yield race({
       success: take(CONNECT_WALLET_SUCCESS),
-      failure: take(CONNECT_WALLET_FAILURE)
-    })) as { success: ConnectWalletSuccessAction; failure: ConnectWalletFailureAction }
+      failure: take(CONNECT_WALLET_FAILURE),
+      timeout: delay(WAIT_FOR_WALLET_CONNECTION_TIMEOUT) // 10 seconds timeout
+    })) as { success: ConnectWalletSuccessAction; failure: ConnectWalletFailureAction; timeout: any }
+    console.log('timeout: ', timeout)
     if (success) {
       yield race({
         success: take(GENERATE_IDENTITY_SUCCESS),

--- a/webapp/src/modules/wallet/utils.ts
+++ b/webapp/src/modules/wallet/utils.ts
@@ -48,12 +48,11 @@ export function formatBalance(balance: number) {
 export function* waitForWalletConnectionAndIdentityIfConnecting() {
   const isConnectingToWallet = (yield select(isConnecting)) as ReturnType<typeof isConnecting>
   if (isConnectingToWallet) {
-    const { success, timeout } = (yield race({
+    const { success } = (yield race({
       success: take(CONNECT_WALLET_SUCCESS),
       failure: take(CONNECT_WALLET_FAILURE),
       timeout: delay(WAIT_FOR_WALLET_CONNECTION_TIMEOUT) // 10 seconds timeout
-    })) as { success: ConnectWalletSuccessAction; failure: ConnectWalletFailureAction; timeout: any }
-    console.log('timeout: ', timeout)
+    })) as { success: ConnectWalletSuccessAction; failure: ConnectWalletFailureAction }
     if (success) {
       yield race({
         success: take(GENERATE_IDENTITY_SUCCESS),

--- a/webapp/src/modules/wallet/utils.ts
+++ b/webapp/src/modules/wallet/utils.ts
@@ -13,7 +13,7 @@ import { config } from '../../config'
 import { GENERATE_IDENTITY_FAILURE, GENERATE_IDENTITY_SUCCESS } from '../identity/actions'
 
 export const TRANSACTIONS_API_URL = config.get('TRANSACTIONS_API_URL')
-const WAIT_FOR_WALLET_CONNECTION_TIMEOUT = 10000
+export const WAIT_FOR_WALLET_CONNECTION_TIMEOUT = 10000 // 10 seconds timeout
 
 export function shortenAddress(address: string) {
   if (address) {
@@ -51,7 +51,7 @@ export function* waitForWalletConnectionAndIdentityIfConnecting() {
     const { success } = (yield race({
       success: take(CONNECT_WALLET_SUCCESS),
       failure: take(CONNECT_WALLET_FAILURE),
-      timeout: delay(WAIT_FOR_WALLET_CONNECTION_TIMEOUT) // 10 seconds timeout
+      timeout: delay(WAIT_FOR_WALLET_CONNECTION_TIMEOUT)
     })) as { success: ConnectWalletSuccessAction; failure: ConnectWalletFailureAction }
     if (success) {
       yield race({


### PR DESCRIPTION
When MM is blocked, this saga keeps waiting for ever since it won't succed or failed. This PR adds a timeout to avoid that
