### PR TITLE
feat: Add magic auto authorization feature

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -27,7 +27,7 @@
         "dcl-catalyst-commons": "^9.0.1",
         "decentraland-connect": "^9.0.0",
         "decentraland-crypto-fetch": "^1.0.3",
-        "decentraland-dapps": "^23.26.1",
+        "decentraland-dapps": "^23.28.0",
         "decentraland-transactions": "^2.18.3",
         "decentraland-ui": "^6.12.1",
         "decentraland-ui2": "^0.10.1",
@@ -10188,9 +10188,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "23.26.1",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-23.26.1.tgz",
-      "integrity": "sha512-bGgvt3h/lwGM09SBZxJBxRa7OZrxfGIPNhUK4VRmu5GurJbuiDcbwiX5nnAtNCT1t/oYzcU+ji+CzV/539sptA==",
+      "version": "23.28.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-23.28.0.tgz",
+      "integrity": "sha512-l3tigLZzANR1D3yhHPRbe1QqvlW4PAKPkQSimBdWHYOlx7vIW99bFjRDMWiYnpWFugeBX9mGnKVexleE1rjxKw==",
       "dependencies": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,7 +22,7 @@
     "dcl-catalyst-commons": "^9.0.1",
     "decentraland-connect": "^9.0.0",
     "decentraland-crypto-fetch": "^1.0.3",
-    "decentraland-dapps": "^23.26.1",
+    "decentraland-dapps": "^23.28.0",
     "decentraland-transactions": "^2.18.3",
     "decentraland-ui": "^6.12.1",
     "decentraland-ui2": "^0.10.1",

--- a/webapp/src/components/AssetPage/BidsTable/BidsTableContent/BidsTableContent.tsx
+++ b/webapp/src/components/AssetPage/BidsTable/BidsTableContent/BidsTableContent.tsx
@@ -28,7 +28,17 @@ import styles from './BidsTableContent.module.css'
 export const ROWS_PER_PAGE = 5
 const INITIAL_PAGE = 1
 
-function BidsTableContent({ asset, isBidsOffchainEnabled, address, sortBy, isAcceptingBid, onAccept, onAuthorizedAction }: Props) {
+function BidsTableContent({
+  asset,
+  isBidsOffchainEnabled,
+  address,
+  sortBy,
+  isAcceptingBid,
+  onAccept,
+  onAuthorizedAction,
+  isLoadingAuthorization,
+  authorizationError
+}: Props) {
   const isMobileOrTablet = useTabletAndBelowMediaQuery()
   const history = useHistory()
   const [bids, setBids] = useState<DataTableType[]>([])
@@ -185,8 +195,9 @@ function BidsTableContent({ asset, isBidsOffchainEnabled, address, sortBy, isAcc
                 valueToConfirm={ethers.utils.formatEther(showConfirmationModal.bid.price)}
                 network={nft.network}
                 onCancel={() => setShowConfirmationModal({ display: false, bid: null })}
-                loading={isAcceptingBid}
-                disabled={isAcceptingBid}
+                loading={isAcceptingBid || isLoadingAuthorization}
+                disabled={isAcceptingBid || isLoadingAuthorization}
+                error={authorizationError}
               />
             )
           }

--- a/webapp/src/components/Bid/Bid.tsx
+++ b/webapp/src/components/Bid/Bid.tsx
@@ -31,6 +31,8 @@ const Bid = (props: Props) => {
     archivedBidIds,
     isBidsOffchainEnabled,
     onAuthorizedAction,
+    isLoadingAuthorization,
+    authorizationError,
     onAccept,
     onArchive,
     onUnarchive,
@@ -169,8 +171,9 @@ const Bid = (props: Props) => {
                 valueToConfirm={ethers.utils.formatEther(bid.price)}
                 network={asset.network}
                 onCancel={() => setShowConfirmationModal(false)}
-                loading={isAcceptingBid}
-                disabled={isAcceptingBid}
+                loading={isAcceptingBid || isLoadingAuthorization}
+                disabled={isAcceptingBid || isLoadingAuthorization}
+                error={authorizationError}
               />
             )
           }

--- a/webapp/src/components/BidPage/BidModal/BidModal.tsx
+++ b/webapp/src/components/BidPage/BidModal/BidModal.tsx
@@ -27,7 +27,18 @@ import { Props } from './BidModal.types'
 import './BidModal.css'
 
 const BidModal = (props: Props) => {
-  const { asset, rental, wallet, onNavigate, onPlaceBid, isPlacingBid, isLoadingAuthorization, isBidsOffchainEnabled, getContract } = props
+  const {
+    asset,
+    rental,
+    wallet,
+    onNavigate,
+    onPlaceBid,
+    isPlacingBid,
+    isLoadingAuthorization,
+    authorizationError,
+    isBidsOffchainEnabled,
+    getContract
+  } = props
 
   const [price, setPrice] = useState('')
   const [expiresAt, setExpiresAt] = useState(getDefaultExpirationDate())
@@ -87,7 +98,6 @@ const BidModal = (props: Props) => {
       (wallet?.chainId as ChainId) !== ChainId.MATIC_MAINNET && !!price && isPriceTooLow(ethers.utils.parseEther(price || '0').toString()), // not connected to polygon AND has price < minimum for meta tx
     [price, wallet?.chainId]
   )
-  console.log('hasLowPriceForMetaTx: ', hasLowPriceForMetaTx)
 
   const isDisabled =
     isOwnedBy(asset, wallet) ||
@@ -214,6 +224,7 @@ const BidModal = (props: Props) => {
             onConfirm={handleConfirmBid}
             valueToConfirm={price}
             network={asset.network}
+            error={authorizationError}
             onCancel={() => setShowConfirmationModal(false)}
             loading={isPlacingBid || isLoadingAuthorization}
             disabled={isPlacingBid || isLoadingAuthorization}

--- a/webapp/src/components/Campaign/CampaignBrowserPage/CampaignBrowserPage.tsx
+++ b/webapp/src/components/Campaign/CampaignBrowserPage/CampaignBrowserPage.tsx
@@ -30,7 +30,6 @@ const CampaignBrowserPage = (props: Props) => {
 
   useEffect(() => {
     if (campaignTag && !isFetchingEvent && Object.values(contracts).length === 0) {
-      console.log('Fetching event contracts', campaignTag, additionalCampaignTags)
       onFetchEventContracts(campaignTag, additionalCampaignTags ?? [])
     }
   }, [onFetchEventContracts, campaignTag, isFetchingEvent, contracts])

--- a/webapp/src/components/ConfirmInputValueModal/ConfirmInputValueModal.tsx
+++ b/webapp/src/components/ConfirmInputValueModal/ConfirmInputValueModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
-import { Modal, Button, ModalNavigation } from 'decentraland-ui'
+import { Modal, Button, ModalNavigation, Message } from 'decentraland-ui'
 import { ManaField } from '../ManaField'
 import { Props } from './ConfirmInputValueModal.types'
 import './ConfirmInputValueModal.css'
@@ -14,6 +14,7 @@ const ConfirmInputValueModal = ({
   onConfirm,
   loading = false,
   disabled = false,
+  error,
   network
 }: Props) => {
   const [confirmedInput, setConfirmedInput] = useState<string>('')
@@ -37,6 +38,7 @@ const ConfirmInputValueModal = ({
             setConfirmedInput(props.value)
           }}
         />
+        {error ? <Message error size="tiny" visible content={error} header={t('global.error')} /> : null}
       </Modal.Content>
       <Modal.Actions>
         <Button

--- a/webapp/src/components/ConfirmInputValueModal/ConfirmInputValueModal.types.ts
+++ b/webapp/src/components/ConfirmInputValueModal/ConfirmInputValueModal.types.ts
@@ -8,6 +8,7 @@ export type Props = {
   loading?: boolean
   network: Network
   disabled?: boolean
+  error?: string | null
   valueToConfirm: string
   onCancel: () => void
   onConfirm: () => void

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.container.ts
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.container.ts
@@ -3,6 +3,7 @@ import { Dispatch } from 'redux'
 import { openBuyManaWithFiatModalRequest } from 'decentraland-dapps/dist/modules/gateway/actions'
 import { switchNetworkRequest } from 'decentraland-dapps/dist/modules/wallet/actions'
 import { isSwitchingNetwork } from 'decentraland-dapps/dist/modules/wallet/selectors'
+import { getIsMagicAutoSignEnabled } from '../../../modules/features/selectors'
 import { RootState } from '../../../modules/reducer'
 import { getIsBuyWithCardPage } from '../../../modules/routing/selectors'
 import { getWallet } from '../../../modules/wallet/selectors'
@@ -13,7 +14,8 @@ const mapState = (state: RootState): MapStateProps => {
   return {
     wallet: getWallet(state),
     isSwitchingNetwork: isSwitchingNetwork(state),
-    isBuyWithCardPage: getIsBuyWithCardPage(state)
+    isBuyWithCardPage: getIsBuyWithCardPage(state),
+    isMagicAutoSignEnabled: getIsMagicAutoSignEnabled(state)
   }
 }
 

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.types.ts
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.types.ts
@@ -8,7 +8,7 @@ import type { CrossChainProvider, Route, Token } from 'decentraland-transactions
 import { Asset } from '../../../modules/asset/types'
 import { CrossChainRoute, GasCost } from './hooks'
 
-export type MapStateProps = Pick<Props, 'wallet' | 'isBuyWithCardPage' | 'isSwitchingNetwork'>
+export type MapStateProps = Pick<Props, 'wallet' | 'isBuyWithCardPage' | 'isSwitchingNetwork' | 'isMagicAutoSignEnabled'>
 export type MapDispatchProps = Pick<Props, 'onGetMana' | 'onSwitchNetwork'>
 export type OnGetGasCost = (selectedToken: Token, nativeChainToken: Token | undefined, wallet: Wallet | null) => GasCost
 export type OnGetCrossChainRoute = (
@@ -27,6 +27,7 @@ export type Props = Pick<WithAuthorizedActionProps, 'isLoadingAuthorization'> &
     isBuyingAsset: boolean
     isSwitchingNetwork: boolean
     isBuyWithCardPage: boolean
+    isMagicAutoSignEnabled: boolean
     onGetCrossChainRoute: OnGetCrossChainRoute
     onGetGasCost: OnGetGasCost
     onSwitchNetwork: typeof switchNetworkRequest

--- a/webapp/src/components/Modals/ConfirmRentModal/ConfirmRentModal.tsx
+++ b/webapp/src/components/Modals/ConfirmRentModal/ConfirmRentModal.tsx
@@ -28,6 +28,7 @@ const ConfirmRentModal = ({
   onAuthorizedAction,
   getContract,
   isLoadingAuthorization,
+  authorizationError,
   onClearRentalErrors,
   error
 }: Props) => {
@@ -56,7 +57,7 @@ const ConfirmRentModal = ({
     if (isUserTheOperatorAddress) {
       setOperatorAddress('')
     } else {
-      setOperatorAddress(wallet!.address)
+      setOperatorAddress(wallet.address)
     }
     setIsUserTheOperatorAddress(!isUserTheOperatorAddress)
   }, [isUserTheOperatorAddress, wallet, setIsUserTheOperatorAddress])
@@ -131,7 +132,9 @@ const ConfirmRentModal = ({
           </div>
         </div>
 
-        {error ? <Message error size="tiny" visible content={error} header={t('global.error')} /> : null}
+        {error || authorizationError ? (
+          <Message error size="tiny" visible content={error || authorizationError} header={t('global.error')} />
+        ) : null}
       </Modal.Content>
       <Modal.Actions className={styles.actions}>
         <Button className={styles.cancel} secondary disabled={isLoading} onClick={onClose}>

--- a/webapp/src/components/Modals/RentalListingModal/RentalListingModal.module.css
+++ b/webapp/src/components/Modals/RentalListingModal/RentalListingModal.module.css
@@ -87,18 +87,15 @@
   height: 64px;
 }
 
-.actions {
+.modal:global(.ui.modal > .actions) {
   flex-direction: column;
   align-items: center;
+  gap: 10px;
 }
 
-.actions :global(.ui.button) {
+.modal:global(.ui.modal > .actions > .ui.button) {
   width: 100%;
-}
-
-.actions :global(.ui.primary.button) + :global(.ui.secondary.button) {
-  margin-left: 0px;
-  margin-top: 15px;
+  margin: 0px;
 }
 
 @media (max-width: 767px) {

--- a/webapp/src/components/SellPage/SellModal/SellModal.tsx
+++ b/webapp/src/components/SellPage/SellModal/SellModal.tsx
@@ -39,6 +39,8 @@ const SellModal = (props: Props) => {
     isCreatingOrder,
     isOffchainPublicNFTOrdersEnabled,
     isLoadingCancelOrder,
+    isLoadingAuthorization,
+    authorizationError,
     getContract,
     onGoBack,
     onCancelOrder,
@@ -230,10 +232,11 @@ const SellModal = (props: Props) => {
         }
         onConfirm={handleSubmit}
         valueToConfirm={price}
+        error={authorizationError}
         network={nft.network}
         onCancel={() => setShowConfirm(false)}
-        loading={isCreatingOrder}
-        disabled={isCreatingOrder}
+        loading={isCreatingOrder || isLoadingAuthorization}
+        disabled={isCreatingOrder || isLoadingAuthorization}
       />
     </AssetAction>
   )

--- a/webapp/src/components/SellPage/SellModal/SellModal.types.ts
+++ b/webapp/src/components/SellPage/SellModal/SellModal.types.ts
@@ -9,7 +9,7 @@ import { Contract } from '../../../modules/vendor/services'
 export type Props = {
   nft: NFT
   order: Order | null
-  wallet: Wallet | null
+  wallet?: Wallet | null
   isLoading: boolean
   isCreatingOrder: boolean
   isOffchainPublicNFTOrdersEnabled: boolean

--- a/webapp/src/modules/features/selectors.spec.ts
+++ b/webapp/src/modules/features/selectors.spec.ts
@@ -14,7 +14,8 @@ import {
   getIsChainSelectorEnabled,
   getIsBidsOffChainEnabled,
   getIsOffchainPublicNFTOrdersEnabled,
-  getIsOffchainPublicItemOrdersEnabled
+  getIsOffchainPublicItemOrdersEnabled,
+  getIsMagicAutoSignEnabled
 } from './selectors'
 import { FeatureName } from './types'
 
@@ -46,6 +47,10 @@ beforeEach(() => {
   } as any
   getIsFeatureEnabledMock = getIsFeatureEnabled as jest.MockedFunction<typeof getIsFeatureEnabled>
   hasLoadedInitialFlagsMock = hasLoadedInitialFlags as jest.MockedFunction<typeof hasLoadedInitialFlags>
+
+  // Reset mocks before each test
+  getIsFeatureEnabledMock.mockReset()
+  hasLoadedInitialFlagsMock.mockReset()
 })
 
 describe('when getting the loading state of the features state', () => {
@@ -58,31 +63,36 @@ const tryCatchSelectors = [
   {
     name: 'IsMaintenance',
     feature: FeatureName.MAINTENANCE,
-    selector: getIsMaintenanceEnabled
+    selector: getIsMaintenanceEnabled,
+    applicationName: ApplicationName.MARKETPLACE
   },
   {
     name: 'IsMarketplaceLaunchPopup',
     feature: FeatureName.LAUNCH_POPUP,
-    selector: getIsMarketplaceLaunchPopupEnabled
+    selector: getIsMarketplaceLaunchPopupEnabled,
+    applicationName: ApplicationName.MARKETPLACE
   },
   {
     name: 'IsCampaignHomepageBanner',
     feature: FeatureName.CAMPAIGN_HOMEPAGE_BANNER,
-    selector: getIsCampaignHomepageBannerEnabled
+    selector: getIsCampaignHomepageBannerEnabled,
+    applicationName: ApplicationName.MARKETPLACE
   },
   {
     name: 'IsCampaignCollectionsBanner',
     feature: FeatureName.CAMPAIGN_COLLECTIBLES_BANNER,
-    selector: getIsCampaignCollectiblesBannerEnabled
+    selector: getIsCampaignCollectiblesBannerEnabled,
+    applicationName: ApplicationName.MARKETPLACE
   },
   {
     name: 'IsCampaignBrowser',
     feature: FeatureName.CAMPAIGN_BROWSER,
-    selector: getIsCampaignBrowserEnabled
+    selector: getIsCampaignBrowserEnabled,
+    applicationName: ApplicationName.MARKETPLACE
   }
 ]
 
-tryCatchSelectors.forEach(({ name, feature, selector }) =>
+tryCatchSelectors.forEach(({ name, feature, applicationName, selector }) =>
   describe(`when getting if the ${name} feature flag is enabled`, () => {
     describe('when the isFeatureEnabled selector fails', () => {
       beforeEach(() => {
@@ -95,7 +105,7 @@ tryCatchSelectors.forEach(({ name, feature, selector }) =>
         const isEnabled = selector(state)
 
         expect(isEnabled).toBe(false)
-        expect(getIsFeatureEnabledMock).toHaveBeenCalledWith(state, ApplicationName.MARKETPLACE, feature)
+        expect(getIsFeatureEnabledMock).toHaveBeenCalledWith(state, applicationName, feature)
       })
     })
 
@@ -108,7 +118,7 @@ tryCatchSelectors.forEach(({ name, feature, selector }) =>
         const isEnabled = selector(state)
 
         expect(isEnabled).toBe(false)
-        expect(getIsFeatureEnabledMock).toHaveBeenCalledWith(state, ApplicationName.MARKETPLACE, feature)
+        expect(getIsFeatureEnabledMock).toHaveBeenCalledWith(state, applicationName, feature)
       })
     })
 
@@ -121,7 +131,7 @@ tryCatchSelectors.forEach(({ name, feature, selector }) =>
         const isEnabled = selector(state)
 
         expect(isEnabled).toBe(true)
-        expect(getIsFeatureEnabledMock).toHaveBeenCalledWith(state, ApplicationName.MARKETPLACE, feature)
+        expect(getIsFeatureEnabledMock).toHaveBeenCalledWith(state, applicationName, feature)
       })
     })
   })
@@ -131,7 +141,8 @@ const waitForInitialLoadingSelectors = [
   {
     name: 'isSmartWearablesFTU',
     feature: FeatureName.SMART_WEARABLES_FTU,
-    selector: getIsSmartWearablesFTUEnabled
+    selector: getIsSmartWearablesFTUEnabled,
+    applicationName: ApplicationName.MARKETPLACE
   },
   {
     name: 'chain-selector',
@@ -155,6 +166,12 @@ const waitForInitialLoadingSelectors = [
     name: 'sfOffchainPublicItemOrdersEnabled',
     feature: FeatureName.OFFCHAIN_PUBLIC_ITEM_ORDERS,
     selector: getIsOffchainPublicItemOrdersEnabled,
+    applicationName: ApplicationName.DAPPS
+  },
+  {
+    name: 'IsMagicAutoSignEnabled',
+    feature: FeatureName.MAGIC_AUTO_SIGN,
+    selector: getIsMagicAutoSignEnabled,
     applicationName: ApplicationName.DAPPS
   }
 ]
@@ -187,7 +204,7 @@ waitForInitialLoadingSelectors.forEach(({ name, feature, applicationName, select
           const isEnabled = selector(state)
 
           expect(isEnabled).toBe(false)
-          expect(getIsFeatureEnabledMock).toHaveBeenCalledWith(state, applicationName || ApplicationName.MARKETPLACE, feature)
+          expect(getIsFeatureEnabledMock).toHaveBeenCalledWith(state, applicationName, feature)
         })
       })
 
@@ -200,7 +217,7 @@ waitForInitialLoadingSelectors.forEach(({ name, feature, applicationName, select
           const isEnabled = selector(state)
 
           expect(isEnabled).toBe(true)
-          expect(getIsFeatureEnabledMock).toHaveBeenCalledWith(state, applicationName || ApplicationName.MARKETPLACE, feature)
+          expect(getIsFeatureEnabledMock).toHaveBeenCalledWith(state, applicationName, feature)
         })
       })
     })

--- a/webapp/src/modules/features/selectors.ts
+++ b/webapp/src/modules/features/selectors.ts
@@ -104,3 +104,10 @@ export const getIsNavbar2Enabled = (state: RootState) => {
   }
   return false
 }
+
+export const getIsMagicAutoSignEnabled = (state: RootState) => {
+  if (hasLoadedInitialFlags(state)) {
+    return getIsFeatureEnabled(state, ApplicationName.DAPPS, FeatureName.MAGIC_AUTO_SIGN)
+  }
+  return false
+}

--- a/webapp/src/modules/features/types.ts
+++ b/webapp/src/modules/features/types.ts
@@ -11,5 +11,6 @@ export enum FeatureName {
   OFFCHAIN_BIDS = 'offchain-bids',
   OFFCHAIN_PUBLIC_NFT_ORDERS = 'offchain-public-nft-orders',
   OFFCHAIN_PUBLIC_ITEM_ORDERS = 'offchain-public-item-orders',
-  NAVBAR_UI2 = 'navbar-ui2'
+  NAVBAR_UI2 = 'navbar-ui2',
+  MAGIC_AUTO_SIGN = 'magic-auto-sign'
 }

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -866,6 +866,8 @@
     "switch_network": "Switch Network to {chain}",
     "confirm_switch_network": "Confirm Network Switch in Your Wallet",
     "confirm_transaction": "Confirm Transaction in Your Wallet",
+    "buying_asset": "Buying...",
+    "authorizing_purchase": "Authorizing purchase...",
     "total": "Total",
     "route_unavailable": "Buying with {token} is not available at the moment. Get MANA, pay with a different token, or pay by card.",
     "exchange_rate": "Exchange Rate",

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -849,6 +849,8 @@
     "switch_network": "Cambiar Red a {chain}",
     "confirm_switch_network": "Confirmar el cambio de red en tu Wallet",
     "confirm_transaction": "Confirmar la transacción en tu Wallet",
+    "buying_asset": "Comprando...",
+    "authorizing_purchase": "Autorizando compra...",
     "total": "Total",
     "route_unavailable": "Comprar con {token} no está disponible en este momento. Obtenga MANA, pague con un token diferente o pague con tarjeta.",
     "exchange_rate": "Exchange Rate",

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -852,6 +852,8 @@
     "switch_network": "将网络切换到 {chain}",
     "confirm_switch_network": "确认钱包中的网络切换",
     "confirm_transaction": "确认您钱包中的交易",
+    "buying_asset": "正在购买...",
+    "authorizing_purchase": "授权购买...",
     "total": "全部的",
     "route_unavailable": "目前无法使用 {token} 购买。获取 MANA、使用不同的令牌支付或通过卡支付。",
     "exchange_rate": "汇率",


### PR DESCRIPTION
This PR adds the Magic Auto Authorization feature. This implies that Magic users will not be prompted to authorize contracts on most of the operations on the Marketplace. There's a `SellModal` that still has authorizations, but other operations should not show the authorization modal.
The new changes imply that we must propagate the error of the authorizations to the components. This is done in several components, most of them which use the `ConfirmInputValueModal` which now handles errors.