### PR TITLE
fix: unity rendering twice

### DIFF
--- a/webapp/src/components/AssetImage/Preview/Preview.tsx
+++ b/webapp/src/components/AssetImage/Preview/Preview.tsx
@@ -162,7 +162,6 @@ export const Preview: React.FC<Props> = ({
 
   const isOwnerOfNFT = useMemo(() => isNFT(asset) && wallet?.address === asset.owner, [asset, wallet?.address])
 
-  const isUnityRenderer = useMemo(() => rendererType === PreviewRenderer.UNITY, [rendererType])
   const isBabylonRenderer = useMemo(() => rendererType === PreviewRenderer.BABYLON, [rendererType])
 
   const isSocialEmote = useMemo(() => {
@@ -334,7 +333,7 @@ export const Preview: React.FC<Props> = ({
           <WearablePreview
             id="wearable-preview"
             background={Rarity.getColor(rarity)}
-            emote={isTryingOnEnabled || isUnityRenderer ? previewEmote : undefined}
+            emote={isTryingOnEnabled || isUnityWearablePreviewEnabled ? previewEmote : undefined}
             hair={hair}
             profile={avatar ? avatar.ethAddress : 'default'}
             skin={skin}


### PR DESCRIPTION
# Fix: WearablePreview Double Load & Back Button Issue

## Problem

When navigating to a wearable/emote detail page, the Unity-based `WearablePreview` was loading **twice**. Additionally, clicking the "Back" button would reload the preview instead of navigating away properly.

## Root Cause

The `emote` prop passed to `WearablePreview` was **unstable** - it changed from `undefined` to a value (e.g., `fashion-3`) after the initial render.

### Before (Bug)

```tsx
emote={isTryingOnEnabled || isUnityRenderer ? previewEmote : undefined}
```

The variable `isUnityRenderer` was derived from internal state:

```tsx
const isUnityRenderer = useMemo(() => rendererType === PreviewRenderer.UNITY, [rendererType])
```

- `rendererType` starts as `undefined`
- `rendererType` is set to `PreviewRenderer.UNITY` in the `onLoad` callback (AFTER the iframe loads)

### What Happened

```
Render #1: isUnityRenderer = false → emote = undefined → Unity iframe mounts
Render #2: (onLoad fires) → isUnityRenderer = true → emote = "fashion-3" → prop changes → IFRAME RELOADS
```

The `WearablePreview` component detects prop changes and rebuilds its iframe URL, causing a full reload.

### Why "Back" Button Seemed Broken

When clicking "Back", the component would unmount. But the reload caused by the unstable `emote` prop made it appear as if the page was just refreshing instead of navigating.

## Solution

Replace `isUnityRenderer` (unstable, changes after load) with `isUnityWearablePreviewEnabled` (stable, from Redux/feature flags):

### After (Fix)

```tsx
emote={isTryingOnEnabled || isUnityWearablePreviewEnabled ? previewEmote : undefined}
```

| Variable | Source | Stability |
|----------|--------|-----------|
| `isUnityRenderer` | Internal state (`rendererType`) | ❌ Changes after first render |
| `isUnityWearablePreviewEnabled` | Redux/feature flags | ✅ Stable from mount |

### Result

```
Render #1: isUnityWearablePreviewEnabled = true → emote = "fashion-3" → Unity iframe mounts
Render #2: isUnityWearablePreviewEnabled = true → emote = "fashion-3" → NO CHANGE → NO RELOAD ✅
```
