### PR TITLE
fix: upgrade decentraland-transactions

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -28,7 +28,7 @@
         "decentraland-connect": "^7.3.2",
         "decentraland-crypto-fetch": "^1.0.3",
         "decentraland-dapps": "^23.22.0",
-        "decentraland-transactions": "^2.18.0",
+        "decentraland-transactions": "^2.18.1",
         "decentraland-ui": "^6.12.1",
         "decentraland-ui2": "^0.8.7",
         "ethers": "^5.6.8",
@@ -10278,9 +10278,9 @@
       }
     },
     "node_modules/decentraland-transactions": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-2.18.0.tgz",
-      "integrity": "sha512-WeK+O/gFvKbW4LcqhYVSPPPAX8BYiB36fR8smH6WA+Vdmgyqq2XNL9XJcAsqZxZnCVZjSXxBp1/u4Mi6gv+uTg==",
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-2.18.1.tgz",
+      "integrity": "sha512-TZF7kGYzq1MpHCYXAW6wR569tklQbOYiJDWBC4UoCWkwiog/7wxmt0ak/5VwrzvcDR1HNr5Q7mJg68dB+8zy8Q==",
       "dependencies": {
         "@0xsquid/sdk": "^2.8.25",
         "@0xsquid/squid-types": "^0.1.78",
@@ -10288,7 +10288,8 @@
         "tslib": "^2.6.2"
       },
       "peerDependencies": {
-        "@dcl/schemas": ">=1.1.1"
+        "@dcl/schemas": ">=1.1.1",
+        "ethers": ">=5.7.2 <7.0.0"
       }
     },
     "node_modules/decentraland-transactions/node_modules/@adraffy/ens-normalize": {
@@ -12779,6 +12780,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/abi": "5.7.0",
         "@ethersproject/abstract-provider": "5.7.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -23,7 +23,7 @@
     "decentraland-connect": "^7.3.2",
     "decentraland-crypto-fetch": "^1.0.3",
     "decentraland-dapps": "^23.22.0",
-    "decentraland-transactions": "^2.18.0",
+    "decentraland-transactions": "^2.18.1",
     "decentraland-ui": "^6.12.1",
     "decentraland-ui2": "^0.8.7",
     "ethers": "^5.6.8",

--- a/webapp/src/modules/ens/sagas.ts
+++ b/webapp/src/modules/ens/sagas.ts
@@ -133,9 +133,11 @@ export function* ensSaga() {
       const { AxelarProvider }: Awaited<typeof crossChainModule> = (yield crossChainModule) as Awaited<typeof crossChainModule>
 
       const crossChainProvider = new AxelarProvider(config.get('SQUID_API_URL'))
-      const txResponse: ethers.providers.TransactionReceipt = yield call([crossChainProvider, 'executeRoute'], route, provider) as Awaited<
-        ReturnType<typeof crossChainProvider.executeRoute>
-      >
+      const txResponse: ethers.providers.TransactionReceipt = (yield call(
+        [crossChainProvider, 'executeRoute'],
+        route,
+        provider
+      )) as ethers.providers.TransactionReceipt
 
       yield put(claimNameTransactionSubmitted(name, wallet.address, chainId, txResponse.transactionHash, route))
     } catch (error) {


### PR DESCRIPTION
Fix the issue with the Axelar modal caused due to `decentraland-transactions` working only with ethers v5.