### PR TITLE
fix: Names search showing other assets

### DIFF
--- a/webapp/src/components/AssetBrowse/AssetBrowse.tsx
+++ b/webapp/src/components/AssetBrowse/AssetBrowse.tsx
@@ -44,6 +44,7 @@ const AssetBrowse = (props: Props) => {
     onlyOnSale,
     onlySmart,
     viewInState,
+    disableSearchDropdown,
     onlyOnRent
   } = props
 
@@ -186,7 +187,7 @@ const AssetBrowse = (props: Props) => {
     case DecentralandSection.ENS:
       right = (
         <>
-          <AssetTopbar />
+          <AssetTopbar disableSearchDropdown={disableSearchDropdown} />
           <AssetList isManager={isCurrentAccount} />
         </>
       )

--- a/webapp/src/components/AssetBrowse/AssetBrowse.types.ts
+++ b/webapp/src/components/AssetBrowse/AssetBrowse.types.ts
@@ -22,6 +22,7 @@ export type Props = {
   onBrowse: typeof browse
   onlyOnSale?: boolean
   onlySmart?: boolean
+  disableSearchDropdown?: boolean
   onlyOnRent?: boolean
 }
 
@@ -31,4 +32,7 @@ export type MapStateProps = Pick<
 >
 export type MapDispatchProps = Pick<Props, 'onSetView' | 'onFetchAssetsFromRoute' | 'onBrowse'>
 export type MapDispatch = Dispatch<SetViewAction | FetchAssetsFromRouteAction | BrowseAction>
-export type OwnProps = Pick<Props, 'vendor' | 'address' | 'isFullscreen' | 'isMap' | 'view' | 'sections' | 'section' | 'contracts'>
+export type OwnProps = Pick<
+  Props,
+  'vendor' | 'address' | 'isFullscreen' | 'isMap' | 'view' | 'sections' | 'section' | 'contracts' | 'disableSearchDropdown'
+>

--- a/webapp/src/components/AssetTopbar/AssetTopbar.tsx
+++ b/webapp/src/components/AssetTopbar/AssetTopbar.tsx
@@ -30,6 +30,7 @@ export const AssetTopbar = ({
   onBrowse,
   onClearFilters,
   onOpenFiltersModal,
+  disableSearchDropdown,
   sortByOptions
 }: Props): JSX.Element => {
   const isMobile = useTabletAndBelowMediaQuery()
@@ -41,7 +42,7 @@ export const AssetTopbar = ({
   const handleInputChange = useCallback(
     (text: string) => {
       // if the user is typing, open the dropdown
-      if (!shouldRenderSearchDropdown && text) {
+      if (!shouldRenderSearchDropdown && text && !disableSearchDropdown) {
         setShouldRenderSearchDropdown(true)
       }
       // if the user clears the input, reset the search
@@ -50,7 +51,7 @@ export const AssetTopbar = ({
           search: ''
         }) // triggers search with no search term
       }
-      if (shouldRenderSearchDropdown) {
+      if (shouldRenderSearchDropdown && !disableSearchDropdown) {
         setSearchValueForDropdown(text)
       } else if (text && text !== search) {
         // common search, when the dropdown is not opened and the input is different than the current search term

--- a/webapp/src/components/AssetTopbar/AssetTopbar.types.ts
+++ b/webapp/src/components/AssetTopbar/AssetTopbar.types.ts
@@ -18,6 +18,7 @@ export type Props = {
   section: Section
   hasFiltersEnabled: boolean
   isLoading: boolean
+  disableSearchDropdown?: boolean
   onBrowse: (options: BrowseOptions) => void
   onClearFilters: typeof clearFilters
   onOpenFiltersModal: () => ReturnType<typeof openModal>

--- a/webapp/src/components/NamesPage/NamesPage.tsx
+++ b/webapp/src/components/NamesPage/NamesPage.tsx
@@ -9,7 +9,13 @@ import { PageLayout } from '../PageLayout'
 const NamesPage = () => {
   return (
     <PageLayout activeTab={NavigationTab.NAMES}>
-      <AssetBrowse vendor={VendorName.DECENTRALAND} view={View.MARKET} section={Section.ENS} sections={[Section.ENS]} />
+      <AssetBrowse
+        disableSearchDropdown
+        vendor={VendorName.DECENTRALAND}
+        view={View.MARKET}
+        section={Section.ENS}
+        sections={[Section.ENS]}
+      />
     </PageLayout>
   )
 }

--- a/webapp/src/modules/routing/selectors.spec.ts
+++ b/webapp/src/modules/routing/selectors.spec.ts
@@ -157,6 +157,12 @@ describe('when getting if the are filters set', () => {
 })
 
 describe('when getting the section', () => {
+  describe("and there's no section URL param and the location is related to names", () => {
+    it("should return the decentraland's ENS section", () => {
+      expect(getSection.resultFunc('', locations.names(), VendorName.DECENTRALAND)).toBe(Sections.decentraland.ENS)
+    })
+  })
+
   describe("when there's no section URL param and the location is related to lands", () => {
     it("should return the decentraland's LAND section", () => {
       expect(getSection.resultFunc('', locations.lands(), VendorName.DECENTRALAND)).toBe(Sections.decentraland.LAND)

--- a/webapp/src/modules/routing/selectors.ts
+++ b/webapp/src/modules/routing/selectors.ts
@@ -39,6 +39,10 @@ export const getSection = createSelector<RootState, string, ReturnType<typeof ge
       return Sections.decentraland.LAND
     }
 
+    if (!section && pathname === locations.names()) {
+      return Sections.decentraland.ENS
+    }
+
     if (
       (!section || (isOfEnumType(section, Sections[vendor]) && section === Sections[vendor].ALL)) &&
       pathname === locations.browse() &&


### PR DESCRIPTION
This PR fixes an issue where:
1. When in the name's browse site, other assets would be loaded when loading more names.
2. The search bar dropdown showed wearables instead of names.

By:
1. Setting the correct section when the user is in the names browse section so the browse sagas can set the correct category (ENS).
2. Adding the capability to **not** show the search bar dropdown for names, as the feature does not work with names for the time being.