### PR TITLE
fix: Item fetched from other API on FF load

### DIFF
--- a/webapp/src/modules/item/sagas.spec.ts
+++ b/webapp/src/modules/item/sagas.spec.ts
@@ -740,12 +740,8 @@ describe('when handling the fetch items request action', () => {
           .provide([
             [matchers.call.fn(CatalogAPI.prototype.get), fetchResult],
             [matchers.call.fn(waitForWalletConnectionAndIdentityIfConnecting), undefined],
-            [matchers.call.fn(waitForFeatureFlagsToBeLoaded), undefined],
-            [select(getIsOffchainPublicItemOrdersEnabled), true],
-            [select(getIsOffchainPublicNFTOrdersEnabled), false],
             [select(getWallet), undefined],
-            [getContext('history'), { location: { pathname } }],
-            [select(getIsMarketplaceServerEnabled), false]
+            [getContext('history'), { location: { pathname } }]
           ])
           .put(fetchItemsSuccess(fetchResult.data, fetchResult.total, itemBrowseOptions, nowTimestamp))
           .dispatch(fetchItemsRequest(itemBrowseOptions))
@@ -760,13 +756,9 @@ describe('when handling the fetch items request action', () => {
         .provide([
           [getContext('history'), { location: { pathname: '' } }],
           [select(getWallet), undefined],
-          [select(getIsMarketplaceServerEnabled), true],
-          [select(getIsOffchainPublicNFTOrdersEnabled), false],
-          [select(getIsOffchainPublicItemOrdersEnabled), true],
           [select(getWallet), undefined],
           [matchers.call.fn(CatalogAPI.prototype.get), Promise.reject(anError)],
-          [matchers.call.fn(waitForWalletConnectionAndIdentityIfConnecting), undefined],
-          [matchers.call.fn(waitForFeatureFlagsToBeLoaded), undefined]
+          [matchers.call.fn(waitForWalletConnectionAndIdentityIfConnecting), undefined]
         ])
         .put(fetchItemsFailure(anError.message, itemBrowseOptions))
         .dispatch(fetchItemsRequest(itemBrowseOptions))
@@ -782,8 +774,7 @@ describe('when handling the fetch items request action', () => {
             .provide([
               [matchers.call.fn(ItemAPI.prototype.getOne), item],
               [matchers.call.fn(PeerAPI.prototype.fetchItemByUrn), entity],
-              [matchers.call.fn(waitForWalletConnectionAndIdentityIfConnecting), undefined],
-              [select(getIsOffchainPublicItemOrdersEnabled), true]
+              [matchers.call.fn(waitForWalletConnectionAndIdentityIfConnecting), undefined]
             ])
             .put(fetchItemSuccess({ ...item, entity }))
             .dispatch(fetchItemRequest(item.contractAddress, item.itemId))
@@ -811,8 +802,7 @@ describe('when handling the fetch items request action', () => {
             .provide([
               [matchers.call.fn(ItemAPI.prototype.getOne), smartWearable],
               [matchers.call.fn(PeerAPI.prototype.fetchItemByUrn), entity],
-              [matchers.call.fn(waitForWalletConnectionAndIdentityIfConnecting), undefined],
-              [select(getIsOffchainPublicItemOrdersEnabled), true]
+              [matchers.call.fn(waitForWalletConnectionAndIdentityIfConnecting), undefined]
             ])
             .put(fetchItemSuccess({ ...smartWearable, entity }))
             .put(fetchSmartWearableRequiredPermissionsRequest(smartWearable))
@@ -827,8 +817,7 @@ describe('when handling the fetch items request action', () => {
         return expectSaga(itemSaga, getIdentity)
           .provide([
             [matchers.call.fn(ItemAPI.prototype.getOne), Promise.reject(anError)],
-            [matchers.call.fn(waitForWalletConnectionAndIdentityIfConnecting), undefined],
-            [select(getIsOffchainPublicItemOrdersEnabled), true]
+            [matchers.call.fn(waitForWalletConnectionAndIdentityIfConnecting), undefined]
           ])
           .put(fetchItemFailure(item.contractAddress, item.itemId, anError.message))
           .dispatch(fetchItemRequest(item.contractAddress, item.itemId))
@@ -856,9 +845,6 @@ describe('when handling the fetch trending items request action', () => {
       it('should dispatch a successful action with the fetched trending items', () => {
         return expectSaga(itemSaga, getIdentity)
           .provide([
-            [matchers.call.fn(waitForFeatureFlagsToBeLoaded), undefined],
-            [select(getIsMarketplaceServerEnabled), true],
-            [select(getIsOffchainPublicNFTOrdersEnabled), false],
             [matchers.call.fn(ItemAPI.prototype.getTrendings), fetchResult],
             [matchers.call.fn(CatalogAPI.prototype.get), fetchResult],
             [matchers.call.fn(waitForWalletConnectionAndIdentityIfConnecting), undefined]
@@ -875,8 +861,6 @@ describe('when handling the fetch trending items request action', () => {
       it('should dispatch a successful action with the fetched trending items', () => {
         return expectSaga(itemSaga, getIdentity)
           .provide([
-            [select(getIsMarketplaceServerEnabled), true],
-            [matchers.call.fn(waitForFeatureFlagsToBeLoaded), undefined],
             [matchers.call.fn(ItemAPI.prototype.getTrendings), fetchResult],
             [matchers.call.fn(waitForWalletConnectionAndIdentityIfConnecting), undefined]
           ])
@@ -891,8 +875,6 @@ describe('when handling the fetch trending items request action', () => {
     it('should dispatch a failing action with the error and the options', () => {
       return expectSaga(itemSaga, getIdentity)
         .provide([
-          [select(getIsMarketplaceServerEnabled), true],
-          [matchers.call.fn(waitForFeatureFlagsToBeLoaded), undefined],
           [matchers.call.fn(ItemAPI.prototype.getTrendings), Promise.reject(anError)],
           [matchers.call.fn(waitForWalletConnectionAndIdentityIfConnecting), undefined]
         ])

--- a/webapp/src/modules/item/sagas.ts
+++ b/webapp/src/modules/item/sagas.ts
@@ -24,13 +24,7 @@ import { API_SIGNER } from '../../lib/api'
 import { isErrorWithMessage } from '../../lib/error'
 import { fetchSmartWearableRequiredPermissionsRequest } from '../asset/actions'
 import { buyAssetWithCard } from '../asset/utils'
-import {
-  getIsCreditsEnabled,
-  getIsMarketplaceServerEnabled,
-  getIsOffchainPublicItemOrdersEnabled,
-  getIsOffchainPublicNFTOrdersEnabled
-} from '../features/selectors'
-import { waitForFeatureFlagsToBeLoaded } from '../features/utils'
+import { getIsCreditsEnabled } from '../features/selectors'
 import { locations } from '../routing/locations'
 import { isCatalogView } from '../routing/utils'
 import { MARKETPLACE_SERVER_URL } from '../vendor/decentraland'
@@ -89,10 +83,8 @@ export function* itemSaga(getIdentity: () => AuthIdentity | undefined) {
     retryDelay: retryParams.delay,
     identity: getIdentity
   }
-  const itemAPI = new ItemAPI(NFT_SERVER_URL, API_OPTS)
   const marketplaceItemAPI = new ItemAPI(MARKETPLACE_SERVER_URL, API_OPTS)
   const marketplaceServerCatalogAPI = new CatalogAPI(MARKETPLACE_SERVER_URL, API_OPTS)
-  const catalogAPI = new CatalogAPI(NFT_SERVER_URL, API_OPTS)
   const tradeService = new TradeService(API_SIGNER, MARKETPLACE_SERVER_URL, getIdentity)
 
   yield fork(() => takeLatestByPath(FETCH_ITEMS_REQUEST, locations.browse()))
@@ -128,10 +120,8 @@ export function* itemSaga(getIdentity: () => AuthIdentity | undefined) {
     // If the wallet is getting connected, wait until it finishes to fetch the items so it can fetch them with authentication
 
     try {
-      yield call(waitForFeatureFlagsToBeLoaded)
-      const isMarketplaceServerEnabled: boolean = yield select(getIsMarketplaceServerEnabled)
       yield call(waitForWalletConnectionAndIdentityIfConnecting)
-      const { data }: { data: Item[] } = yield call([isMarketplaceServerEnabled ? marketplaceItemAPI : itemAPI, 'getTrendings'], size)
+      const { data }: { data: Item[] } = yield call([marketplaceItemAPI, 'getTrendings'], size)
 
       if (!data.length) {
         yield put(fetchTrendingItemsSuccess([]))
@@ -139,15 +129,7 @@ export function* itemSaga(getIdentity: () => AuthIdentity | undefined) {
       }
 
       const ids = data.map(item => item.id)
-      const api = isMarketplaceServerEnabled ? marketplaceServerCatalogAPI : catalogAPI
-      const isOffchainEnabled: boolean = yield select(getIsOffchainPublicNFTOrdersEnabled)
-      const { data: itemData }: { data: Item[]; total: number } = yield call(
-        [api, 'get'],
-        {
-          ids
-        },
-        { v2: isOffchainEnabled }
-      )
+      const { data: itemData }: { data: Item[]; total: number } = yield call([marketplaceServerCatalogAPI, 'get'], { ids }, { v2: true })
       yield put(fetchTrendingItemsSuccess(itemData))
     } catch (error) {
       yield put(fetchTrendingItemsFailure(isErrorWithMessage(error) ? error.message : t('global.unknown_error')))
@@ -157,9 +139,7 @@ export function* itemSaga(getIdentity: () => AuthIdentity | undefined) {
   function* handleFetchCollectionItemsRequest(action: FetchCollectionItemsRequestAction) {
     const { contractAddresses, first } = action.payload
     try {
-      const isOffchainPublicItemOrdersEnabled: boolean = yield select(getIsOffchainPublicItemOrdersEnabled)
-      const api = isOffchainPublicItemOrdersEnabled ? marketplaceItemAPI : itemAPI
-      const { data }: { data: Item[]; total: number } = yield call([api, 'get'], { first, contractAddresses })
+      const { data }: { data: Item[]; total: number } = yield call([marketplaceItemAPI, 'get'], { first, contractAddresses })
       yield put(fetchCollectionItemsSuccess(data))
     } catch (error) {
       yield put(fetchCollectionItemsFailure(isErrorWithMessage(error) ? error.message : t('global.unknown_error')))


### PR DESCRIPTION
This PR removes the usage of FFs to load item data from our APIs which when getting an item, in some cases, fetched the item before the FF was loaded.
As we haven't used our old API for a long time, this PR removes all FFs in the items sagas.