### PR TITLE
fix: add mapper to getHomepage to it looks for nfts or items

### DIFF
--- a/webapp/src/modules/ui/asset/homepage/selectors.spec.ts
+++ b/webapp/src/modules/ui/asset/homepage/selectors.spec.ts
@@ -1,0 +1,122 @@
+import { BodyShape, EmoteCategory, NFTCategory, Network, Rarity, WearableCategory } from '@dcl/schemas'
+import { RootState } from '../../../reducer'
+import { VendorName } from '../../../vendor'
+import { UIState } from '../../reducer'
+import { View } from '../../types'
+import { getHomepage } from './selectors'
+
+describe('getHomepage', () => {
+  let itemId: string
+  let state: RootState
+  beforeEach(() => {
+    itemId = '0x332b4067a1bcdee66abcfb3e37a47da8a0b408dc-1'
+    state = {
+      ui: {
+        asset: {
+          homepage: {
+            [View.HOME_TRENDING_ITEMS]: [],
+            [View.HOME_NEW_ITEMS]: ['0x332b4067a1bcdee66abcfb3e37a47da8a0b408dc-1'],
+            [View.HOME_SOLD_ITEMS]: [],
+            [View.HOME_WEARABLES]: [],
+            [View.HOME_LAND]: [],
+            [View.HOME_ENS]: []
+          }
+        }
+      } as unknown as UIState,
+      nft: {
+        data: {
+          [itemId]: {
+            id: '0x332b4067a1bcdee66abcfb3e37a47da8a0b408dc-1',
+            tokenId: '1',
+            contractAddress: '0x332b4067a1bcdee66abcfb3e37a47da8a0b408dc',
+            category: NFTCategory.EMOTE,
+            activeOrderId: '0xd19f0874ea5e1a9ba435d94e3ecc11f04fdfef307ef2d320c4cabf586453cdb3',
+            openRentalId: null,
+            owner: '0xc9c29ab98e6bc42015985165a11153f564e9f8c2',
+            name: 'whispering kiss',
+            image:
+              'https://peer.decentraland.zone/lambdas/collections/contents/urn:decentraland:amoy:collections-v2:0x332b4067a1bcdee66abcfb3e37a47da8a0b408dc:0/thumbnail',
+            url: '/contracts/0x332b4067a1bcdee66abcfb3e37a47da8a0b408dc/tokens/1',
+            data: {
+              emote: {
+                bodyShapes: [BodyShape.MALE, BodyShape.FEMALE],
+                category: EmoteCategory.GREETINGS,
+                description: 'DESCIPTION OF THE EMOTE BSBMJASJHASVKHAJSVKAASHJLHSAVKJAHDGSDSAJ',
+                rarity: Rarity.LEGENDARY,
+                loop: false,
+                hasSound: false,
+                hasGeometry: false
+              }
+            },
+            issuedId: '1',
+            itemId: '0',
+            network: Network.MATIC,
+            chainId: 80002,
+            createdAt: 1715107138000,
+            updatedAt: 1715108766000,
+            soldAt: 0,
+            urn: 'urn:decentraland:amoy:collections-v2:0x332b4067a1bcdee66abcfb3e37a47da8a0b408dc:0',
+            vendor: VendorName.DECENTRALAND
+          }
+        },
+        loading: [],
+        error: null
+      },
+      item: {
+        data: {
+          [itemId]: {
+            id: '0x332b4067a1bcdee66abcfb3e37a47da8a0b408dc-1',
+            beneficiary: '0xc9c29ab98e6bc42015985165a11153f564e9f8c2',
+            itemId: '1',
+            name: 'galactic armor',
+            thumbnail:
+              'https://peer.decentraland.zone/lambdas/collections/contents/urn:decentraland:amoy:collections-v2:0x332b4067a1bcdee66abcfb3e37a47da8a0b408dc:1/thumbnail',
+            url: '/contracts/0x332b4067a1bcdee66abcfb3e37a47da8a0b408dc/items/1',
+            category: NFTCategory.WEARABLE,
+            contractAddress: '0x332b4067a1bcdee66abcfb3e37a47da8a0b408dc',
+            rarity: Rarity.EPIC,
+            available: 5000,
+            isOnSale: true,
+            creator: '0xc9c29ab98e6bc42015985165a11153f564e9f8c2',
+            data: {
+              wearable: {
+                description: 'DESCRIPTIONDESCRIPTIONDESCRIPTIONDESCRIPTIONDESCRIPTIONDESCRIPTI',
+                category: WearableCategory.UPPER_BODY,
+                bodyShapes: [BodyShape.FEMALE],
+                rarity: Rarity.RARE,
+                isSmart: false
+              }
+            },
+            network: Network.MATIC,
+            chainId: 80002,
+            price: '1000000000000000000',
+            createdAt: 1713470731,
+            updatedAt: 1713470731,
+            reviewedAt: 1713470731,
+            firstListedAt: 1715106572,
+            soldAt: 0,
+            minPrice: '1000000000000000000',
+            maxListingPrice: null,
+            minListingPrice: null,
+            listings: 0,
+            owners: null,
+            picks: {
+              count: 0,
+              pickedByUser: false
+            },
+            urn: ''
+          }
+        },
+        loading: [],
+        error: null
+      }
+    } as unknown as RootState
+  })
+
+  describe('and has an item with the same id as an nft', () => {
+    it('should have the item in home new items instead of the nft', () => {
+      const result = getHomepage(state)
+      expect(result[View.HOME_NEW_ITEMS]).toEqual(expect.arrayContaining([state.item.data[itemId]]))
+    })
+  })
+})

--- a/webapp/src/modules/ui/asset/homepage/selectors.ts
+++ b/webapp/src/modules/ui/asset/homepage/selectors.ts
@@ -5,6 +5,7 @@ import { Asset } from '../../../asset/types'
 import { FETCH_ITEMS_REQUEST, FETCH_TRENDING_ITEMS_REQUEST, FetchItemsRequestAction } from '../../../item/actions'
 import { ItemState } from '../../../item/reducer'
 import { getData as getItemData, getLoading as getItemLoading } from '../../../item/selectors'
+import { Item } from '../../../item/types'
 import { FETCH_NFTS_REQUEST, FetchNFTsRequestAction } from '../../../nft/actions'
 import { NFTState } from '../../../nft/reducer'
 import { getData as getNFTData, getLoading as getNFTLoading } from '../../../nft/selectors'
@@ -27,9 +28,15 @@ export const getHomepage = createSelector<RootState, HomepageUIState, NFTState['
   (homepage, nftsById, itemsById) => {
     const result: Record<string, Asset[]> = {}
 
+    const mapper: { [key in View]?: Record<string, Item> } = {
+      [View.HOME_TRENDING_ITEMS]: itemsById,
+      [View.HOME_NEW_ITEMS]: itemsById,
+      [View.HOME_SOLD_ITEMS]: itemsById
+    }
+
     let view: HomepageView
     for (view in homepage) {
-      result[view] = homepage[view].map(id => nftsById[id] || itemsById[id])
+      result[view] = homepage[view].map(id => mapper[view]?.[id] || itemsById[id] || nftsById[id])
     }
 
     return result as Record<HomepageView, Asset[]>


### PR DESCRIPTION
![image](https://github.com/decentraland/marketplace/assets/8763687/88e27550-d77e-4a97-bd51-f315efaeac7a)

the emote in this image is an nft instead of an item

after the fix, it's not in the carousel any more, instead the item that has that same `itemId` as the `nftId` from above, is shown:
![image](https://github.com/decentraland/marketplace/assets/8763687/820c4279-4389-443d-a977-f5676ccac2bc)
