### PR TITLE
Redirect to name detail from manage button

### DIFF
--- a/webapp/src/components/AssetPage/Actions/Actions.tsx
+++ b/webapp/src/components/AssetPage/Actions/Actions.tsx
@@ -71,7 +71,7 @@ const Actions = (props: Props) => {
         </Button>
       ) : null}
       {isOwner && isENSName && (
-        <Button as="a" href={`${builderUrl}/names`} fluid>
+        <Button as="a" href={`${builderUrl}/names/${data.ens?.subdomain || ''}`} fluid>
           {t('asset_page.actions.manage')}
         </Button>
       )}


### PR DESCRIPTION
# Fix: Name tab displays all names instead of filtering to a selected name

#### Related issue: https://github.com/decentraland/dapps-issues/issues/234
#### Related PR from Builder: https://github.com/decentraland/builder/pull/3328

## Problem & Solution

When clicking on the "Manage Name" tab on the marketplace, the UI currently shows all owned names rather than focusing on a single selected name & since there is no search bar, it's difficult to locate and swap to an intended name, especially for users with a large number of registered names.

Solved the problem by redirecting to NAME details instead on NAMEs list. Additionally, we added the missing "Transfer" feature on the Builder details screen for a consistent experience.

## Screenshots

https://github.com/user-attachments/assets/411e3a43-bee2-4733-9490-60ce5a363d8b


