### PR TITLE
feat: Update connect, dapps and other dependencies

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -27,7 +27,7 @@
         "decentraland-connect": "^11.0.0",
         "decentraland-crypto-fetch": "^1.0.3",
         "decentraland-dapps": "^26.3.0",
-        "decentraland-transactions": "^2.24.2",
+        "decentraland-transactions": "^2.24.4",
         "decentraland-ui": "^7.1.0",
         "decentraland-ui2": "^1.1.6",
         "ethers": "^5.6.8",
@@ -4722,6 +4722,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.18.0.tgz",
       "integrity": "sha512-bbH/HaJZpFtXGvWg3TsBWG4eyt3gah3E7nCNU8GLyRjVoWcA91Vm/T+sjHfUcwgJSw9iLtucfHBoq+qW/T30aA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/core-downloads-tracker": "^5.18.0",
@@ -9945,6 +9946,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
       "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -11670,9 +11672,9 @@
       }
     },
     "node_modules/decentraland-transactions": {
-      "version": "2.24.2",
-      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-2.24.2.tgz",
-      "integrity": "sha512-pN3L4yGiYaDALpxwRDHIWmu+qz+CSjwSVrzYTzs6Rz6x/53KLcxBdt5a92b1jA3lDJhrqCGCwVlcMBT2dDWXCA==",
+      "version": "2.24.4",
+      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-2.24.4.tgz",
+      "integrity": "sha512-JqNGWneFDbewmJ6N7loK1eHk6DBXf9MEEBVWkq+ino0BMl/Y3X0PlnzvR0cUmxl91CFR4Uwio6SJaJMVUpLJ7w==",
       "dependencies": {
         "@0xsquid/sdk": "2.8.25",
         "@0xsquid/squid-types": "0.1.78",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,7 +22,7 @@
     "decentraland-connect": "^11.0.0",
     "decentraland-crypto-fetch": "^1.0.3",
     "decentraland-dapps": "^26.3.0",
-    "decentraland-transactions": "^2.24.2",
+    "decentraland-transactions": "^2.24.4",
     "decentraland-ui": "^7.1.0",
     "decentraland-ui2": "^1.1.6",
     "ethers": "^5.6.8",


### PR DESCRIPTION
This PR updates some of our dependencies, specially the `decentraland-dapps` and `decentraland-connect` that are now using the latest version of the wallet connect packages.