### PR TITLE
Fix typo in CSS comments

### DIFF
--- a/webapp/src/components/AnalyticsVolumeDayData/AnalyticsVolumeDayData.css
+++ b/webapp/src/components/AnalyticsVolumeDayData/AnalyticsVolumeDayData.css
@@ -62,7 +62,7 @@
 }
 
 .AnalyticsVolumeDayData .dcl.header-menu-right .ui.basic.button.active {
-  /* to override the butotns basic !importants */
+  /* to override the buttons basic !importants */
   background-color: var(--primary) !important;
   color: white !important;
 }

--- a/webapp/src/components/Rankings/TimeframeSelector/TimeframeSelector.css
+++ b/webapp/src/components/Rankings/TimeframeSelector/TimeframeSelector.css
@@ -11,7 +11,7 @@
 }
 
 .TimeframeSelector .ui.basic.button.active {
-  /* to override the butotns basic !importants */
+  /* to override the buttons basic !importants */
   background-color: var(--primary) !important;
   color: white !important;
 }


### PR DESCRIPTION
## Summary
- Fixed typo in CSS comments: "butotns" -> "buttons" (2 occurrences)

Affected files:
- webapp/src/components/AnalyticsVolumeDayData/AnalyticsVolumeDayData.css
- webapp/src/components/Rankings/TimeframeSelector/TimeframeSelector.css

## Test plan
- No functional change, CSS comments only