### PR TITLE
feat: show specific toast when credits name route fetch fails

### DIFF
--- a/webapp/src/modules/ens/sagas.spec.ts
+++ b/webapp/src/modules/ens/sagas.spec.ts
@@ -9,7 +9,9 @@ import { CreditsClient } from 'decentraland-dapps/dist/modules/credits/CreditsCl
 import { getCredits } from 'decentraland-dapps/dist/modules/credits/selectors'
 import { CreditsResponse } from 'decentraland-dapps/dist/modules/credits/types'
 import { closeModal } from 'decentraland-dapps/dist/modules/modal/actions'
+import { showToast } from 'decentraland-dapps/dist/modules/toast/actions'
 import { waitForTx } from 'decentraland-dapps/dist/modules/transaction/utils'
+import { t } from 'decentraland-dapps/dist/modules/translation'
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { sendTransaction } from 'decentraland-dapps/dist/modules/wallet/utils'
 import { Route, AxelarProvider } from 'decentraland-transactions/crossChain'
@@ -21,6 +23,7 @@ import { DCLRegistrar__factory } from '../../contracts/factories'
 import { DCLController__factory } from '../../contracts/factories/DCLController__factory'
 import { pollSquidRouteStatus, SquidStatusResponse, SquidTransactionStatus } from '../../lib/squid'
 import { getCurrentIdentity } from '../identity/selectors'
+import { getClaimNameWithCreditsRouteUnavailableToast } from '../toast/toasts'
 import { getWallet } from '../wallet/selectors'
 import {
   CLAIM_NAME_REQUEST,
@@ -413,8 +416,9 @@ describe('ENS Saga', () => {
         mockIdentity = {} as AuthIdentity
       })
 
-      it('should put a failure action with the error message', () => {
+      it('should show a route-unavailable toast, put a failure action with the route-unavailable message, and close the modal', () => {
         const clientError = new Error('Server error: Something went wrong')
+        const routeUnavailableMessage = t('toast.claim_name_with_credits_route_unavailable.body')
 
         return expectSaga(ensSaga)
           .provide([
@@ -426,7 +430,9 @@ describe('ENS Saga', () => {
               Promise.reject(clientError)
             ]
           ])
-          .put(claimNameWithCreditsFailure(mockName, clientError.message))
+          .put(showToast(getClaimNameWithCreditsRouteUnavailableToast()))
+          .put(claimNameWithCreditsFailure(mockName, routeUnavailableMessage))
+          .put(closeModal('BuyWithCryptoModal'))
           .dispatch(claimNameWithCreditsRequest(mockName))
           .silentRun()
       })

--- a/webapp/src/modules/ens/sagas.ts
+++ b/webapp/src/modules/ens/sagas.ts
@@ -8,6 +8,7 @@ import { CreditsClient } from 'decentraland-dapps/dist/modules/credits/CreditsCl
 import { getCredits } from 'decentraland-dapps/dist/modules/credits/selectors'
 import { CreditsNameRouteResponse, CreditsResponse } from 'decentraland-dapps/dist/modules/credits/types'
 import { closeModal } from 'decentraland-dapps/dist/modules/modal/actions'
+import { showToast } from 'decentraland-dapps/dist/modules/toast/actions'
 import { TRANSACTION_ACTION_FLAG } from 'decentraland-dapps/dist/modules/transaction/types'
 import { waitForTx } from 'decentraland-dapps/dist/modules/transaction/utils'
 import { t } from 'decentraland-dapps/dist/modules/translation'
@@ -22,6 +23,7 @@ import { DCLRegistrar__factory } from '../../contracts/factories/DCLRegistrar__f
 import { isErrorWithMessage } from '../../lib/error'
 import { pollSquidRouteStatus, SquidStatusResponse } from '../../lib/squid'
 import { getCurrentIdentity } from '../identity/selectors'
+import { getClaimNameWithCreditsRouteUnavailableToast } from '../toast/toasts'
 import { getWallet } from '../wallet/selectors'
 import {
   CLAIM_NAME_REQUEST,
@@ -201,7 +203,17 @@ export function* ensSaga() {
 
       const creditsServerUrl = config.get('CREDITS_SERVER_URL')
       const creditsClient = new CreditsClient(creditsServerUrl, { identity })
-      const routeData: CreditsNameRouteResponse = yield call([creditsClient, 'fetchCreditsNameRoute'], name, ChainId.MATIC_MAINNET)
+      let routeData: CreditsNameRouteResponse
+      try {
+        routeData = (yield call([creditsClient, 'fetchCreditsNameRoute'], name, ChainId.MATIC_MAINNET)) as CreditsNameRouteResponse
+      } catch (routeError) {
+        captureException(routeError, { tags: { saga: 'handleClaimNameWithCreditsRequest', phase: 'fetch-route' } })
+        const routeUnavailableMessage = t('toast.claim_name_with_credits_route_unavailable.body')
+        yield put(showToast(getClaimNameWithCreditsRouteUnavailableToast()))
+        yield put(claimNameWithCreditsFailure(name, routeUnavailableMessage))
+        yield put(closeModal('BuyWithCryptoModal'))
+        return
+      }
 
       // Use CreditsService to handle the transaction
       const creditsService = new CreditsService()

--- a/webapp/src/modules/toast/toasts.tsx
+++ b/webapp/src/modules/toast/toasts.tsx
@@ -131,6 +131,17 @@ export function getExecuteOrderFailureToast(): Omit<Toast, 'id'> {
   }
 }
 
+export function getClaimNameWithCreditsRouteUnavailableToast(): Omit<Toast, 'id'> {
+  return {
+    type: ToastType.ERROR,
+    title: t('toast.claim_name_with_credits_route_unavailable.title'),
+    body: <p>{t('toast.claim_name_with_credits_route_unavailable.body')}</p>,
+    icon: <Icon size="big" name="exclamation circle" />,
+    closable: true,
+    timeout: 15000
+  }
+}
+
 export function getFetchAssetsFailureToast(error: string): Omit<Toast, 'id'> {
   return {
     type: ToastType.ERROR,

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -1237,6 +1237,10 @@
       "body": "Build your personal space in the metaverse.",
       "cta": "View my worlds"
     },
+    "claim_name_with_credits_route_unavailable": {
+      "title": "Service temporarily unavailable",
+      "body": "This feature is not available at the moment. Please try again later."
+    },
     "cross_chain_tx": {
       "body": "The transaction can take up to <highlight>3 minutes</highlight> to be processed.<br></br>You can also track its progress in the links below:",
       "view_transaction": "View transaction"

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -1219,6 +1219,10 @@
       "body": "Construí tu espacio personal en el metaverso.",
       "cta": "Ver mis worlds"
     },
+    "claim_name_with_credits_route_unavailable": {
+      "title": "Servicio temporalmente no disponible",
+      "body": "Esta función no está disponible en este momento. Por favor, inténtalo de nuevo más tarde."
+    },
     "cross_chain_tx": {
       "body": "La transacción puede tardar hasta <highlight>3 miuntos</highlight> para ser procesada.<br></br>Puedes seguir su progreso en los siguientes enlaces:",
       "view_transaction": "Ver transacción"

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -1222,6 +1222,10 @@
       "body": "在虚拟宇宙中建立您的个人空间。",
       "cta": "查看我的世界"
     },
+    "claim_name_with_credits_route_unavailable": {
+      "title": "服务暂时不可用",
+      "body": "此功能目前不可用。请稍后再试。"
+    },
     "cross_chain_tx": {
       "body": "处理该交易最多可能需要 <highlight>3 分钟</highlight>。<br></br>您还可以在以下链接中跟踪其进度：",
       "view_transaction": "查看交易"


### PR DESCRIPTION
## Changes

- When `fetchCreditsNameRoute` (the backend call that resolves the cross-chain Axelar/Squid route used to buy a Decentraland NAME with Credits) fails, the saga now dispatches a dedicated user-facing toast instead of letting the failure surface as the generic "something went wrong" message.
- The toast wording is intentionally generic — no blockchain jargon — so it reads as a normal service outage from the user's perspective: "Service temporarily unavailable / This feature is not available at the moment. Please try again later."
- Translations added in `en`, `es`, `zh`.
- The route-fetch failure path also closes `BuyWithCryptoModal` so the toast is the single source of feedback.
- Existing setup/polling failure paths are unchanged.

## Files

- `webapp/src/modules/ens/sagas.ts` — wraps `fetchCreditsNameRoute` in an inner try/catch; dispatches `showToast` + `claimNameWithCreditsFailure` + `closeModal`, then early-returns. Outer catch still covers wallet/identity/setup errors.
- `webapp/src/modules/toast/toasts.tsx` — new `getClaimNameWithCreditsRouteUnavailableToast` (timeout 15s, closable, ERROR style).
- `webapp/src/modules/translation/locales/{en,es,zh}.json` — new `toast.claim_name_with_credits_route_unavailable.{title,body}` keys.
- `webapp/src/modules/ens/sagas.spec.ts` — updates the existing "credits client fails" test to assert the new toast, failure message, and modal close.

## Test plan

- [x] `npx jest src/modules/ens/sagas.spec.ts` — all 15 tests pass, including the updated assertion.
- [x] `npm run build` — passes.
- [x] Manually triggered the path locally with a wallet that has no real credits server-side and confirmed the new toast renders with the expected copy.