### PR TITLE
fix: Incorrectly building trade byte parameters

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -27,7 +27,7 @@
         "dcl-catalyst-commons": "^9.0.1",
         "decentraland-connect": "^7.3.2",
         "decentraland-crypto-fetch": "^1.0.3",
-        "decentraland-dapps": "^23.17.0",
+        "decentraland-dapps": "^23.17.1",
         "decentraland-transactions": "^2.18.0",
         "decentraland-ui": "^6.12.1",
         "ethers": "^5.6.8",
@@ -9683,9 +9683,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "23.17.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-23.17.0.tgz",
-      "integrity": "sha512-GcTRKxKP313PJH6Sx0aD6VqX54CYRkgJUNdatfyubYCff3uWeBOYqJV8s2iHgITaKG5yPpw6Mfvyp3Xbz/Y4Fg==",
+      "version": "23.17.1",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-23.17.1.tgz",
+      "integrity": "sha512-IW6hIwUkKDmv5gvoi2i8TZkWpUmrWNTyjamkuzw6l3J++cVeQrKmodKP+Evtx4f11gfAx925ckMB0qIpMW6yAA==",
       "dependencies": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,7 +22,7 @@
     "dcl-catalyst-commons": "^9.0.1",
     "decentraland-connect": "^7.3.2",
     "decentraland-crypto-fetch": "^1.0.3",
-    "decentraland-dapps": "^23.17.0",
+    "decentraland-dapps": "^23.17.1",
     "decentraland-transactions": "^2.18.0",
     "decentraland-ui": "^6.12.1",
     "ethers": "^5.6.8",

--- a/webapp/src/modules/bid/utils.ts
+++ b/webapp/src/modules/bid/utils.ts
@@ -1,5 +1,5 @@
 import { ethers, BigNumber } from 'ethers'
-import { Bid, Contract, TradeAssetType, TradeCreation, TradeType } from '@dcl/schemas'
+import { Bid, Contract, Network, TradeAssetType, TradeCreation, TradeType } from '@dcl/schemas'
 import { BidTrade } from '@dcl/schemas/dist/dapps/bid'
 import { AuthorizeActionOptions } from 'decentraland-dapps/dist/containers/withAuthorizedAction'
 import { getNetworkProvider, getSigner } from 'decentraland-dapps/dist/lib/eth'
@@ -104,14 +104,16 @@ export function getAcceptBidAuthorizationOptions(
   }
 
   const offchainMarketplaceContract = getContract(ContractName.OffChainMarketplace, bid.chainId)
+  const targetContractName = bid.network === Network.MATIC ? ContractName.ERC721CollectionV2 : ContractName.ERC721
+
   const authorizeActionOptions = {
-    targetContractName: ContractName.ERC721CollectionV2,
-    targetContractLabel: targetContractLabel || ContractName.ERC721CollectionV2,
+    targetContractName: targetContractName,
+    targetContractLabel: targetContractLabel || targetContractName,
     authorizedAddress: offchainMarketplaceContract.address,
     targetContract: {
       address: bid.contractAddress,
       chainId: bid.chainId,
-      name: ContractName.ERC721CollectionV2,
+      name: targetContractName,
       network: bid.network
     } as Contract,
     authorizedContractLabel: offchainMarketplaceContract.name,

--- a/webapp/src/utils/trades.spec.ts
+++ b/webapp/src/utils/trades.spec.ts
@@ -145,7 +145,7 @@ describe('when getting the trade signature', () => {
           externalChecks: trade.checks.externalChecks?.map(externalCheck => ({
             contractAddress: externalCheck.contractAddress,
             selector: externalCheck.selector,
-            value: externalCheck.value,
+            value: externalCheck.value ? externalCheck.value : '0x',
             required: externalCheck.required
           }))
         },
@@ -153,13 +153,13 @@ describe('when getting the trade signature', () => {
           assetType: asset.assetType,
           contractAddress: asset.contractAddress,
           value: getValueForTradeAsset(asset),
-          extra: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(asset.extra))
+          extra: asset.extra ? asset.extra : '0x'
         })),
         received: trade.received.map(asset => ({
           assetType: asset.assetType,
           contractAddress: asset.contractAddress,
           value: getValueForTradeAsset(asset),
-          extra: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(asset.extra)),
+          extra: asset.extra ? asset.extra : '0x',
           beneficiary: asset.beneficiary
         }))
       }
@@ -199,7 +199,7 @@ describe('when getting the trade to accept', () => {
           assetType: TradeAssetType.ERC20,
           contractAddress: '0x123',
           amount: '2',
-          extra: ''
+          extra: '0x'
         }
       ],
       received: [
@@ -207,7 +207,7 @@ describe('when getting the trade to accept', () => {
           assetType: TradeAssetType.ERC721,
           contractAddress: '0x123',
           tokenId: '1',
-          extra: '',
+          extra: '0x',
           beneficiary: '0x123123'
         }
       ]
@@ -235,14 +235,14 @@ describe('when getting the trade to accept', () => {
         assetType: asset.assetType,
         contractAddress: asset.contractAddress,
         value: getValueForTradeAsset(asset),
-        extra: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(asset.extra)),
+        extra: asset.extra ? asset.extra : '0x',
         beneficiary: beneficiaryAddress
       })),
       received: trade.received.map(asset => ({
         assetType: asset.assetType,
         contractAddress: asset.contractAddress,
         value: getValueForTradeAsset(asset),
-        extra: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(asset.extra)),
+        extra: asset.extra ? asset.extra : '0x',
         beneficiary: asset.beneficiary
       }))
     })

--- a/webapp/src/utils/trades.ts
+++ b/webapp/src/utils/trades.ts
@@ -78,7 +78,8 @@ export function generateTradeValues(trade: Omit<TradeCreation, 'signature'>) {
       externalChecks: trade.checks.externalChecks?.map(externalCheck => ({
         contractAddress: externalCheck.contractAddress,
         selector: externalCheck.selector,
-        value: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(externalCheck.value)),
+        // '0x' is the default value for value bytes (0 bytes)
+        value: externalCheck.value ? externalCheck.value : '0x',
         required: externalCheck.required
       }))
     },
@@ -86,13 +87,15 @@ export function generateTradeValues(trade: Omit<TradeCreation, 'signature'>) {
       assetType: asset.assetType,
       contractAddress: asset.contractAddress,
       value: getValueForTradeAsset(asset),
-      extra: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(asset.extra))
+      // '0x' is the default value for extra bytes (0 bytes)
+      extra: asset.extra ? asset.extra : '0x'
     })),
     received: trade.received.map(asset => ({
       assetType: asset.assetType,
       contractAddress: asset.contractAddress,
       value: getValueForTradeAsset(asset),
-      extra: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(asset.extra)),
+      // '0x' is the default value for extra bytes (0 bytes)
+      extra: asset.extra ? asset.extra : '0x',
       beneficiary: asset.beneficiary
     }))
   }


### PR DESCRIPTION
This PR changes the way we're building the trade object to be signed to correctly set the parameters of byte values (extra and the external check values). The issue seems to have come from the usage of `ethers.utils.hexlify` `ethers.utils.toUtf8Bytes` to allow building the trade signature without failures when the byte parameters where set as empty strings, which the signature function would not recognize as empty byte arrays (the real type).
This PR replaces the usage of those functions in favor of setting the value `'0x'`, the empty bytes value, when the bytes parameters is empty or the set value when it's set.

Depends on: https://github.com/decentraland/decentraland-dapps/pull/656