### PR TITLE
feat: load activity page from marketplace-server with local tx fallback

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -27,7 +27,7 @@
         "decentraland-connect": "^12.0.0",
         "decentraland-crypto-fetch": "^2.0.1",
         "decentraland-dapps": "^28.9.0",
-        "decentraland-transactions": "^3.0.2",
+        "decentraland-transactions": "^3.0.3",
         "decentraland-ui": "^7.1.0",
         "decentraland-ui2": "^3.8.0",
         "ethers": "^5.6.8",
@@ -15212,9 +15212,9 @@
       }
     },
     "node_modules/decentraland-transactions": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-3.0.2.tgz",
-      "integrity": "sha512-M8m1Uy8WrZ+GxZ/IH1PTA5B3WIYvJAcrtcDZMpdkaK9y/KUi0Vmlk3Qp07FPCLsUyZiFR/wh8HToSq0N0warrA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-3.0.3.tgz",
+      "integrity": "sha512-raXccg2xNwYslFiHjSE9LASNF0lEpocSv4LvXFfeYjVhdoYOhSC2gVko6mV3WYBMKpbYsUpXlvzQYN3X4bqqmw==",
       "dependencies": {
         "tslib": "^2.6.2"
       },

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,7 +22,7 @@
     "decentraland-connect": "^12.0.0",
     "decentraland-crypto-fetch": "^2.0.1",
     "decentraland-dapps": "^28.9.0",
-    "decentraland-transactions": "^3.0.2",
+    "decentraland-transactions": "^3.0.3",
     "decentraland-ui": "^7.1.0",
     "decentraland-ui2": "^3.8.0",
     "ethers": "^5.6.8",

--- a/webapp/src/components/ActivityPage/ActivityEventItem/ActivityEventItem.tsx
+++ b/webapp/src/components/ActivityPage/ActivityEventItem/ActivityEventItem.tsx
@@ -21,13 +21,19 @@ const formatPrice = (priceInWei?: string) => {
   try {
     return Number(ethers.utils.formatEther(priceInWei)).toLocaleString()
   } catch {
-    return '0'
+    return '—'
   }
 }
 
-const getAssetSelector = (event: ActivityEvent): { type: AssetType; tokenId: string } | null => {
-  if (event.itemId && event.contractAddress) return { type: AssetType.ITEM, tokenId: event.itemId }
-  if (event.tokenId && event.contractAddress) return { type: AssetType.NFT, tokenId: event.tokenId }
+type AssetSelector = { type: AssetType; tokenId: string; contractAddress: string }
+
+const getAssetSelector = (event: ActivityEvent): AssetSelector | null => {
+  if (event.itemId && event.contractAddress) {
+    return { type: AssetType.ITEM, tokenId: event.itemId, contractAddress: event.contractAddress }
+  }
+  if (event.tokenId && event.contractAddress) {
+    return { type: AssetType.NFT, tokenId: event.tokenId, contractAddress: event.contractAddress }
+  }
   return null
 }
 
@@ -109,7 +115,7 @@ const ActivityEventItem = (props: Props) => {
   }
 
   return (
-    <AssetProvider type={selector.type} contractAddress={event.contractAddress} tokenId={selector.tokenId}>
+    <AssetProvider type={selector.type} contractAddress={selector.contractAddress} tokenId={selector.tokenId}>
       {asset => body(asset)}
     </AssetProvider>
   )

--- a/webapp/src/components/ActivityPage/ActivityEventItem/ActivityEventItem.tsx
+++ b/webapp/src/components/ActivityPage/ActivityEventItem/ActivityEventItem.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import { ethers } from 'ethers'
 import { Profile } from 'decentraland-dapps/dist/containers'
 import { T, t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Icon, Loader } from 'decentraland-ui'
-import { ethers } from 'ethers'
 import { formatDistanceToNow } from '../../../lib/date'
 import { ActivityEvent, ActivityEventType } from '../../../modules/activity/types'
 import { Asset, AssetType } from '../../../modules/asset/types'
@@ -109,7 +109,7 @@ const ActivityEventItem = (props: Props) => {
   }
 
   return (
-    <AssetProvider type={selector.type} contractAddress={event.contractAddress!} tokenId={selector.tokenId}>
+    <AssetProvider type={selector.type} contractAddress={event.contractAddress} tokenId={selector.tokenId}>
       {asset => body(asset)}
     </AssetProvider>
   )

--- a/webapp/src/components/ActivityPage/ActivityEventItem/ActivityEventItem.tsx
+++ b/webapp/src/components/ActivityPage/ActivityEventItem/ActivityEventItem.tsx
@@ -1,0 +1,118 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { Profile } from 'decentraland-dapps/dist/containers'
+import { T, t } from 'decentraland-dapps/dist/modules/translation/utils'
+import { Icon, Loader } from 'decentraland-ui'
+import { ethers } from 'ethers'
+import { formatDistanceToNow } from '../../../lib/date'
+import { ActivityEvent, ActivityEventType } from '../../../modules/activity/types'
+import { Asset, AssetType } from '../../../modules/asset/types'
+import { getAssetName, getAssetUrl } from '../../../modules/asset/utils'
+import { locations } from '../../../modules/routing/locations'
+import { AssetImage } from '../../AssetImage'
+import { AssetProvider } from '../../AssetProvider'
+import { Column } from '../../Layout/Column'
+import { Row } from '../../Layout/Row'
+import { Mana } from '../../Mana'
+import { Props } from './ActivityEventItem.types'
+
+const formatPrice = (priceInWei?: string) => {
+  if (!priceInWei) return '0'
+  try {
+    return Number(ethers.utils.formatEther(priceInWei)).toLocaleString()
+  } catch {
+    return '0'
+  }
+}
+
+const getAssetSelector = (event: ActivityEvent): { type: AssetType; tokenId: string } | null => {
+  if (event.itemId && event.contractAddress) return { type: AssetType.ITEM, tokenId: event.itemId }
+  if (event.tokenId && event.contractAddress) return { type: AssetType.NFT, tokenId: event.tokenId }
+  return null
+}
+
+const renderAssetLink = (event: ActivityEvent, asset: Asset | null | undefined): React.ReactNode => {
+  if (!event.contractAddress) return ''
+  const name = asset ? getAssetName(asset) : '…'
+  if (event.itemId) return <Link to={locations.item(event.contractAddress, event.itemId)}>{name}</Link>
+  if (event.tokenId) return <Link to={locations.nft(event.contractAddress, event.tokenId)}>{name}</Link>
+  return name
+}
+
+const renderCounterparty = (address?: string): React.ReactNode => {
+  if (!address) return ''
+  return (
+    <Link to={locations.account(address)}>
+      <Profile address={address} />
+    </Link>
+  )
+}
+
+const eventTranslationKey: Record<ActivityEventType, string> = {
+  [ActivityEventType.SALE_BUYER]: 'activity_page.event.sale_buyer',
+  [ActivityEventType.SALE_SELLER]: 'activity_page.event.sale_seller',
+  [ActivityEventType.BID_PLACED]: 'activity_page.event.bid_placed',
+  [ActivityEventType.BID_RECEIVED]: 'activity_page.event.bid_received',
+  [ActivityEventType.ORDER_CREATED]: 'activity_page.event.order_created',
+  [ActivityEventType.ORDER_FILLED]: 'activity_page.event.order_filled',
+  [ActivityEventType.TRADE_CREATED]: 'activity_page.event.trade_created'
+}
+
+const ActivityEventItem = (props: Props) => {
+  const { event } = props
+  const selector = getAssetSelector(event)
+  const priceLabel = (
+    <Mana showTooltip network={event.network} inline>
+      {formatPrice(event.price)}
+    </Mana>
+  )
+
+  const body = (asset: Asset | null | undefined) => (
+    <Row className="TransactionDetail">
+      <Column align="left" grow={true}>
+        <div className="image">
+          {asset === null ? (
+            <Loader active size="small" />
+          ) : asset ? (
+            <Link to={getAssetUrl(asset)}>
+              <AssetImage asset={asset} isSmall />
+            </Link>
+          ) : (
+            <Mana showTooltip network={event.network} />
+          )}
+        </div>
+        <div className="text">
+          <div className="description">
+            <T
+              id={eventTranslationKey[event.type]}
+              values={{
+                name: renderAssetLink(event, asset),
+                price: priceLabel,
+                counterparty: renderCounterparty(event.counterparty)
+              }}
+            />
+          </div>
+          <div className="timestamp">{formatDistanceToNow(event.timestamp)}.</div>
+        </div>
+      </Column>
+      <Column align="right">
+        <span className="status confirmed">
+          <div className="description">{t('activity_page.event.status.confirmed')}</div>
+          <Icon name="check" />
+        </span>
+      </Column>
+    </Row>
+  )
+
+  if (!selector) {
+    return body(undefined)
+  }
+
+  return (
+    <AssetProvider type={selector.type} contractAddress={event.contractAddress!} tokenId={selector.tokenId}>
+      {asset => body(asset)}
+    </AssetProvider>
+  )
+}
+
+export default React.memo(ActivityEventItem)

--- a/webapp/src/components/ActivityPage/ActivityEventItem/ActivityEventItem.types.ts
+++ b/webapp/src/components/ActivityPage/ActivityEventItem/ActivityEventItem.types.ts
@@ -1,0 +1,5 @@
+import { ActivityEvent } from '../../../modules/activity/types'
+
+export type Props = {
+  event: ActivityEvent
+}

--- a/webapp/src/components/ActivityPage/ActivityEventItem/index.ts
+++ b/webapp/src/components/ActivityPage/ActivityEventItem/index.ts
@@ -1,0 +1,3 @@
+import ActivityEventItem from './ActivityEventItem'
+export { ActivityEventItem }
+export default ActivityEventItem

--- a/webapp/src/components/ActivityPage/ActivityPage.container.ts
+++ b/webapp/src/components/ActivityPage/ActivityPage.container.ts
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { clearTransactions } from 'decentraland-dapps/dist/modules/transaction/actions'
 import { FETCH_USER_ACTIVITY_REQUEST, fetchUserActivityRequest } from '../../modules/activity/actions'
-import { getError, getLoading, getMergedActivity } from '../../modules/activity/selectors'
+import { getError, getHasMore, getLoaded, getLoading, getMergedActivity } from '../../modules/activity/selectors'
 import { RootState } from '../../modules/reducer'
 import { getAddress } from '../../modules/wallet/selectors'
 import ActivityPage from './ActivityPage'
@@ -12,12 +12,14 @@ const mapState = (state: RootState): MapStateProps => ({
   address: getAddress(state),
   mergedActivity: getMergedActivity(state),
   loading: isLoadingType(getLoading(state), FETCH_USER_ACTIVITY_REQUEST),
-  error: getError(state)
+  error: getError(state),
+  hasMore: getHasMore(state),
+  loaded: getLoaded(state)
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
   onClearHistory: address => dispatch(clearTransactions(address)),
-  onLoadActivity: () => dispatch(fetchUserActivityRequest())
+  onLoadActivity: (limit, offset) => dispatch(fetchUserActivityRequest({ limit, offset }))
 })
 
 export default connect(mapState, mapDispatch)(ActivityPage)

--- a/webapp/src/components/ActivityPage/ActivityPage.container.ts
+++ b/webapp/src/components/ActivityPage/ActivityPage.container.ts
@@ -1,18 +1,23 @@
 import { connect } from 'react-redux'
+import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { clearTransactions } from 'decentraland-dapps/dist/modules/transaction/actions'
+import { FETCH_USER_ACTIVITY_REQUEST, fetchUserActivityRequest } from '../../modules/activity/actions'
+import { getError, getLoading, getMergedActivity } from '../../modules/activity/selectors'
 import { RootState } from '../../modules/reducer'
-import { getTransactions } from '../../modules/transaction/selectors'
 import { getAddress } from '../../modules/wallet/selectors'
 import ActivityPage from './ActivityPage'
 import { MapStateProps, MapDispatchProps, MapDispatch } from './ActivityPage.types'
 
 const mapState = (state: RootState): MapStateProps => ({
   address: getAddress(state),
-  transactions: getTransactions(state)
+  mergedActivity: getMergedActivity(state),
+  loading: isLoadingType(getLoading(state), FETCH_USER_ACTIVITY_REQUEST),
+  error: getError(state)
 })
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
-  onClearHistory: address => dispatch(clearTransactions(address))
+  onClearHistory: address => dispatch(clearTransactions(address)),
+  onLoadActivity: () => dispatch(fetchUserActivityRequest())
 })
 
 export default connect(mapState, mapDispatch)(ActivityPage)

--- a/webapp/src/components/ActivityPage/ActivityPage.css
+++ b/webapp/src/components/ActivityPage/ActivityPage.css
@@ -20,3 +20,11 @@
 .ActivityPage .transactions {
   margin-top: 20px;
 }
+
+.ActivityPage .activity-sentinel {
+  min-height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 0;
+}

--- a/webapp/src/components/ActivityPage/ActivityPage.tsx
+++ b/webapp/src/components/ActivityPage/ActivityPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Button, Header, Loader, Message, Modal, Page } from 'decentraland-ui'
 import { Column } from '../Layout/Column'
@@ -10,16 +10,46 @@ import { Transaction } from './Transaction'
 import { Props } from './ActivityPage.types'
 import './ActivityPage.css'
 
+const PAGE_SIZE = 20
+
 const ActivityPage = (props: Props) => {
-  const { address, mergedActivity, loading, error, onClearHistory, onLoadActivity } = props
+  const { address, mergedActivity, loading, error, hasMore, loaded, onClearHistory, onLoadActivity } = props
 
   const [showConfirmation, setShowConfirmation] = useState(false)
+  const sentinelRef = useRef<HTMLDivElement | null>(null)
+  const hasLoadedFirstPage = useRef(false)
 
+  // First-page load: fires once per mount (or when the wallet address changes).
   useEffect(() => {
-    if (address) {
-      onLoadActivity()
-    }
+    if (!address) return
+    hasLoadedFirstPage.current = false
+    onLoadActivity(PAGE_SIZE, 0)
+    hasLoadedFirstPage.current = true
   }, [address, onLoadActivity])
+
+  // Infinite scroll: IntersectionObserver fires whenever the sentinel becomes visible.
+  // That's viewport-aware — on a tall screen where all current items fit, the sentinel
+  // is visible immediately and we auto-page until either the viewport fills or there's
+  // nothing more to load.
+  useEffect(() => {
+    const node = sentinelRef.current
+    if (!node) return
+    if (!address) return
+
+    const observer = new IntersectionObserver(
+      entries => {
+        const entry = entries[0]
+        if (!entry?.isIntersecting) return
+        if (loading) return
+        if (!hasMore) return
+        if (!hasLoadedFirstPage.current) return
+        onLoadActivity(PAGE_SIZE, loaded)
+      },
+      { rootMargin: '200px' }
+    )
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [address, loading, hasMore, loaded, onLoadActivity])
 
   const handleClear = useCallback(() => {
     if (address) {
@@ -35,7 +65,9 @@ const ActivityPage = (props: Props) => {
 
   const errorBanner = error ? <Message warning size="tiny" content={t('activity_page.error')} /> : null
 
-  if (loading && mergedActivity.length === 0) {
+  const isInitialLoading = loading && mergedActivity.length === 0
+
+  if (isInitialLoading) {
     content = (
       <div className="center">
         <Loader active size="large">
@@ -74,6 +106,9 @@ const ActivityPage = (props: Props) => {
               <ActivityEventItem event={item.event} key={`server:${item.event.id}`} />
             )
           )}
+        </div>
+        <div ref={sentinelRef} className="activity-sentinel" aria-hidden="true">
+          {hasMore && loading ? <Loader active inline="centered" size="small" /> : null}
         </div>
       </>
     )

--- a/webapp/src/components/ActivityPage/ActivityPage.tsx
+++ b/webapp/src/components/ActivityPage/ActivityPage.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Button, Header, Loader, Message, Modal, Page } from 'decentraland-ui'
-import { ActivityEventItem } from './ActivityEventItem'
-import { Transaction } from './Transaction'
 import { Column } from '../Layout/Column'
 import { Row } from '../Layout/Row'
 import { NavigationTab } from '../Navigation/Navigation.types'
 import { PageLayout } from '../PageLayout'
+import { ActivityEventItem } from './ActivityEventItem'
+import { Transaction } from './Transaction'
 import { Props } from './ActivityPage.types'
 import './ActivityPage.css'
 
@@ -33,9 +33,7 @@ const ActivityPage = (props: Props) => {
 
   let content: React.ReactNode
 
-  const errorBanner = error ? (
-    <Message warning size="tiny" content={t('activity_page.error')} />
-  ) : null
+  const errorBanner = error ? <Message warning size="tiny" content={t('activity_page.error')} /> : null
 
   if (loading && mergedActivity.length === 0) {
     content = (

--- a/webapp/src/components/ActivityPage/ActivityPage.tsx
+++ b/webapp/src/components/ActivityPage/ActivityPage.tsx
@@ -1,18 +1,25 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
-import { Page, Header, Button, Modal } from 'decentraland-ui'
+import { Button, Header, Loader, Message, Modal, Page } from 'decentraland-ui'
+import { ActivityEventItem } from './ActivityEventItem'
+import { Transaction } from './Transaction'
 import { Column } from '../Layout/Column'
 import { Row } from '../Layout/Row'
 import { NavigationTab } from '../Navigation/Navigation.types'
 import { PageLayout } from '../PageLayout'
-import { Transaction } from './Transaction'
 import { Props } from './ActivityPage.types'
 import './ActivityPage.css'
 
 const ActivityPage = (props: Props) => {
-  const { address, transactions, onClearHistory } = props
+  const { address, mergedActivity, loading, error, onClearHistory, onLoadActivity } = props
 
   const [showConfirmation, setShowConfirmation] = useState(false)
+
+  useEffect(() => {
+    if (address) {
+      onLoadActivity()
+    }
+  }, [address, onLoadActivity])
 
   const handleClear = useCallback(() => {
     if (address) {
@@ -24,17 +31,33 @@ const ActivityPage = (props: Props) => {
   const handleConfirm = useCallback(() => setShowConfirmation(true), [setShowConfirmation])
   const handleCancel = useCallback(() => setShowConfirmation(false), [setShowConfirmation])
 
-  let content = null
+  let content: React.ReactNode
 
-  if (transactions.length === 0) {
+  const errorBanner = error ? (
+    <Message warning size="tiny" content={t('activity_page.error')} />
+  ) : null
+
+  if (loading && mergedActivity.length === 0) {
     content = (
       <div className="center">
-        <p>{t('activity_page.empty')}</p>
+        <Loader active size="large">
+          {t('activity_page.loading')}
+        </Loader>
       </div>
+    )
+  } else if (mergedActivity.length === 0) {
+    content = (
+      <>
+        {errorBanner}
+        <div className="center">
+          <p>{t('activity_page.empty')}</p>
+        </div>
+      </>
     )
   } else {
     content = (
       <>
+        {errorBanner}
         <Row>
           <Column align="left" grow={true}>
             <Header sub>{t('activity_page.latest_activity')}</Header>
@@ -45,7 +68,15 @@ const ActivityPage = (props: Props) => {
             </Button>
           </Column>
         </Row>
-        <div className="transactions">{transactions.map(tx => <Transaction tx={tx} key={tx.hash} />).reverse()}</div>
+        <div className="transactions">
+          {mergedActivity.map(item =>
+            item.kind === 'local' ? (
+              <Transaction tx={item.tx} key={`local:${item.tx.hash}`} />
+            ) : (
+              <ActivityEventItem event={item.event} key={`server:${item.event.id}`} />
+            )
+          )}
+        </div>
       </>
     )
   }

--- a/webapp/src/components/ActivityPage/ActivityPage.types.ts
+++ b/webapp/src/components/ActivityPage/ActivityPage.types.ts
@@ -1,13 +1,17 @@
 import { Dispatch } from 'redux'
 import { clearTransactions, ClearTransactionsAction } from 'decentraland-dapps/dist/modules/transaction/actions'
-import { Transaction } from 'decentraland-dapps/dist/modules/transaction/types'
+import { FetchUserActivityRequestAction } from '../../modules/activity/actions'
+import { MergedActivityItem } from '../../modules/activity/selectors'
 
 export type Props = {
   address?: string
-  transactions: Transaction[]
+  mergedActivity: MergedActivityItem[]
+  loading: boolean
+  error: string | null
   onClearHistory: typeof clearTransactions
+  onLoadActivity: () => void
 }
 
-export type MapStateProps = Pick<Props, 'address' | 'transactions'>
-export type MapDispatchProps = Pick<Props, 'onClearHistory'>
-export type MapDispatch = Dispatch<ClearTransactionsAction>
+export type MapStateProps = Pick<Props, 'address' | 'mergedActivity' | 'loading' | 'error'>
+export type MapDispatchProps = Pick<Props, 'onClearHistory' | 'onLoadActivity'>
+export type MapDispatch = Dispatch<ClearTransactionsAction | FetchUserActivityRequestAction>

--- a/webapp/src/components/ActivityPage/ActivityPage.types.ts
+++ b/webapp/src/components/ActivityPage/ActivityPage.types.ts
@@ -8,10 +8,12 @@ export type Props = {
   mergedActivity: MergedActivityItem[]
   loading: boolean
   error: string | null
+  hasMore: boolean
+  loaded: number
   onClearHistory: typeof clearTransactions
-  onLoadActivity: () => void
+  onLoadActivity: (limit: number, offset: number) => void
 }
 
-export type MapStateProps = Pick<Props, 'address' | 'mergedActivity' | 'loading' | 'error'>
+export type MapStateProps = Pick<Props, 'address' | 'mergedActivity' | 'loading' | 'error' | 'hasMore' | 'loaded'>
 export type MapDispatchProps = Pick<Props, 'onClearHistory' | 'onLoadActivity'>
 export type MapDispatch = Dispatch<ClearTransactionsAction | FetchUserActivityRequestAction>

--- a/webapp/src/modules/activity/actions.ts
+++ b/webapp/src/modules/activity/actions.ts
@@ -6,8 +6,7 @@ export const FETCH_USER_ACTIVITY_SUCCESS = '[Success] Fetch user activity'
 export const FETCH_USER_ACTIVITY_FAILURE = '[Failure] Fetch user activity'
 
 export const fetchUserActivityRequest = () => action(FETCH_USER_ACTIVITY_REQUEST, {})
-export const fetchUserActivitySuccess = (events: ActivityEvent[], total: number) =>
-  action(FETCH_USER_ACTIVITY_SUCCESS, { events, total })
+export const fetchUserActivitySuccess = (events: ActivityEvent[], total: number) => action(FETCH_USER_ACTIVITY_SUCCESS, { events, total })
 export const fetchUserActivityFailure = (error: string) => action(FETCH_USER_ACTIVITY_FAILURE, { error })
 
 export type FetchUserActivityRequestAction = ReturnType<typeof fetchUserActivityRequest>

--- a/webapp/src/modules/activity/actions.ts
+++ b/webapp/src/modules/activity/actions.ts
@@ -1,0 +1,15 @@
+import { action } from 'typesafe-actions'
+import { ActivityEvent } from './types'
+
+export const FETCH_USER_ACTIVITY_REQUEST = '[Request] Fetch user activity'
+export const FETCH_USER_ACTIVITY_SUCCESS = '[Success] Fetch user activity'
+export const FETCH_USER_ACTIVITY_FAILURE = '[Failure] Fetch user activity'
+
+export const fetchUserActivityRequest = () => action(FETCH_USER_ACTIVITY_REQUEST, {})
+export const fetchUserActivitySuccess = (events: ActivityEvent[], total: number) =>
+  action(FETCH_USER_ACTIVITY_SUCCESS, { events, total })
+export const fetchUserActivityFailure = (error: string) => action(FETCH_USER_ACTIVITY_FAILURE, { error })
+
+export type FetchUserActivityRequestAction = ReturnType<typeof fetchUserActivityRequest>
+export type FetchUserActivitySuccessAction = ReturnType<typeof fetchUserActivitySuccess>
+export type FetchUserActivityFailureAction = ReturnType<typeof fetchUserActivityFailure>

--- a/webapp/src/modules/activity/actions.ts
+++ b/webapp/src/modules/activity/actions.ts
@@ -5,8 +5,14 @@ export const FETCH_USER_ACTIVITY_REQUEST = '[Request] Fetch user activity'
 export const FETCH_USER_ACTIVITY_SUCCESS = '[Success] Fetch user activity'
 export const FETCH_USER_ACTIVITY_FAILURE = '[Failure] Fetch user activity'
 
-export const fetchUserActivityRequest = () => action(FETCH_USER_ACTIVITY_REQUEST, {})
-export const fetchUserActivitySuccess = (events: ActivityEvent[], total: number) => action(FETCH_USER_ACTIVITY_SUCCESS, { events, total })
+export type FetchActivityPayload = {
+  limit: number
+  offset: number
+}
+
+export const fetchUserActivityRequest = (payload: FetchActivityPayload) => action(FETCH_USER_ACTIVITY_REQUEST, payload)
+export const fetchUserActivitySuccess = (events: ActivityEvent[], total: number, offset: number) =>
+  action(FETCH_USER_ACTIVITY_SUCCESS, { events, total, offset })
 export const fetchUserActivityFailure = (error: string) => action(FETCH_USER_ACTIVITY_FAILURE, { error })
 
 export type FetchUserActivityRequestAction = ReturnType<typeof fetchUserActivityRequest>

--- a/webapp/src/modules/activity/reducer.spec.ts
+++ b/webapp/src/modules/activity/reducer.spec.ts
@@ -1,0 +1,64 @@
+import { Network } from '@dcl/schemas'
+import { fetchUserActivityFailure, fetchUserActivityRequest, fetchUserActivitySuccess } from './actions'
+import { activityReducer, INITIAL_STATE } from './reducer'
+import { ActivityEvent, ActivityEventType } from './types'
+
+const makeEvent = (id: string, timestamp = 0): ActivityEvent =>
+  ({
+    id,
+    type: ActivityEventType.SALE_BUYER,
+    timestamp,
+    network: Network.MATIC,
+    contractAddress: '0xnft',
+    tokenId: '1',
+    price: '100',
+    details: {} as any
+  }) as ActivityEvent
+
+describe('activityReducer', () => {
+  describe('on FETCH_USER_ACTIVITY_REQUEST', () => {
+    it('should clear any prior error and mark loading', () => {
+      const previous = { ...INITIAL_STATE, error: 'prior boom' }
+      const next = activityReducer(previous, fetchUserActivityRequest({ limit: 20, offset: 0 }))
+      expect(next.error).toBeNull()
+      expect(next.loading.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('on FETCH_USER_ACTIVITY_SUCCESS with offset === 0 (first page)', () => {
+    it('should replace any prior data', () => {
+      const previous = { ...INITIAL_STATE, data: [makeEvent('old', 100)], loaded: 1, total: 1 }
+      const next = activityReducer(previous, fetchUserActivitySuccess([makeEvent('new', 200)], 5, 0))
+      expect(next.data.map(e => e.id)).toEqual(['new'])
+      expect(next.loaded).toBe(1)
+      expect(next.total).toBe(5)
+    })
+  })
+
+  describe('on FETCH_USER_ACTIVITY_SUCCESS with offset > 0 (subsequent page)', () => {
+    it('should append the new events to the existing data', () => {
+      const previous = { ...INITIAL_STATE, data: [makeEvent('a', 100), makeEvent('b', 90)], loaded: 2, total: 4 }
+      const next = activityReducer(previous, fetchUserActivitySuccess([makeEvent('c', 80), makeEvent('d', 70)], 4, 2))
+      expect(next.data.map(e => e.id)).toEqual(['a', 'b', 'c', 'd'])
+      expect(next.loaded).toBe(4)
+      expect(next.total).toBe(4)
+    })
+
+    it('should dedupe events by id (defense against server shifting the slice between requests)', () => {
+      const previous = { ...INITIAL_STATE, data: [makeEvent('a'), makeEvent('b'), makeEvent('c')], loaded: 3, total: 6 }
+      // Page 2 returns events including a duplicate of 'c' because a new event arrived and shifted the slice
+      const next = activityReducer(previous, fetchUserActivitySuccess([makeEvent('c'), makeEvent('d')], 6, 3))
+      expect(next.data.map(e => e.id)).toEqual(['a', 'b', 'c', 'd'])
+      expect(next.loaded).toBe(4)
+    })
+  })
+
+  describe('on FETCH_USER_ACTIVITY_FAILURE', () => {
+    it('should store the error and stop loading', () => {
+      const previous = { ...INITIAL_STATE, loading: [{ type: '[Request] Fetch user activity' } as any] }
+      const next = activityReducer(previous, fetchUserActivityFailure('boom'))
+      expect(next.error).toBe('boom')
+      expect(next.loading).toHaveLength(0)
+    })
+  })
+})

--- a/webapp/src/modules/activity/reducer.ts
+++ b/webapp/src/modules/activity/reducer.ts
@@ -12,6 +12,7 @@ import { ActivityEvent } from './types'
 export type ActivityState = {
   data: ActivityEvent[]
   total: number
+  loaded: number
   loading: LoadingState
   error: string | null
 }
@@ -19,12 +20,18 @@ export type ActivityState = {
 export const INITIAL_STATE: ActivityState = {
   data: [],
   total: 0,
+  loaded: 0,
   loading: [],
   error: null
 }
 
 type ActivityReducerAction = FetchUserActivityRequestAction | FetchUserActivitySuccessAction | FetchUserActivityFailureAction
 
+// Append-mode reducer for infinite scroll. The first page (offset === 0) RESETS the list
+// — typical scenarios: user navigates to the page fresh, or we re-fetch after a wallet
+// change. Subsequent pages APPEND. We dedupe by event id to defend against the server
+// returning the same event in adjacent pages (e.g. if new events arrive between requests
+// and shift the slice boundary).
 export function activityReducer(state = INITIAL_STATE, action: ActivityReducerAction): ActivityState {
   switch (action.type) {
     case FETCH_USER_ACTIVITY_REQUEST:
@@ -34,13 +41,22 @@ export function activityReducer(state = INITIAL_STATE, action: ActivityReducerAc
         error: null
       }
     case FETCH_USER_ACTIVITY_SUCCESS: {
-      const { events, total } = action.payload
+      const { events, total, offset } = action.payload
+      const isFirstPage = offset === 0
+      const merged = isFirstPage ? events : [...state.data, ...events]
+      const seenIds = new Set<string>()
+      const deduped = merged.filter(ev => {
+        if (seenIds.has(ev.id)) return false
+        seenIds.add(ev.id)
+        return true
+      })
       return {
         ...state,
         loading: loadingReducer(state.loading, action),
         error: null,
-        data: events,
-        total
+        data: deduped,
+        total,
+        loaded: deduped.length
       }
     }
     case FETCH_USER_ACTIVITY_FAILURE: {

--- a/webapp/src/modules/activity/reducer.ts
+++ b/webapp/src/modules/activity/reducer.ts
@@ -1,0 +1,57 @@
+import { loadingReducer, LoadingState } from 'decentraland-dapps/dist/modules/loading/reducer'
+import {
+  FETCH_USER_ACTIVITY_FAILURE,
+  FETCH_USER_ACTIVITY_REQUEST,
+  FETCH_USER_ACTIVITY_SUCCESS,
+  FetchUserActivityFailureAction,
+  FetchUserActivityRequestAction,
+  FetchUserActivitySuccessAction
+} from './actions'
+import { ActivityEvent } from './types'
+
+export type ActivityState = {
+  data: ActivityEvent[]
+  total: number
+  loading: LoadingState
+  error: string | null
+}
+
+export const INITIAL_STATE: ActivityState = {
+  data: [],
+  total: 0,
+  loading: [],
+  error: null
+}
+
+type ActivityReducerAction = FetchUserActivityRequestAction | FetchUserActivitySuccessAction | FetchUserActivityFailureAction
+
+export function activityReducer(state = INITIAL_STATE, action: ActivityReducerAction): ActivityState {
+  switch (action.type) {
+    case FETCH_USER_ACTIVITY_REQUEST:
+      return {
+        ...state,
+        loading: loadingReducer(state.loading, action),
+        error: null
+      }
+    case FETCH_USER_ACTIVITY_SUCCESS: {
+      const { events, total } = action.payload
+      return {
+        ...state,
+        loading: loadingReducer(state.loading, action),
+        error: null,
+        data: events,
+        total
+      }
+    }
+    case FETCH_USER_ACTIVITY_FAILURE: {
+      const { error } = action.payload
+      return {
+        ...state,
+        loading: loadingReducer(state.loading, action),
+        error
+      }
+    }
+    default:
+      return state
+  }
+}

--- a/webapp/src/modules/activity/sagas.spec.ts
+++ b/webapp/src/modules/activity/sagas.spec.ts
@@ -3,13 +3,9 @@ import { expectSaga } from 'redux-saga-test-plan'
 import { throwError } from 'redux-saga-test-plan/providers'
 import { AuthIdentity } from '@dcl/crypto'
 import { Network } from '@dcl/schemas'
-import { activityAPI } from '../vendor/decentraland/activity'
 import { getIdentity } from '../identity/utils'
-import {
-  fetchUserActivityFailure,
-  fetchUserActivityRequest,
-  fetchUserActivitySuccess
-} from './actions'
+import { activityAPI } from '../vendor/decentraland/activity'
+import { fetchUserActivityFailure, fetchUserActivityRequest, fetchUserActivitySuccess } from './actions'
 import { activitySaga } from './sagas'
 import { ActivityEvent, ActivityEventType } from './types'
 

--- a/webapp/src/modules/activity/sagas.spec.ts
+++ b/webapp/src/modules/activity/sagas.spec.ts
@@ -17,7 +17,7 @@ describe('when fetching user activity', () => {
     identity = { authChain: [], expiration: new Date(Date.now() + 60000), ephemeralIdentity: {} as any }
     events = [
       {
-        id: 'sale:1',
+        id: 'sale_buyer:1',
         type: ActivityEventType.SALE_BUYER,
         timestamp: 1000,
         network: Network.MATIC,
@@ -32,14 +32,25 @@ describe('when fetching user activity', () => {
   })
 
   describe('and the API responds successfully', () => {
-    it('should dispatch a success action with events + total', () => {
+    it('should forward limit + offset to the API and dispatch success with the offset', () => {
       return expectSaga(activitySaga)
         .provide([
           [call(getIdentity), identity],
-          [call([activityAPI, activityAPI.fetchUserActivity], identity), { data: events, total: 1 }]
+          [call([activityAPI, activityAPI.fetchUserActivity], identity, { limit: 20, offset: 0 }), { data: events, total: 1 }]
         ])
-        .put(fetchUserActivitySuccess(events, 1))
-        .dispatch(fetchUserActivityRequest())
+        .put(fetchUserActivitySuccess(events, 1, 0))
+        .dispatch(fetchUserActivityRequest({ limit: 20, offset: 0 }))
+        .run({ silenceTimeout: true })
+    })
+
+    it('should forward a non-zero offset for subsequent pages', () => {
+      return expectSaga(activitySaga)
+        .provide([
+          [call(getIdentity), identity],
+          [call([activityAPI, activityAPI.fetchUserActivity], identity, { limit: 20, offset: 40 }), { data: events, total: 80 }]
+        ])
+        .put(fetchUserActivitySuccess(events, 80, 40))
+        .dispatch(fetchUserActivityRequest({ limit: 20, offset: 40 }))
         .run({ silenceTimeout: true })
     })
   })
@@ -49,10 +60,10 @@ describe('when fetching user activity', () => {
       return expectSaga(activitySaga)
         .provide([
           [call(getIdentity), identity],
-          [call([activityAPI, activityAPI.fetchUserActivity], identity), throwError(new Error('boom'))]
+          [call([activityAPI, activityAPI.fetchUserActivity], identity, { limit: 20, offset: 0 }), throwError(new Error('boom'))]
         ])
         .put(fetchUserActivityFailure('boom'))
-        .dispatch(fetchUserActivityRequest())
+        .dispatch(fetchUserActivityRequest({ limit: 20, offset: 0 }))
         .run({ silenceTimeout: true })
     })
   })
@@ -62,7 +73,7 @@ describe('when fetching user activity', () => {
       return expectSaga(activitySaga)
         .provide([[call(getIdentity), throwError(new Error('no identity'))]])
         .put(fetchUserActivityFailure('no identity'))
-        .dispatch(fetchUserActivityRequest())
+        .dispatch(fetchUserActivityRequest({ limit: 20, offset: 0 }))
         .run({ silenceTimeout: true })
     })
   })

--- a/webapp/src/modules/activity/sagas.spec.ts
+++ b/webapp/src/modules/activity/sagas.spec.ts
@@ -1,0 +1,73 @@
+import { call } from 'redux-saga/effects'
+import { expectSaga } from 'redux-saga-test-plan'
+import { throwError } from 'redux-saga-test-plan/providers'
+import { AuthIdentity } from '@dcl/crypto'
+import { Network } from '@dcl/schemas'
+import { activityAPI } from '../vendor/decentraland/activity'
+import { getIdentity } from '../identity/utils'
+import {
+  fetchUserActivityFailure,
+  fetchUserActivityRequest,
+  fetchUserActivitySuccess
+} from './actions'
+import { activitySaga } from './sagas'
+import { ActivityEvent, ActivityEventType } from './types'
+
+describe('when fetching user activity', () => {
+  let identity: AuthIdentity
+  let events: ActivityEvent[]
+
+  beforeEach(() => {
+    identity = { authChain: [], expiration: new Date(Date.now() + 60000), ephemeralIdentity: {} as any }
+    events = [
+      {
+        id: 'sale:1',
+        type: ActivityEventType.SALE_BUYER,
+        timestamp: 1000,
+        network: Network.MATIC,
+        txHash: '0xabc',
+        contractAddress: '0xnft',
+        tokenId: '1',
+        price: '100',
+        counterparty: '0xseller',
+        details: {} as any
+      }
+    ]
+  })
+
+  describe('and the API responds successfully', () => {
+    it('should dispatch a success action with events + total', () => {
+      return expectSaga(activitySaga)
+        .provide([
+          [call(getIdentity), identity],
+          [call([activityAPI, activityAPI.fetchUserActivity], identity), { data: events, total: 1 }]
+        ])
+        .put(fetchUserActivitySuccess(events, 1))
+        .dispatch(fetchUserActivityRequest())
+        .run({ silenceTimeout: true })
+    })
+  })
+
+  describe('and the API rejects', () => {
+    it('should dispatch a failure action with the error message', () => {
+      return expectSaga(activitySaga)
+        .provide([
+          [call(getIdentity), identity],
+          [call([activityAPI, activityAPI.fetchUserActivity], identity), throwError(new Error('boom'))]
+        ])
+        .put(fetchUserActivityFailure('boom'))
+        .dispatch(fetchUserActivityRequest())
+        .run({ silenceTimeout: true })
+    })
+  })
+
+  describe('and the identity cannot be obtained', () => {
+    it('should dispatch a failure action', () => {
+      return expectSaga(activitySaga)
+        .provide([[call(getIdentity), throwError(new Error('no identity'))]])
+        .put(fetchUserActivityFailure('no identity'))
+        .dispatch(fetchUserActivityRequest())
+        .run({ silenceTimeout: true })
+    })
+  })
+})

--- a/webapp/src/modules/activity/sagas.ts
+++ b/webapp/src/modules/activity/sagas.ts
@@ -1,0 +1,27 @@
+import { AuthIdentity } from '@dcl/crypto'
+import { call, put, takeEvery } from 'redux-saga/effects'
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import { isErrorWithMessage } from '../../lib/error'
+import { activityAPI } from '../vendor/decentraland/activity'
+import { getIdentity } from '../identity/utils'
+import {
+  FETCH_USER_ACTIVITY_REQUEST,
+  fetchUserActivityFailure,
+  fetchUserActivitySuccess
+} from './actions'
+
+export function* activitySaga() {
+  yield takeEvery(FETCH_USER_ACTIVITY_REQUEST, handleFetchUserActivityRequest)
+}
+
+export function* handleFetchUserActivityRequest() {
+  try {
+    const identity = (yield call(getIdentity)) as AuthIdentity
+    const { data, total } = (yield call([activityAPI, activityAPI.fetchUserActivity], identity)) as Awaited<
+      ReturnType<typeof activityAPI.fetchUserActivity>
+    >
+    yield put(fetchUserActivitySuccess(data, total))
+  } catch (error) {
+    yield put(fetchUserActivityFailure(isErrorWithMessage(error) ? error.message : t('global.unknown_error')))
+  }
+}

--- a/webapp/src/modules/activity/sagas.ts
+++ b/webapp/src/modules/activity/sagas.ts
@@ -1,14 +1,10 @@
-import { AuthIdentity } from '@dcl/crypto'
 import { call, put, takeEvery } from 'redux-saga/effects'
+import { AuthIdentity } from '@dcl/crypto'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { isErrorWithMessage } from '../../lib/error'
-import { activityAPI } from '../vendor/decentraland/activity'
 import { getIdentity } from '../identity/utils'
-import {
-  FETCH_USER_ACTIVITY_REQUEST,
-  fetchUserActivityFailure,
-  fetchUserActivitySuccess
-} from './actions'
+import { activityAPI } from '../vendor/decentraland/activity'
+import { FETCH_USER_ACTIVITY_REQUEST, fetchUserActivityFailure, fetchUserActivitySuccess } from './actions'
 
 export function* activitySaga() {
   yield takeEvery(FETCH_USER_ACTIVITY_REQUEST, handleFetchUserActivityRequest)

--- a/webapp/src/modules/activity/sagas.ts
+++ b/webapp/src/modules/activity/sagas.ts
@@ -4,19 +4,20 @@ import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { isErrorWithMessage } from '../../lib/error'
 import { getIdentity } from '../identity/utils'
 import { activityAPI } from '../vendor/decentraland/activity'
-import { FETCH_USER_ACTIVITY_REQUEST, fetchUserActivityFailure, fetchUserActivitySuccess } from './actions'
+import { FETCH_USER_ACTIVITY_REQUEST, FetchUserActivityRequestAction, fetchUserActivityFailure, fetchUserActivitySuccess } from './actions'
 
 export function* activitySaga() {
   yield takeEvery(FETCH_USER_ACTIVITY_REQUEST, handleFetchUserActivityRequest)
 }
 
-export function* handleFetchUserActivityRequest() {
+export function* handleFetchUserActivityRequest(action: FetchUserActivityRequestAction) {
+  const { limit, offset } = action.payload
   try {
     const identity = (yield call(getIdentity)) as AuthIdentity
-    const { data, total } = (yield call([activityAPI, activityAPI.fetchUserActivity], identity)) as Awaited<
+    const { data, total } = (yield call([activityAPI, activityAPI.fetchUserActivity], identity, { limit, offset })) as Awaited<
       ReturnType<typeof activityAPI.fetchUserActivity>
     >
-    yield put(fetchUserActivitySuccess(data, total))
+    yield put(fetchUserActivitySuccess(data, total, offset))
   } catch (error) {
     yield put(fetchUserActivityFailure(isErrorWithMessage(error) ? error.message : t('global.unknown_error')))
   }

--- a/webapp/src/modules/activity/selectors.spec.ts
+++ b/webapp/src/modules/activity/selectors.spec.ts
@@ -20,7 +20,7 @@ const makeTx = (overrides: Partial<Transaction> = {}): Transaction =>
     withReceipt: false,
     isCrossChain: false,
     ...(overrides as object)
-  } as unknown as Transaction)
+  }) as unknown as Transaction
 
 const makeServerEvent = (overrides: Partial<ActivityEvent> = {}): ActivityEvent =>
   ({
@@ -35,14 +35,14 @@ const makeServerEvent = (overrides: Partial<ActivityEvent> = {}): ActivityEvent 
     counterparty: '0xseller',
     details: {} as any,
     ...overrides
-  } as ActivityEvent)
+  }) as ActivityEvent
 
 const makeState = (txs: Transaction[], events: ActivityEvent[]): RootState =>
   ({
     transaction: { data: txs, loading: [], error: null },
     wallet: { data: { address: '0xuser' }, loading: [], error: null },
     activity: { ...INITIAL_ACTIVITY_STATE, data: events, total: events.length }
-  } as unknown as RootState)
+  }) as unknown as RootState
 
 describe('getMergedActivity', () => {
   describe('when local and server have no overlap', () => {

--- a/webapp/src/modules/activity/selectors.spec.ts
+++ b/webapp/src/modules/activity/selectors.spec.ts
@@ -1,0 +1,105 @@
+import { Network } from '@dcl/schemas'
+import { Transaction, TransactionStatus } from 'decentraland-dapps/dist/modules/transaction/types'
+import { RootState } from '../reducer'
+import { INITIAL_STATE as INITIAL_ACTIVITY_STATE } from './reducer'
+import { getMergedActivity } from './selectors'
+import { ActivityEvent, ActivityEventType } from './types'
+
+const makeTx = (overrides: Partial<Transaction> = {}): Transaction =>
+  ({
+    hash: '0xLOCAL',
+    actionType: 'BUY_ITEM_SUCCESS',
+    from: '0xuser',
+    status: TransactionStatus.PENDING,
+    timestamp: 5000,
+    chainId: 137,
+    payload: {},
+    url: 'https://etherscan.io/tx/0xLOCAL',
+    nonce: 1,
+    replacedBy: null,
+    withReceipt: false,
+    isCrossChain: false,
+    ...(overrides as object)
+  } as unknown as Transaction)
+
+const makeServerEvent = (overrides: Partial<ActivityEvent> = {}): ActivityEvent =>
+  ({
+    id: 'sale:1',
+    type: ActivityEventType.SALE_BUYER,
+    timestamp: 1000,
+    network: Network.MATIC,
+    txHash: '0xSERVER',
+    contractAddress: '0xnft',
+    tokenId: '1',
+    price: '100',
+    counterparty: '0xseller',
+    details: {} as any,
+    ...overrides
+  } as ActivityEvent)
+
+const makeState = (txs: Transaction[], events: ActivityEvent[]): RootState =>
+  ({
+    transaction: { data: txs, loading: [], error: null },
+    wallet: { data: { address: '0xuser' }, loading: [], error: null },
+    activity: { ...INITIAL_ACTIVITY_STATE, data: events, total: events.length }
+  } as unknown as RootState)
+
+describe('getMergedActivity', () => {
+  describe('when local and server have no overlap', () => {
+    it('should include both, sorted DESC by timestamp', () => {
+      const localTx = makeTx({ hash: '0xa', timestamp: 5000 })
+      const serverEvent = makeServerEvent({ id: 's:1', txHash: '0xb', timestamp: 1000 })
+      const state = makeState([localTx], [serverEvent])
+
+      const merged = getMergedActivity(state)
+      expect(merged).toHaveLength(2)
+      expect(merged[0].kind).toBe('local')
+      expect(merged[1].kind).toBe('server')
+    })
+  })
+
+  describe('when a local tx has the same hash as a server event', () => {
+    it('should drop the server event (prefer-local dedup)', () => {
+      const sharedHash = '0xSHARED'
+      const localTx = makeTx({ hash: sharedHash, timestamp: 5000 })
+      const serverEvent = makeServerEvent({ id: 's:1', txHash: sharedHash, timestamp: 1000 })
+
+      const merged = getMergedActivity(makeState([localTx], [serverEvent]))
+      expect(merged).toHaveLength(1)
+      expect(merged[0].kind).toBe('local')
+    })
+
+    it('should be case-insensitive on the txHash match', () => {
+      const localTx = makeTx({ hash: '0xABCDEF', timestamp: 5000 })
+      const serverEvent = makeServerEvent({ id: 's:1', txHash: '0xabcdef', timestamp: 1000 })
+
+      const merged = getMergedActivity(makeState([localTx], [serverEvent]))
+      expect(merged).toHaveLength(1)
+      expect(merged[0].kind).toBe('local')
+    })
+  })
+
+  describe('when a server event has no txHash', () => {
+    it('should NOT be deduped against local txs', () => {
+      const localTx = makeTx({ hash: '0xLOCAL', timestamp: 5000 })
+      const serverEvent = makeServerEvent({ id: 's:1', txHash: undefined, timestamp: 1000 })
+
+      const merged = getMergedActivity(makeState([localTx], [serverEvent]))
+      expect(merged).toHaveLength(2)
+    })
+  })
+
+  describe('when there are many items', () => {
+    it('should sort all items by timestamp DESC', () => {
+      const local = [makeTx({ hash: '0x1', timestamp: 5000 }), makeTx({ hash: '0x2', timestamp: 9000 })]
+      const server = [
+        makeServerEvent({ id: 's:1', txHash: '0xa', timestamp: 1000 }),
+        makeServerEvent({ id: 's:2', txHash: '0xb', timestamp: 7000 })
+      ]
+
+      const merged = getMergedActivity(makeState(local, server))
+      const timestamps = merged.map(m => m.timestamp)
+      expect(timestamps).toEqual([9000, 7000, 5000, 1000])
+    })
+  })
+})

--- a/webapp/src/modules/activity/selectors.ts
+++ b/webapp/src/modules/activity/selectors.ts
@@ -1,0 +1,37 @@
+import { createSelector } from 'reselect'
+import { Transaction } from 'decentraland-dapps/dist/modules/transaction/types'
+import { RootState } from '../reducer'
+import { getTransactions } from '../transaction/selectors'
+import { ActivityEvent } from './types'
+
+export const getState = (state: RootState) => state.activity
+export const getData = (state: RootState) => getState(state).data
+export const getTotal = (state: RootState) => getState(state).total
+export const getLoading = (state: RootState) => getState(state).loading
+export const getError = (state: RootState) => getState(state).error
+
+export type MergedActivityItem =
+  | { kind: 'local'; tx: Transaction; timestamp: number }
+  | { kind: 'server'; event: ActivityEvent; timestamp: number }
+
+// Merge local transactions (decentraland-dapps state, persisted in localStorage)
+// with server-side ActivityEvents. When the same on-chain transaction shows up in
+// both, keep the LOCAL one (user choice: preserves pending state and the precise
+// signing-time ordering). Result is sorted DESC by timestamp.
+export const getMergedActivity = createSelector<RootState, Transaction[], ActivityEvent[], MergedActivityItem[]>(
+  getTransactions,
+  getData,
+  (localTxs, serverEvents) => {
+    const localHashes = new Set(
+      localTxs.map(tx => tx.hash?.toLowerCase()).filter((h): h is string => !!h)
+    )
+    const dedupedServer = serverEvents.filter(ev => !ev.txHash || !localHashes.has(ev.txHash.toLowerCase()))
+
+    const merged: MergedActivityItem[] = [
+      ...localTxs.map(tx => ({ kind: 'local' as const, tx, timestamp: tx.timestamp ?? 0 })),
+      ...dedupedServer.map(event => ({ kind: 'server' as const, event, timestamp: event.timestamp }))
+    ]
+
+    return merged.sort((a, b) => b.timestamp - a.timestamp)
+  }
+)

--- a/webapp/src/modules/activity/selectors.ts
+++ b/webapp/src/modules/activity/selectors.ts
@@ -7,8 +7,10 @@ import { ActivityEvent } from './types'
 export const getState = (state: RootState) => state.activity
 export const getData = (state: RootState) => getState(state).data
 export const getTotal = (state: RootState) => getState(state).total
+export const getLoaded = (state: RootState) => getState(state).loaded
 export const getLoading = (state: RootState) => getState(state).loading
 export const getError = (state: RootState) => getState(state).error
+export const getHasMore = (state: RootState) => getState(state).loaded < getState(state).total
 
 export type MergedActivityItem =
   | { kind: 'local'; tx: Transaction; timestamp: number }

--- a/webapp/src/modules/activity/selectors.ts
+++ b/webapp/src/modules/activity/selectors.ts
@@ -22,9 +22,7 @@ export const getMergedActivity = createSelector<RootState, Transaction[], Activi
   getTransactions,
   getData,
   (localTxs, serverEvents) => {
-    const localHashes = new Set(
-      localTxs.map(tx => tx.hash?.toLowerCase()).filter((h): h is string => !!h)
-    )
+    const localHashes = new Set(localTxs.map(tx => tx.hash?.toLowerCase()).filter((h): h is string => !!h))
     const dedupedServer = serverEvents.filter(ev => !ev.txHash || !localHashes.has(ev.txHash.toLowerCase()))
 
     const merged: MergedActivityItem[] = [

--- a/webapp/src/modules/activity/types.ts
+++ b/webapp/src/modules/activity/types.ts
@@ -1,0 +1,40 @@
+import { Bid, Network, Order, Sale, Trade } from '@dcl/schemas'
+
+export enum ActivityEventType {
+  SALE_BUYER = 'sale_buyer',
+  SALE_SELLER = 'sale_seller',
+  BID_PLACED = 'bid_placed',
+  BID_RECEIVED = 'bid_received',
+  ORDER_CREATED = 'order_created',
+  ORDER_FILLED = 'order_filled',
+  TRADE_CREATED = 'trade_created'
+}
+
+export type ActivityEventBase = {
+  id: string
+  timestamp: number
+  network: Network
+  txHash?: string
+  contractAddress?: string
+  tokenId?: string
+  itemId?: string
+  price?: string
+  counterparty?: string
+}
+
+export type SaleBuyerEvent = ActivityEventBase & { type: ActivityEventType.SALE_BUYER; details: { sale: Sale } }
+export type SaleSellerEvent = ActivityEventBase & { type: ActivityEventType.SALE_SELLER; details: { sale: Sale } }
+export type BidPlacedEvent = ActivityEventBase & { type: ActivityEventType.BID_PLACED; details: { bid: Bid } }
+export type BidReceivedEvent = ActivityEventBase & { type: ActivityEventType.BID_RECEIVED; details: { bid: Bid } }
+export type OrderCreatedEvent = ActivityEventBase & { type: ActivityEventType.ORDER_CREATED; details: { order: Order } }
+export type OrderFilledEvent = ActivityEventBase & { type: ActivityEventType.ORDER_FILLED; details: { order: Order } }
+export type TradeCreatedEvent = ActivityEventBase & { type: ActivityEventType.TRADE_CREATED; details: { trade: Trade } }
+
+export type ActivityEvent =
+  | SaleBuyerEvent
+  | SaleSellerEvent
+  | BidPlacedEvent
+  | BidReceivedEvent
+  | OrderCreatedEvent
+  | OrderFilledEvent
+  | TradeCreatedEvent

--- a/webapp/src/modules/reducer.ts
+++ b/webapp/src/modules/reducer.ts
@@ -12,6 +12,7 @@ import { transactionReducer as transaction } from 'decentraland-dapps/dist/modul
 import { translationReducer as translation } from 'decentraland-dapps/dist/modules/translation/reducer'
 import { walletReducer as wallet } from 'decentraland-dapps/dist/modules/wallet/reducer'
 import { accountReducer as account } from './account/reducer'
+import { activityReducer as activity } from './activity/reducer'
 import { analyticsReducer as analytics } from './analytics/reducer'
 import { assetReducer as asset } from './asset/reducer'
 import { bidReducer as bid } from './bid/reducer'
@@ -35,6 +36,7 @@ export const createRootReducer = () =>
   combineReducers({
     asset,
     account,
+    activity,
     campaign,
     authorization,
     bid,

--- a/webapp/src/modules/sagas.ts
+++ b/webapp/src/modules/sagas.ts
@@ -22,6 +22,7 @@ import { config } from '../config'
 import { API_SIGNER } from '../lib/api'
 import { peerUrl } from '../lib/environment'
 import { accountSaga } from './account/sagas'
+import { activitySaga } from './activity/sagas'
 import { analyticsSagas as marketplaceAnalyticsSagas } from './analytics/sagas'
 import { assetSaga } from './asset/sagas'
 import { bidSaga } from './bid/sagas'
@@ -122,6 +123,7 @@ export function* rootSaga(getIdentity: () => AuthIdentity | undefined) {
     walletSaga(),
     collectionSaga(),
     saleSaga(),
+    activitySaga(),
     accountSaga(lambdasClient),
     collectionSaga(),
     storeSaga(contentClient),

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -1065,6 +1065,20 @@
     "latest_activity": "Latest Activity",
     "clear_history": "Clear History",
     "empty": "You have no activity yet.",
+    "loading": "Loading your activity…",
+    "error": "Couldn't load your full activity history right now. Showing recent activity from this browser only.",
+    "event": {
+      "sale_buyer": "You bought {name} from {counterparty} for {price}.",
+      "sale_seller": "You sold {name} to {counterparty} for {price}.",
+      "bid_placed": "You placed a bid of {price} on {name}.",
+      "bid_received": "You received a bid of {price} on {name} from {counterparty}.",
+      "order_created": "You listed {name} on sale for {price}.",
+      "order_filled": "Your listing of {name} was bought for {price}.",
+      "trade_created": "You created a trade for {name}.",
+      "status": {
+        "confirmed": "Confirmed"
+      }
+    },
     "clear_history_modal": {
       "title": "Are you sure?",
       "text": "You are about to clear your transaction history. Do you want to proceed?"

--- a/webapp/src/modules/vendor/decentraland/activity/api.ts
+++ b/webapp/src/modules/vendor/decentraland/activity/api.ts
@@ -30,11 +30,9 @@ class ActivityAPI {
 
     const json = (await response.json().catch(() => null)) as ActivityResponseBody | null
 
-    if (!response.ok) {
-      throw new Error(json && isErrorBody(json) && json.message ? json.message : 'Could not fetch activity')
-    }
-    if (!json || isErrorBody(json)) {
-      throw new Error(json && isErrorBody(json) && json.message ? json.message : 'Could not fetch activity')
+    if (!response.ok || !json || isErrorBody(json)) {
+      const msg = json && isErrorBody(json) && json.message ? json.message : 'Could not fetch activity'
+      throw new Error(msg)
     }
     return json
   }

--- a/webapp/src/modules/vendor/decentraland/activity/api.ts
+++ b/webapp/src/modules/vendor/decentraland/activity/api.ts
@@ -1,0 +1,32 @@
+import signedFetch, { AuthIdentity } from 'decentraland-crypto-fetch'
+import { ActivityEvent } from '../../../activity/types'
+import { MARKETPLACE_SERVER_URL } from '../nft'
+
+type ActivityResponse = {
+  ok: boolean
+  message?: string
+  data: { data: ActivityEvent[]; total: number }
+}
+
+class ActivityAPI {
+  fetchUserActivity = async (identity: AuthIdentity): Promise<{ data: ActivityEvent[]; total: number }> => {
+    const url = `${MARKETPLACE_SERVER_URL}/activity`
+    const response = await signedFetch(url, {
+      method: 'GET',
+      identity,
+      headers: { 'Content-Type': 'application/json' }
+    })
+
+    if (!response.ok) {
+      throw new Error('Could not fetch activity')
+    }
+
+    const json = (await response.json()) as ActivityResponse
+    if (json.ok) {
+      return json.data
+    }
+    throw new Error(json.message ?? 'Could not fetch activity')
+  }
+}
+
+export const activityAPI = new ActivityAPI()

--- a/webapp/src/modules/vendor/decentraland/activity/api.ts
+++ b/webapp/src/modules/vendor/decentraland/activity/api.ts
@@ -1,31 +1,42 @@
 import signedFetch, { AuthIdentity } from 'decentraland-crypto-fetch'
+import { API_SIGNER } from '../../../../lib/api'
 import { ActivityEvent } from '../../../activity/types'
 import { MARKETPLACE_SERVER_URL } from '../nft'
 
-type ActivityResponse = {
-  ok: boolean
-  message?: string
-  data: { data: ActivityEvent[]; total: number }
-}
+// Success body matches the sales/orders/bids shape: { data, total } (no `ok` envelope).
+// Errors still carry { ok: false, message } — that's the server's convention.
+type ActivitySuccessBody = { data: ActivityEvent[]; total: number }
+type ActivityErrorBody = { ok: false; message?: string }
+type ActivityResponseBody = ActivitySuccessBody | ActivityErrorBody
+
+const isErrorBody = (b: ActivityResponseBody): b is ActivityErrorBody => 'ok' in b && b.ok === false
 
 class ActivityAPI {
-  fetchUserActivity = async (identity: AuthIdentity): Promise<{ data: ActivityEvent[]; total: number }> => {
-    const url = `${MARKETPLACE_SERVER_URL}/activity`
+  fetchUserActivity = async (
+    identity: AuthIdentity,
+    options: { limit: number; offset: number } = { limit: 20, offset: 0 }
+  ): Promise<ActivitySuccessBody> => {
+    const params = new URLSearchParams({
+      limit: String(options.limit),
+      offset: String(options.offset)
+    })
+    const url = `${MARKETPLACE_SERVER_URL}/activity?${params.toString()}`
     const response = await signedFetch(url, {
       method: 'GET',
       identity,
+      metadata: { signer: API_SIGNER },
       headers: { 'Content-Type': 'application/json' }
     })
 
-    if (!response.ok) {
-      throw new Error('Could not fetch activity')
-    }
+    const json = (await response.json().catch(() => null)) as ActivityResponseBody | null
 
-    const json = (await response.json()) as ActivityResponse
-    if (json.ok) {
-      return json.data
+    if (!response.ok) {
+      throw new Error(json && isErrorBody(json) && json.message ? json.message : 'Could not fetch activity')
     }
-    throw new Error(json.message ?? 'Could not fetch activity')
+    if (!json || isErrorBody(json)) {
+      throw new Error(json && isErrorBody(json) && json.message ? json.message : 'Could not fetch activity')
+    }
+    return json
   }
 }
 

--- a/webapp/src/modules/vendor/decentraland/activity/index.ts
+++ b/webapp/src/modules/vendor/decentraland/activity/index.ts
@@ -1,0 +1,1 @@
+export * from './api'


### PR DESCRIPTION
## Changes

- `ActivityPage` now fetches the user's activity from `GET /v1/activity` (marketplace-server) on mount via signed-fetch, in addition to the existing localStorage-backed transactions.
- New `activity` redux module (`actions`, `reducer`, `sagas`, `selectors`, `types`) plus `vendor/decentraland/activity` API client.
- `getMergedActivity` selector merges local txs with server `ActivityEvent[]`, deduping by `txHash` and preferring the local entry (preserves pending state and signing-time order). Result sorted DESC by timestamp.
- New `ActivityEventItem` component renders the seven server-side event types reusing `AssetProvider`, `AssetImage`, `Mana`, `Profile`, `formatDistanceToNow` and existing `TransactionDetail` CSS.
- Loading skeleton on first load; inline warning banner if the server call fails (page still renders local txs — never blocks on server error).
- New i18n keys under `activity_page.event.*`.

Depends on: marketplace-server PR adding `GET /v1/activity`.

## Test plan

- [ ] `npm test` passes (8 new tests under `modules/activity`; full suite stays green — 1747 tests)
- [ ] Local against prod read DB: page loads with full historical activity for a known active address
- [ ] Disconnect/stop the server mid-session: page still renders local txs with a small warning banner instead of blocking
- [ ] Initiate a buy from another tab → local pending tx appears at the top; after confirmation it persists (dedup prefers local)
