### PR TITLE
fix: Claiming name not showing the gas cost modal

### DIFF
--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -870,6 +870,7 @@
     "covered_by_dao": "covered by the DAO",
     "free": "free",
     "switch_network": "Switch Network to {chain}",
+    "switching_network": "Switching network...",
     "confirm_switch_network": "Confirm Network Switch in Your Wallet",
     "confirm_transaction": "Confirm Transaction in Your Wallet",
     "buying_asset": "Buying...",

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -854,6 +854,7 @@
     "covered_by_dao": "cubiertos por la DAO",
     "free": "gratis",
     "switch_network": "Cambiar Red a {chain}",
+    "switching_network": "Cambiando de red...",
     "confirm_switch_network": "Confirmar el cambio de red en tu Wallet",
     "confirm_transaction": "Confirmar la transacción en tu Wallet",
     "buying_asset": "Comprando...",

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -856,6 +856,7 @@
     "covered_by_dao": "由 DAO 涵盖",
     "free": "自由的",
     "switch_network": "将网络切换到 {chain}",
+    "switching_network": "更改网络...",
     "confirm_switch_network": "确认钱包中的网络切换",
     "confirm_transaction": "确认您钱包中的交易",
     "buying_asset": "正在购买...",


### PR DESCRIPTION
This PR changes the way we're claiming a name from using the compiled contract to using the contract from `decentraland-transactions` and the `sendTransaction` method. This change makes it possible to show the gas cost modal for Magic users, as this modal exclusively depends on the `sendTransaction` method.