### PR TITLE
BREAKING: Update decentraland-connect

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -25,7 +25,7 @@
         "date-fns": "^2.23.0",
         "dcl-catalyst-client": "21.2.0",
         "dcl-catalyst-commons": "^9.0.1",
-        "decentraland-connect": "^7.3.2",
+        "decentraland-connect": "^8.0.1",
         "decentraland-crypto-fetch": "^1.0.3",
         "decentraland-dapps": "^23.25.1",
         "decentraland-transactions": "^2.18.1",
@@ -4194,6 +4194,14 @@
       "version": "15.6.0",
       "resolved": "https://registry.npmjs.org/@magic-ext/oauth/-/oauth-15.6.0.tgz",
       "integrity": "sha512-OBLxdPUvL+kW/DIxH8V5Fp4rjkV7LdFfVkRHdy6dPBhdbJjpD9/XOReNZnWa45OHx7+OOl1OocPtXn9hEAFoyQ==",
+      "dependencies": {
+        "crypto-js": "^3.3.0"
+      }
+    },
+    "node_modules/@magic-ext/oauth2": {
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/@magic-ext/oauth2/-/oauth2-9.21.0.tgz",
+      "integrity": "sha512-43KvjPg8xxqSYo0W8mVcFcotCo78p3JZNQ+O8P83qvkyTxe8ZAPwBUbSxDLKvBqlcnxvRkz7vru+M/B7Vx4ezg==",
       "dependencies": {
         "crypto-js": "^3.3.0"
       }
@@ -10050,13 +10058,13 @@
       }
     },
     "node_modules/decentraland-connect": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-7.3.2.tgz",
-      "integrity": "sha512-0VUrAMhiM/IcavuFHWXvi5ZVkoIv20TpKcKS+8IHiIqYmK6wj9g7y2Zq8tnrp1qp7du9no771nv4KisB/m/sNA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-8.0.1.tgz",
+      "integrity": "sha512-SU8va4voYFfh+rNqyLs6N3/1N8n7ND29IX4cqBqBgL++vAD0nyr/QwXc5HEPmoMrNV1tdMs239yXsDckalwemg==",
       "dependencies": {
         "@dcl/schemas": "^15.1.2",
         "@dcl/single-sign-on-client": "^0.1.0",
-        "@magic-ext/oauth": "^15.5.0",
+        "@magic-ext/oauth2": "^9.19.0",
         "@walletconnect/ethereum-provider": "^2.17.1",
         "@walletconnect/modal": "^2.6.2",
         "@web3-react/fortmatic-connector": "^6.1.6",
@@ -10064,7 +10072,7 @@
         "@web3-react/network-connector": "^6.1.3",
         "@web3-react/walletlink-connector": "^6.2.13",
         "ethers": "^6.9.1",
-        "magic-sdk": "^21.4.1",
+        "magic-sdk": "^27.0.0",
         "socket.io-client": "^4.7.2",
         "tslib": "^2.6.2"
       }
@@ -10073,6 +10081,33 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
       "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
+    },
+    "node_modules/decentraland-connect/node_modules/@magic-sdk/commons": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@magic-sdk/commons/-/commons-23.0.0.tgz",
+      "integrity": "sha512-y94UJG9WRrSnxTh6+WnLAvSRjYmE1/kJtTABD/MWJcIIN/qY7LV3mBdY6PzcYbhXvcz2jedmZ2YPnzVWJgJCrA==",
+      "peerDependencies": {
+        "@magic-sdk/provider": ">=18.6.0",
+        "@magic-sdk/types": ">=15.8.0"
+      }
+    },
+    "node_modules/decentraland-connect/node_modules/@magic-sdk/provider": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@magic-sdk/provider/-/provider-27.0.0.tgz",
+      "integrity": "sha512-k2haK2zhYkqf+cbMF+/HKvqa8qPWqdZbW10qgN6AdqaOE750ceC3GDQCUwAfkzdofmWrRtFgW5jVAVCVz5WklQ==",
+      "dependencies": {
+        "@magic-sdk/types": "^23.0.0",
+        "eventemitter3": "^4.0.4",
+        "web3-core": "1.5.2"
+      },
+      "peerDependencies": {
+        "localforage": "^1.7.4"
+      }
+    },
+    "node_modules/decentraland-connect/node_modules/@magic-sdk/types": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@magic-sdk/types/-/types-23.0.0.tgz",
+      "integrity": "sha512-NTjgGPJVYxoncSrHtDZLDiJzdSbxHV0jCy6J+YvT+LY7QUiGY3zzu+NhLqgLxE6KZODXERhSLYSimotcokZbmw=="
     },
     "node_modules/decentraland-connect/node_modules/@noble/curves": {
       "version": "1.2.0",
@@ -10137,6 +10172,17 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/decentraland-connect/node_modules/magic-sdk": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/magic-sdk/-/magic-sdk-27.0.0.tgz",
+      "integrity": "sha512-FpLHSR6+OC4JYOqRE0dX8u7qGOa6L9bxdGIODlB6DUyuoO0jxghKxlAqGE2ZAMVkJEwwTV8Mm3JZCZxtf2eGJg==",
+      "dependencies": {
+        "@magic-sdk/commons": "^23.0.0",
+        "@magic-sdk/provider": "^27.0.0",
+        "@magic-sdk/types": "^23.0.0",
+        "localforage": "^1.7.4"
+      }
     },
     "node_modules/decentraland-connect/node_modules/ws": {
       "version": "8.5.0",
@@ -10218,6 +10264,11 @@
         "redux-saga": "^1.1.3"
       }
     },
+    "node_modules/decentraland-dapps/node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
+    },
     "node_modules/decentraland-dapps/node_modules/@formatjs/intl": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.2.1.tgz",
@@ -10240,6 +10291,41 @@
         }
       }
     },
+    "node_modules/decentraland-dapps/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/decentraland-dapps/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/decentraland-dapps/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/decentraland-dapps/node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+    },
     "node_modules/decentraland-dapps/node_modules/axios": {
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
@@ -10252,6 +10338,53 @@
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+    },
+    "node_modules/decentraland-dapps/node_modules/decentraland-connect": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-7.3.3.tgz",
+      "integrity": "sha512-dA5z5dFfGCg06Jw1bXIvNvWH4Opotzr4oHJSdX2A0vtRuqY4+WXXX4LEwSUmw/NXuut6mGmpITTA6xUVvSmtdA==",
+      "dependencies": {
+        "@dcl/schemas": "^15.1.2",
+        "@dcl/single-sign-on-client": "^0.1.0",
+        "@magic-ext/oauth": "^15.5.0",
+        "@walletconnect/ethereum-provider": "^2.17.1",
+        "@walletconnect/modal": "^2.6.2",
+        "@web3-react/fortmatic-connector": "^6.1.6",
+        "@web3-react/injected-connector": "^6.0.7",
+        "@web3-react/network-connector": "^6.1.3",
+        "@web3-react/walletlink-connector": "^6.2.13",
+        "ethers": "^6.9.1",
+        "magic-sdk": "^21.4.1",
+        "socket.io-client": "^4.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/decentraland-dapps/node_modules/decentraland-connect/node_modules/ethers": {
+      "version": "6.13.5",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.5.tgz",
+      "integrity": "sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/decentraland-dapps/node_modules/decentraland-crypto-fetch": {
       "version": "2.0.1",
@@ -10313,6 +10446,11 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/decentraland-dapps/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "node_modules/decentraland-transactions": {
       "version": "2.18.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -20,7 +20,7 @@
     "date-fns": "^2.23.0",
     "dcl-catalyst-client": "21.2.0",
     "dcl-catalyst-commons": "^9.0.1",
-    "decentraland-connect": "^7.3.2",
+    "decentraland-connect": "^8.0.1",
     "decentraland-crypto-fetch": "^1.0.3",
     "decentraland-dapps": "^23.25.1",
     "decentraland-transactions": "^2.18.1",


### PR DESCRIPTION
This PR updates `decentraland-connect` and `decentraland-dapps` to use the new Magic's OAuth V2 provider.