### PR TITLE
feat: Add off chain marketplace to contract settings

### DIFF
--- a/webapp/src/components/SettingsPage/SettingsPage.tsx
+++ b/webapp/src/components/SettingsPage/SettingsPage.tsx
@@ -44,6 +44,16 @@ const SettingsPage = (props: Props) => {
     network: Network.MATIC
   })
 
+  const offChainMarketplaceEthereum = getContract({
+    name: contractNames.OFF_CHAIN_MARKETPLACE,
+    network: Network.ETHEREUM
+  })
+
+  const offChainMarketplaceMatic = getContract({
+    name: contractNames.OFF_CHAIN_MARKETPLACE,
+    network: Network.MATIC
+  })
+
   const bidsEthereum = getContract({
     name: contractNames.BIDS,
     network: Network.ETHEREUM
@@ -75,6 +85,8 @@ const SettingsPage = (props: Props) => {
     !collectionStore ||
     !marketplaceEthereum ||
     !marketplaceMatic ||
+    !offChainMarketplaceEthereum ||
+    !offChainMarketplaceMatic ||
     !bidsEthereum ||
     !bidsMatic ||
     !manaEthereum ||
@@ -174,6 +186,26 @@ const SettingsPage = (props: Props) => {
                             authorization={{
                               address: wallet.address,
                               authorizedAddress: marketplaceMatic.address,
+                              contractAddress: manaMatic.address,
+                              contractName: ContractName.MANAToken,
+                              chainId: manaMatic.chainId,
+                              type: AuthorizationType.ALLOWANCE
+                            }}
+                          />
+                          <Authorization
+                            authorization={{
+                              address: wallet.address,
+                              authorizedAddress: offChainMarketplaceEthereum.address,
+                              contractAddress: manaEthereum.address,
+                              contractName: ContractName.MANAToken,
+                              chainId: manaEthereum.chainId,
+                              type: AuthorizationType.ALLOWANCE
+                            }}
+                          />
+                          <Authorization
+                            authorization={{
+                              address: wallet.address,
+                              authorizedAddress: offChainMarketplaceMatic.address,
                               contractAddress: manaMatic.address,
                               contractName: ContractName.MANAToken,
                               chainId: manaMatic.chainId,

--- a/webapp/src/modules/contract/sagas.spec.ts
+++ b/webapp/src/modules/contract/sagas.spec.ts
@@ -60,6 +60,24 @@ describe('when handling the fetch contracts request', () => {
         vendor: VendorName.DECENTRALAND
       }
 
+      const offChainMarketplaceEthereum: Contract = {
+        address: 'offChainMarketplaceEthereumAddress',
+        category: null,
+        chainId: ChainId.ETHEREUM_MAINNET,
+        name: contractNames.OFF_CHAIN_MARKETPLACE,
+        network: Network.ETHEREUM,
+        vendor: VendorName.DECENTRALAND
+      }
+
+      const offChainMarketplaceMatic: Contract = {
+        address: 'offChainMarketplaceMaticAddress',
+        category: null,
+        chainId: ChainId.MATIC_MAINNET,
+        name: contractNames.OFF_CHAIN_MARKETPLACE,
+        network: Network.MATIC,
+        vendor: VendorName.DECENTRALAND
+      }
+
       const legacyMarketplace: Contract = {
         address: 'legacyMarketplaceAddress',
         category: null,
@@ -144,6 +162,20 @@ describe('when handling the fetch contracts request', () => {
           ],
           [
             select(getContract, {
+              name: contractNames.OFF_CHAIN_MARKETPLACE,
+              network: Network.ETHEREUM
+            }),
+            offChainMarketplaceEthereum
+          ],
+          [
+            select(getContract, {
+              name: contractNames.OFF_CHAIN_MARKETPLACE,
+              network: Network.MATIC
+            }),
+            offChainMarketplaceMatic
+          ],
+          [
+            select(getContract, {
               name: contractNames.LEGACY_MARKETPLACE,
               network: Network.MATIC
             }),
@@ -208,6 +240,22 @@ describe('when handling the fetch contracts request', () => {
         .put(fetchContractsSuccess([]))
         .put(
           fetchAuthorizationsRequest([
+            {
+              address,
+              authorizedAddress: offChainMarketplaceEthereum.address,
+              contractAddress: manaEthereum.address,
+              contractName: ContractName.MANAToken,
+              chainId: ChainId.ETHEREUM_GOERLI,
+              type: AuthorizationType.ALLOWANCE
+            },
+            {
+              address,
+              authorizedAddress: offChainMarketplaceMatic.address,
+              contractAddress: manaMatic.address,
+              contractName: ContractName.MANAToken,
+              chainId: ChainId.MATIC_AMOY,
+              type: AuthorizationType.ALLOWANCE
+            },
             {
               address,
               authorizedAddress: marketplaceEthereum.address,

--- a/webapp/src/modules/contract/sagas.ts
+++ b/webapp/src/modules/contract/sagas.ts
@@ -68,6 +68,16 @@ export function* handleFetchContractsSuccess() {
     network: Network.MATIC
   })) as ReturnType<typeof getContract>
 
+  const offChainMarketplaceEthereum: Contract | null = (yield select(getContract, {
+    name: contractNames.OFF_CHAIN_MARKETPLACE,
+    network: Network.ETHEREUM
+  })) as ReturnType<typeof getContract>
+
+  const offChainMarketplaceMatic: Contract | null = (yield select(getContract, {
+    name: contractNames.OFF_CHAIN_MARKETPLACE,
+    network: Network.MATIC
+  })) as ReturnType<typeof getContract>
+
   const legacyMarketplaceMatic: Contract | null = (yield select(getContract, {
     name: contractNames.LEGACY_MARKETPLACE,
     network: Network.MATIC
@@ -116,6 +126,17 @@ export function* handleFetchContractsSuccess() {
     })
   }
 
+  if (offChainMarketplaceEthereum && manaEthereum) {
+    authorizations.push({
+      address,
+      authorizedAddress: offChainMarketplaceEthereum.address,
+      contractAddress: manaEthereum.address,
+      contractName: ContractName.MANAToken,
+      chainId: manaEthereum.chainId,
+      type: AuthorizationType.ALLOWANCE
+    })
+  }
+
   if (marketplaceMatic && manaMatic) {
     authorizations.push({
       address,
@@ -131,6 +152,17 @@ export function* handleFetchContractsSuccess() {
     authorizations.push({
       address,
       authorizedAddress: legacyMarketplaceMatic.address,
+      contractAddress: manaMatic.address,
+      contractName: ContractName.MANAToken,
+      chainId: manaMatic.chainId,
+      type: AuthorizationType.ALLOWANCE
+    })
+  }
+
+  if (offChainMarketplaceMatic && manaMatic) {
+    authorizations.push({
+      address,
+      authorizedAddress: offChainMarketplaceMatic.address,
       contractAddress: manaMatic.address,
       contractName: ContractName.MANAToken,
       chainId: manaMatic.chainId,

--- a/webapp/src/modules/contract/sagas.ts
+++ b/webapp/src/modules/contract/sagas.ts
@@ -18,8 +18,7 @@ import { getAuthorizationKey } from './utils'
 export function* contractSaga() {
   yield takeEvery(FETCH_CONTRACTS_REQUEST, handleFetchContractsRequest)
   yield takeEvery(FETCH_CONTRACTS_SUCCESS, handleFetchContractsSuccess)
-  yield takeEvery(CHANGE_ACCOUNT, handleChangeAccount)
-  yield takeEvery(CONNECT_WALLET_SUCCESS, handleConnectWalletSuccess)
+  yield takeEvery([CHANGE_ACCOUNT, CONNECT_WALLET_SUCCESS], handleWalletChange)
   yield takeEvery(FETCH_TRANSACTION_SUCCESS, handleFetchTransactionSuccess)
 }
 
@@ -115,10 +114,10 @@ export function* handleFetchContractsSuccess() {
 
   let authorizations: Authorization[] = []
 
-  if (marketplaceEthereum && manaEthereum) {
+  if (offChainMarketplaceEthereum && manaEthereum) {
     authorizations.push({
       address,
-      authorizedAddress: marketplaceEthereum.address,
+      authorizedAddress: offChainMarketplaceEthereum.address,
       contractAddress: manaEthereum.address,
       contractName: ContractName.MANAToken,
       chainId: manaEthereum.chainId,
@@ -126,10 +125,21 @@ export function* handleFetchContractsSuccess() {
     })
   }
 
-  if (offChainMarketplaceEthereum && manaEthereum) {
+  if (offChainMarketplaceMatic && manaMatic) {
     authorizations.push({
       address,
-      authorizedAddress: offChainMarketplaceEthereum.address,
+      authorizedAddress: offChainMarketplaceMatic.address,
+      contractAddress: manaMatic.address,
+      contractName: ContractName.MANAToken,
+      chainId: manaMatic.chainId,
+      type: AuthorizationType.ALLOWANCE
+    })
+  }
+
+  if (marketplaceEthereum && manaEthereum) {
+    authorizations.push({
+      address,
+      authorizedAddress: marketplaceEthereum.address,
       contractAddress: manaEthereum.address,
       contractName: ContractName.MANAToken,
       chainId: manaEthereum.chainId,
@@ -152,17 +162,6 @@ export function* handleFetchContractsSuccess() {
     authorizations.push({
       address,
       authorizedAddress: legacyMarketplaceMatic.address,
-      contractAddress: manaMatic.address,
-      contractName: ContractName.MANAToken,
-      chainId: manaMatic.chainId,
-      type: AuthorizationType.ALLOWANCE
-    })
-  }
-
-  if (offChainMarketplaceMatic && manaMatic) {
-    authorizations.push({
-      address,
-      authorizedAddress: offChainMarketplaceMatic.address,
       contractAddress: manaMatic.address,
       contractName: ContractName.MANAToken,
       chainId: manaMatic.chainId,
@@ -265,15 +264,10 @@ export function* handleFetchContractsSuccess() {
   )
 
   authorizations = authorizations.filter(authorization => !storeAuthorizationsMap.has(getAuthorizationKey(authorization)))
-
   yield put(fetchAuthorizationsRequest(authorizations))
 }
 
-function* handleChangeAccount() {
-  yield put(resetHasFetched())
-}
-
-function* handleConnectWalletSuccess() {
+function* handleWalletChange() {
   yield put(resetHasFetched())
 }
 

--- a/webapp/src/modules/vendor/decentraland/contracts.ts
+++ b/webapp/src/modules/vendor/decentraland/contracts.ts
@@ -7,6 +7,7 @@ export const LEGACY_MARKETPLACE_MAINNET_CONTRACT = '0xb3bca6f5052c7e24726b44da74
 export enum ContractName {
   MANA = 'MANA',
   MARKETPLACE = 'Marketplace',
+  OFF_CHAIN_MARKETPLACE = 'OffChainMarketplace',
   LEGACY_MARKETPLACE = 'LegacyMarketplace',
   BIDS = 'Bids',
   COLLECTION_STORE = 'CollectionStore',
@@ -467,6 +468,14 @@ const localContracts = {
       chainId: ChainId.ETHEREUM_SEPOLIA
     },
     {
+      name: ContractName.OFF_CHAIN_MARKETPLACE,
+      address: getContract(CN.OffChainMarketplace, ChainId.ETHEREUM_SEPOLIA).address,
+      vendor: 'decentraland',
+      category: null,
+      network: Network.ETHEREUM,
+      chainId: ChainId.ETHEREUM_SEPOLIA
+    },
+    {
       name: ContractName.BIDS,
       address: getContract(CN.Bid, ChainId.ETHEREUM_SEPOLIA).address,
       vendor: 'decentraland',
@@ -494,6 +503,14 @@ const localContracts = {
       name: ContractName.MARKETPLACE,
       address: getContract(CN.MarketplaceV2, ChainId.MATIC_AMOY).address,
       label: 'MarketplaceV2',
+      vendor: 'decentraland',
+      category: null,
+      network: Network.MATIC,
+      chainId: ChainId.MATIC_AMOY
+    },
+    {
+      name: ContractName.OFF_CHAIN_MARKETPLACE,
+      address: getContract(CN.OffChainMarketplace, ChainId.MATIC_AMOY).address,
       vendor: 'decentraland',
       category: null,
       network: Network.MATIC,
@@ -619,6 +636,14 @@ const localContracts = {
       chainId: ChainId.ETHEREUM_MAINNET
     },
     {
+      name: ContractName.OFF_CHAIN_MARKETPLACE,
+      address: getContract(CN.OffChainMarketplace, ChainId.ETHEREUM_MAINNET).address,
+      vendor: 'decentraland',
+      category: null,
+      network: Network.ETHEREUM,
+      chainId: ChainId.ETHEREUM_MAINNET
+    },
+    {
       name: ContractName.BIDS,
       address: getContract(CN.Bid, ChainId.ETHEREUM_MAINNET).address,
       vendor: 'decentraland',
@@ -645,6 +670,14 @@ const localContracts = {
     {
       name: ContractName.MARKETPLACE,
       address: getContract(CN.MarketplaceV2, ChainId.MATIC_MAINNET).address,
+      vendor: 'decentraland',
+      category: null,
+      network: Network.MATIC,
+      chainId: ChainId.MATIC_MAINNET
+    },
+    {
+      name: ContractName.OFF_CHAIN_MARKETPLACE,
+      address: getContract(CN.OffChainMarketplace, ChainId.MATIC_MAINNET).address,
       vendor: 'decentraland',
       category: null,
       network: Network.MATIC,


### PR DESCRIPTION
This PR adds the off chain marketplace to the settings page to allow or revoke the handling of MANA.
There's one slight issue with the settings handling. The name of the contracts is the same for all of the marketplace's contracts. This should be addressed in another PR.