### PR TITLE
fix: Remove auth for actions that only require paying for authorization

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -27,7 +27,7 @@
         "dcl-catalyst-commons": "^9.0.1",
         "decentraland-connect": "^9.1.0",
         "decentraland-crypto-fetch": "^1.0.3",
-        "decentraland-dapps": "^24.7.0",
+        "decentraland-dapps": "^24.8.0",
         "decentraland-transactions": "^2.18.3",
         "decentraland-ui": "^6.13.0",
         "decentraland-ui2": "^0.11.5",
@@ -10285,9 +10285,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "24.7.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-24.7.0.tgz",
-      "integrity": "sha512-DMsM2ncwnxPPpnoAVt+SZKch2RreBH4ACuwx4Xu2H3UStVDM3HYUlQRRKzez/OAj4Lcp81x3dtyPn0RUAJMPCw==",
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-24.8.0.tgz",
+      "integrity": "sha512-khxyQnbah6REoIxei54S614i8nrnZP3EeKMmXN+Yr5AZlqnBpwZQJ0muVrQiV6cxZzu2ZAwF9UHdLW2QOMl2xQ==",
       "dependencies": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,7 +22,7 @@
     "dcl-catalyst-commons": "^9.0.1",
     "decentraland-connect": "^9.1.0",
     "decentraland-crypto-fetch": "^1.0.3",
-    "decentraland-dapps": "^24.7.0",
+    "decentraland-dapps": "^24.8.0",
     "decentraland-transactions": "^2.18.3",
     "decentraland-ui": "^6.13.0",
     "decentraland-ui2": "^0.11.5",

--- a/webapp/src/components/BidPage/BidModal/BidModal.tsx
+++ b/webapp/src/components/BidPage/BidModal/BidModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useMemo } from 'react'
 import { ethers } from 'ethers'
-import { ChainId, Contract, Network, NFTCategory } from '@dcl/schemas'
+import { ChainId, Contract, NFTCategory } from '@dcl/schemas'
 import { withAuthorizedAction, ChainButton } from 'decentraland-dapps/dist/containers'
 import { AuthorizedAction } from 'decentraland-dapps/dist/containers/withAuthorizedAction/AuthorizationModal'
 import { toFixedMANAValue } from 'decentraland-dapps/dist/lib/mana'
@@ -76,11 +76,9 @@ const BidModal = (props: Props) => {
 
   const handleConfirmBid = () => {
     const { onAuthorizedAction, onClearBidError } = props
-    const isAuthorizationCostingGas =
-      asset.network === Network.ETHEREUM || (asset.network as Network.ETHEREUM | Network.MATIC) === wallet?.network
+
     onClearBidError()
     onAuthorizedAction({
-      manual: isAuthorizationCostingGas,
       targetContractName: ContractName.MANAToken,
       authorizedAddress: isBidsOffchainEnabled && !!offchainBidsContract ? offchainBidsContract.address : bids.address,
       targetContract: mana as Contract,

--- a/webapp/src/components/SellPage/SellModal/SellModal.tsx
+++ b/webapp/src/components/SellPage/SellModal/SellModal.tsx
@@ -123,10 +123,7 @@ const SellModal = (props: Props) => {
 
   const handleSubmit = () => {
     onClearOrderErrors()
-    const isAuthorizationCostingGas =
-      nft.network === Network.ETHEREUM || (nft.network as Network.ETHEREUM | Network.MATIC) === wallet.network
     onAuthorizedAction({
-      manual: isAuthorizationCostingGas,
       authorizationType: AuthorizationType.APPROVAL,
       authorizedAddress:
         !!offchainOrdersContract && isOffchainPublicNFTOrdersEnabled ? offchainOrdersContract.address : marketplace.address,


### PR DESCRIPTION
This PR removes the manual authorization for actions that only require paying for the authorization. This means that, bidding, for example, which requires approving the contract to operate MANA on your behalf should not show the authorization modal, as the bid is then done off-chain.
This PR also updates the `decentraland-dapps` dependency which adds internationalization to the Web2TransactionModal.