### PR TITLE
feat: Manually sign authorizations that require gas when using Magic

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -27,7 +27,7 @@
         "dcl-catalyst-commons": "^9.0.1",
         "decentraland-connect": "^9.0.0",
         "decentraland-crypto-fetch": "^1.0.3",
-        "decentraland-dapps": "^23.28.2",
+        "decentraland-dapps": "^24.6.0",
         "decentraland-transactions": "^2.18.3",
         "decentraland-ui": "^6.12.1",
         "decentraland-ui2": "^0.10.1",
@@ -2069,6 +2069,64 @@
         "ethereum-cryptography": "^1.0.3",
         "ipfs-unixfs-importer": "^7.0.3",
         "multiformats": "^9.6.3"
+      }
+    },
+    "node_modules/@dcl/hooks": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@dcl/hooks/-/hooks-0.0.2.tgz",
+      "integrity": "sha512-bNopqGEkz5VQY/CgMIQxQsWO1ZJevs5n8LM8NrFQeq6n/bULV3GK0O9QEz20kvrprfle6c+/aK/UQ5vInCilpw==",
+      "dependencies": {
+        "@sentry/browser": "^9.0.0",
+        "ua-parser-js": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@dcl/hooks/node_modules/@sentry-internal/feedback": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-9.1.0.tgz",
+      "integrity": "sha512-jTDCqkqH3QDC8m9WO4mB06hqnBRsl3p7ozoh0E774UvNB6blOEZjShhSGMMEy5jbbJajPWsOivCofUtFAwbfGw==",
+      "dependencies": {
+        "@sentry/core": "9.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@dcl/hooks/node_modules/@sentry-internal/replay-canvas": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-9.1.0.tgz",
+      "integrity": "sha512-gxredVe+mOgfNqDJ3dTLiRON3FK1rZ8d0LHp7TICK/umLkWFkuso0DbNeyKU+3XCEjCr9VM7ZRqTDMzmY6zyVg==",
+      "dependencies": {
+        "@sentry-internal/replay": "9.1.0",
+        "@sentry/core": "9.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@dcl/hooks/node_modules/@sentry/browser": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-9.1.0.tgz",
+      "integrity": "sha512-G55e5j77DqRW3LkalJLAjRRfuyKrjHaKTnwIYXa6ycO+Q1+l14pEUxu+eK5Abu2rtSdViwRSb5/G6a/miSUlYA==",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "9.1.0",
+        "@sentry-internal/feedback": "9.1.0",
+        "@sentry-internal/replay": "9.1.0",
+        "@sentry-internal/replay-canvas": "9.1.0",
+        "@sentry/core": "9.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@dcl/hooks/node_modules/@sentry/core": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.1.0.tgz",
+      "integrity": "sha512-djWEzSBpMgqdF3GQuxO+kXCUX+Mgq42G4Uah/HSUBvPDHKipMmyWlutGRoFyVPPOnCDgpHu3wCt83wbpEyVmDw==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@dcl/schemas": {
@@ -5511,6 +5569,25 @@
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-9.1.0.tgz",
+      "integrity": "sha512-S1uT+kkFlstWpwnaBTIJSwwAID8PS3aA0fIidOjNezeoUE5gOvpsjDATo9q+sl6FbGWynxMz6EnYSrq/5tuaBQ==",
+      "dependencies": {
+        "@sentry/core": "9.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/browser-utils/node_modules/@sentry/core": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.1.0.tgz",
+      "integrity": "sha512-djWEzSBpMgqdF3GQuxO+kXCUX+Mgq42G4Uah/HSUBvPDHKipMmyWlutGRoFyVPPOnCDgpHu3wCt83wbpEyVmDw==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@sentry-internal/feedback": {
       "version": "7.106.1",
       "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.106.1.tgz",
@@ -5522,6 +5599,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-9.1.0.tgz",
+      "integrity": "sha512-E2xrUoms90qvm0BVOuaZ8QfkMoTUEgoIW/35uOeaqNcL7uOIj8c5cSEQQKit2Dr7CL6W+Ci5c6Khdyd5C0NL5w==",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "9.1.0",
+        "@sentry/core": "9.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
@@ -5536,6 +5625,14 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/replay/node_modules/@sentry/core": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.1.0.tgz",
+      "integrity": "sha512-djWEzSBpMgqdF3GQuxO+kXCUX+Mgq42G4Uah/HSUBvPDHKipMmyWlutGRoFyVPPOnCDgpHu3wCt83wbpEyVmDw==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/tracing": {
@@ -6805,9 +6902,9 @@
       }
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.0"
@@ -10188,9 +10285,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "23.28.2",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-23.28.2.tgz",
-      "integrity": "sha512-gOW+s9itOBo/y+j4Z44xs939zkhe1TPZDmKZ61xq1lm1pvK35NMp/XAFqAbTOIGWieDi5v0jdyfdGhGWNZ2wfg==",
+      "version": "24.6.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-24.6.0.tgz",
+      "integrity": "sha512-ke9gVz81PdUzO2ZPn3ex7fI8unh3MnIxP6EYeM89uxwHeP5csLm/G0aWe9a8OGNnsZ9bTvY9K/rgrLOv7+owwA==",
       "dependencies": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
@@ -10210,10 +10307,11 @@
         "decentraland-crypto-fetch": "^2.0.1",
         "decentraland-transactions": "^2.18.3",
         "decentraland-ui": "^6.12.3",
-        "decentraland-ui2": "^0.10.1",
+        "decentraland-ui2": "^0.11.5",
         "ethers": "^5.7.2",
         "events": "^3.3.0",
         "flat": "^5.0.2",
+        "isbot": "^5.1.22",
         "pusher-js": "^8.0.1",
         "react-intl": "^5.20.7",
         "redux-persistence": "^1.2.0",
@@ -10291,6 +10389,48 @@
       "engines": {
         "node": ">=12",
         "npm": ">=6"
+      }
+    },
+    "node_modules/decentraland-dapps/node_modules/decentraland-ui2": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-0.11.6.tgz",
+      "integrity": "sha512-2Db9MmxJkI6q/rtQQENwlzvQuwVCUj0qz6z/Sf8z+08pv98MO815lyhmK6lGWIgwZfh87Ax4SvMI/HE9Yk3F0w==",
+      "dependencies": {
+        "@contentful/rich-text-react-renderer": "^16.0.1",
+        "@dcl/hooks": "^0.0.2",
+        "@dcl/schemas": "^15.6.0",
+        "@dcl/ui-env": "^1.5.1",
+        "@emotion/react": "^11.11.4",
+        "@emotion/styled": "^11.11.5",
+        "@mui/icons-material": "^5.16.0",
+        "@mui/material": "^5.16.0",
+        "autoprefixer": "^10.4.19",
+        "date-fns": "^3.6.0",
+        "ethereum-blockies": "^0.1.1",
+        "radash": "^11.0.0",
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2",
+        "react-tile-map": "^0.4.1"
+      }
+    },
+    "node_modules/decentraland-dapps/node_modules/decentraland-ui2/node_modules/@dcl/schemas": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-15.8.1.tgz",
+      "integrity": "sha512-XzKOtv0y1i/mVeZqJ8Xr8JCuJjDvmwayPSNLmBiG+VgsbYZ8OCLswGchRi3aIjAh1oSMcth9jevw8dBe5MIJAw==",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-keywords": "^5.1.0",
+        "mitt": "^3.0.1"
+      }
+    },
+    "node_modules/decentraland-dapps/node_modules/decentraland-ui2/node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/decentraland-dapps/node_modules/react-intl": {
@@ -10648,6 +10788,25 @@
       "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
       "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==",
       "license": "MIT"
+    },
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ]
     },
     "node_modules/detect-libc": {
       "version": "1.0.3",
@@ -14905,6 +15064,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ]
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -15024,6 +15202,14 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    },
+    "node_modules/isbot": {
+      "version": "5.1.22",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.22.tgz",
+      "integrity": "sha512-RqCFY3cJy3c2y1I+rMn81cfzAR4XJwfPBC+M8kffUjbPzxApzyyv7Tbm1C/gXXq2dSCuD238pKFEWlQMTWsTFw==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -21428,6 +21614,57 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ]
+    },
+    "node_modules/ua-parser-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.2.tgz",
+      "integrity": "sha512-NoaPjzMmuUlo5bJ2jrdkzvHL8gpcgVrhUugAqsqsundDO3R8rw7R0OwxLoWhcKtsTb+6u3z9dES8m6+vxEcJog==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "dependencies": {
+        "@types/node-fetch": "^2.6.12",
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "node-fetch": "^2.7.0",
+        "ua-is-frozen": "^0.1.2"
+      },
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ufo": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,7 +22,7 @@
     "dcl-catalyst-commons": "^9.0.1",
     "decentraland-connect": "^9.0.0",
     "decentraland-crypto-fetch": "^1.0.3",
-    "decentraland-dapps": "^23.28.2",
+    "decentraland-dapps": "^24.6.0",
     "decentraland-transactions": "^2.18.3",
     "decentraland-ui": "^6.12.1",
     "decentraland-ui2": "^0.10.1",

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyNftWithCryptoModal/BuyNftWithCryptoModal.container.ts
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyNftWithCryptoModal/BuyNftWithCryptoModal.container.ts
@@ -2,6 +2,7 @@ import { connect } from 'react-redux'
 import { Dispatch, bindActionCreators } from 'redux'
 import type { Item } from '@dcl/schemas'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading'
+import { getData as getWallet } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import type { Route } from 'decentraland-transactions/crossChain'
 import { getContract } from '../../../../modules/contract/selectors'
 import { getIsOffchainPublicNFTOrdersEnabled } from '../../../../modules/features/selectors'
@@ -13,9 +14,9 @@ import type { RootState } from '../../../../modules/reducer'
 import type { Contract } from '../../../../modules/vendor/services'
 import { BuyNftWithCryptoModal } from './BuyNftWithCryptoModal'
 import type { MapDispatchProps, MapStateProps, OwnProps } from './BuyNftWithCryptoModal.types'
-
 const mapState = (state: RootState): MapStateProps => {
   return {
+    connectedChainId: getWallet(state)?.chainId,
     isExecutingOrder: isLoadingType(getLoadingOrders(state), EXECUTE_ORDER_REQUEST),
     isExecutingOrderCrossChain: isLoadingType(getItemsLoading(state), BUY_ITEM_CROSS_CHAIN_REQUEST),
     isOffchainPublicNFTOrdersEnabled: getIsOffchainPublicNFTOrdersEnabled(state),

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyNftWithCryptoModal/BuyNftWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyNftWithCryptoModal/BuyNftWithCryptoModal.tsx
@@ -19,6 +19,7 @@ const BuyNftWithCryptoModalHOC = (props: Props) => {
   const {
     name,
     isExecutingOrder,
+    connectedChainId,
     isExecutingOrderCrossChain,
     isOffchainPublicNFTOrdersEnabled,
     onClose,
@@ -52,6 +53,8 @@ const BuyNftWithCryptoModalHOC = (props: Props) => {
       isOffchainPublicNFTOrdersEnabled && order?.tradeId && getDCLContract(ContractName.OffChainMarketplace, nft.chainId)
 
     onAuthorizedAction({
+      // Override the automatic Magic sign in if the user needs to pay gas for the transaction
+      manual: connectedChainId === nft.chainId,
       targetContractName: ContractName.MANAToken,
       authorizationType: AuthorizationType.ALLOWANCE,
       authorizedAddress: offchainMarketplace ? offchainMarketplace.address : order.marketplaceAddress,
@@ -63,7 +66,7 @@ const BuyNftWithCryptoModalHOC = (props: Props) => {
   }, [nft, order, fingerprint, getContract, onAuthorizedAction, onExecuteOrder])
 
   const onBuyWithCard = useCallback(() => {
-    getAnalytics().track(events.CLICK_BUY_NFT_WITH_CARD)
+    getAnalytics()?.track(events.CLICK_BUY_NFT_WITH_CARD)
     onExecuteOrderWithCard(nft)
   }, [nft])
 

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyNftWithCryptoModal/BuyNftWithCryptoModal.types.ts
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyNftWithCryptoModal/BuyNftWithCryptoModal.types.ts
@@ -1,4 +1,4 @@
-import type { Order } from '@dcl/schemas'
+import type { ChainId, Order } from '@dcl/schemas'
 import type { WithAuthorizedActionProps } from 'decentraland-dapps/dist/containers/withAuthorizedAction'
 import type { ModalProps } from 'decentraland-dapps/dist/providers/ModalProvider/ModalProvider.types'
 import type { Route } from 'decentraland-transactions/crossChain'
@@ -10,6 +10,7 @@ import type { Contract } from '../../../../modules/vendor/services'
 export type Props = WithAuthorizedActionProps &
   Omit<ModalProps, 'metadata'> & {
     metadata: { nft: NFT; order: Order; slippage?: number }
+    connectedChainId: ChainId | undefined
     isExecutingOrder: boolean
     isExecutingOrderCrossChain: boolean
     isOffchainPublicNFTOrdersEnabled: boolean
@@ -21,7 +22,7 @@ export type Props = WithAuthorizedActionProps &
 
 export type MapStateProps = Pick<
   Props,
-  'getContract' | 'isExecutingOrder' | 'isExecutingOrderCrossChain' | 'isOffchainPublicNFTOrdersEnabled'
+  'getContract' | 'isExecutingOrder' | 'isExecutingOrderCrossChain' | 'isOffchainPublicNFTOrdersEnabled' | 'connectedChainId'
 >
 export type MapDispatchProps = Pick<Props, 'onExecuteOrder' | 'onExecuteOrderCrossChain' | 'onExecuteOrderWithCard'>
 export type OwnProps = Pick<Props, 'metadata'>

--- a/webapp/src/components/Modals/BuyWithCryptoModal/MintNameWithCryptoModal/MintNameWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/MintNameWithCryptoModal/MintNameWithCryptoModal.tsx
@@ -53,6 +53,8 @@ const MintNameWithCryptoModalHOC = (props: Props) => {
     }
 
     onAuthorizedAction({
+      // Override the automatic Magic sign in as the user will need to pay gas for the transaction
+      manual: true,
       authorizedAddress: CONTROLLER_V2_ADDRESS,
       authorizedContractLabel: 'DCLControllerV2',
       targetContract: manaContract,

--- a/webapp/src/components/Modals/BuyWithCryptoModal/MintNftWithCryptoModal/MintNftWithCryptoModal.container.ts
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/MintNftWithCryptoModal/MintNftWithCryptoModal.container.ts
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 import { Dispatch, bindActionCreators } from 'redux'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading'
+import { getData as getWallet } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import type { Route } from 'decentraland-transactions/crossChain'
 import { getContract } from '../../../../modules/contract/selectors'
 import {
@@ -18,6 +19,7 @@ import { MapDispatchProps, MapStateProps, OwnProps } from './MintNftWithCryptoMo
 
 const mapState = (state: RootState): MapStateProps => {
   return {
+    connectedChainId: getWallet(state)?.chainId,
     isBuyingItemNatively: isLoadingType(getItemsLoading(state), BUY_ITEM_REQUEST),
     isBuyingItemCrossChain: isLoadingType(getItemsLoading(state), BUY_ITEM_CROSS_CHAIN_REQUEST),
     getContract: (query: Partial<Contract>) => getContract(state, query)

--- a/webapp/src/components/Modals/BuyWithCryptoModal/MintNftWithCryptoModal/MintNftWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/MintNftWithCryptoModal/MintNftWithCryptoModal.tsx
@@ -17,6 +17,7 @@ import { Props } from './MintNftWithCryptoModal.types'
 const MintNftWithCryptoModalHOC = (props: Props) => {
   const {
     name,
+    connectedChainId,
     metadata: { item },
     isUsingMagic,
     isMagicAutoSignEnabled,
@@ -50,6 +51,8 @@ const MintNftWithCryptoModalHOC = (props: Props) => {
     const authorizedContractLabel = item.tradeId ? offchainMarketplace.name : collectionStore.label || collectionStore.name
 
     onAuthorizedAction({
+      // Override the automatic Magic sign in if the user needs to pay gas for the transaction
+      manual: connectedChainId === item.chainId,
       targetContractName: ContractName.MANAToken,
       authorizationType: AuthorizationType.ALLOWANCE,
       authorizedAddress,
@@ -61,7 +64,7 @@ const MintNftWithCryptoModalHOC = (props: Props) => {
   }, [item, getContract, onAuthorizedAction, onBuyItem])
 
   const onBuyWithCard = useCallback(() => {
-    getAnalytics().track(events.CLICK_BUY_NFT_WITH_CARD)
+    getAnalytics()?.track(events.CLICK_BUY_NFT_WITH_CARD)
     onBuyItemWithCard(item)
   }, [item])
 

--- a/webapp/src/components/Modals/BuyWithCryptoModal/MintNftWithCryptoModal/MintNftWithCryptoModal.types.ts
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/MintNftWithCryptoModal/MintNftWithCryptoModal.types.ts
@@ -1,4 +1,4 @@
-import { Item } from '@dcl/schemas'
+import { ChainId, Item } from '@dcl/schemas'
 import { WithAuthorizedActionProps } from 'decentraland-dapps/dist/containers/withAuthorizedAction'
 import { ModalProps } from 'decentraland-dapps/dist/providers/ModalProvider/ModalProvider.types'
 import type { Route } from 'decentraland-transactions/crossChain'
@@ -8,6 +8,7 @@ import { Contract } from '../../../../modules/vendor/services'
 
 export type Props = WithAuthorizedActionProps &
   Omit<ModalProps, 'metadata'> & {
+    connectedChainId: ChainId | undefined
     metadata: { item: Item }
     isBuyingItemNatively: boolean
     isBuyingItemCrossChain: boolean
@@ -17,6 +18,6 @@ export type Props = WithAuthorizedActionProps &
     onBuyWithCard: typeof buyItemWithCardRequest
   }
 
-export type MapStateProps = Pick<Props, 'getContract' | 'isBuyingItemNatively' | 'isBuyingItemCrossChain'>
+export type MapStateProps = Pick<Props, 'getContract' | 'isBuyingItemNatively' | 'isBuyingItemCrossChain' | 'connectedChainId'>
 export type MapDispatchProps = Pick<Props, 'onBuyItem' | 'onBuyItemCrossChain' | 'onBuyWithCard'>
 export type OwnProps = Pick<Props, 'metadata'>

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -2,13 +2,13 @@ import { NodeGlobalsPolyfillPlugin } from '@esbuild-plugins/node-globals-polyfil
 import { NodeModulesPolyfillPlugin } from '@esbuild-plugins/node-modules-polyfill'
 import react from '@vitejs/plugin-react-swc'
 import rollupNodePolyFill from 'rollup-plugin-polyfill-node'
-import { defineConfig, UserConfig, loadEnv, splitVendorChunkPlugin } from 'vite'
+import { defineConfig, UserConfig, loadEnv } from 'vite'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {
   const envVariables = loadEnv(mode, process.cwd())
   return {
-    plugins: [react(), splitVendorChunkPlugin()],
+    plugins: [react()],
     // Required because the CatalystClient tries to access it
     define: {
       // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
This PR uses the changes in the `decentraland-dapps` package that allow as to mark as manual the authorizations that require the user to pay gas. These authorization that require gas are for the purchase of L1 assets or L2 assets on the native network.