### PR TITLE
fix: subtitle overlapping the creators name in the homepage table

### DIFF
--- a/webapp/src/components/RankingsTable/RankingCreatorRow/RankingCreatorRow.css
+++ b/webapp/src/components/RankingsTable/RankingCreatorRow/RankingCreatorRow.css
@@ -23,7 +23,7 @@
     line-height: 18px;
     position: absolute;
     left: 60px;
-    bottom: 36px;
+    bottom: 20px;
     white-space: nowrap;
   }
 


### PR DESCRIPTION
## before the fix

<img width="434" alt="image" src="https://github.com/decentraland/marketplace/assets/8763687/d991cc36-64d0-43f5-8ace-4f85a4f98e66">


## after the fix

<img width="408" alt="image" src="https://github.com/decentraland/marketplace/assets/8763687/d55b277b-5142-48aa-a1d5-3db52e93a68a">
