### PR TITLE
ci: remove legacy-peer-deps from workflows

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -31,7 +31,7 @@ jobs:
           deterministic-snapshot: true
           only-update-versions: true
       - name: Install
-        run: npm install --legacy-peer-deps
+        run: npm install
       - name: Build
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,6 +17,6 @@ jobs:
           cache: "npm"
           cache-dependency-path: webapp/package-lock.json
       - name: Install
-        run: npm install --legacy-peer-deps
+        run: npm install
       - name: Lint
         run: npm run check:code

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
           cache: "npm"
           cache-dependency-path: webapp/package-lock.json
       - name: Install
-        run: npm install --legacy-peer-deps
+        run: npm install
       - name: Test
         run: npm run test:coverage
       - name: report coverage


### PR DESCRIPTION
Removes legacy-peer-deps flag from CI workflows (test, lint, build-release).
With the React 18 migration and updated dependencies, peer dependency conflicts should be resolved and this flag is no longer needed.