### PR TITLE
Fix typo in AssetFiltersModal.module.css

### DIFF
--- a/webapp/src/components/Modals/AssetFiltersModal/AssetFiltersModal.module.css
+++ b/webapp/src/components/Modals/AssetFiltersModal/AssetFiltersModal.module.css
@@ -34,7 +34,7 @@
 :global(.ui.modal).assetFiltersModal > :global(.content) {
   overflow: scroll;
   margin: 0;
-  padding: 0 !important; /* override important from decentralnad-ui */
+  padding: 0 !important; /* override important from decentraland-ui */
   display: flex;
   flex-direction: column;
   flex: 1;


### PR DESCRIPTION
## Summary
- Fixed typo in CSS comment: "decentralnad-ui" -> "decentraland-ui"

## Test plan
- No functional change, CSS comment only