### PR TITLE
feat: handle EstateRegistry getFingerprintV2 upgrade in marketplace UI

### DIFF
--- a/indexer/abis/EstateRegistry.json
+++ b/indexer/abis/EstateRegistry.json
@@ -1091,6 +1091,25 @@
         {
           "name": "estateId",
           "type": "uint256"
+        }
+      ],
+      "name": "getFingerprintV2",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "estateId",
+          "type": "uint256"
         },
         {
           "name": "fingerprint",

--- a/webapp/src/components/AssetPage/BuyNFTBox/BuyNFTBox.tsx
+++ b/webapp/src/components/AssetPage/BuyNFTBox/BuyNFTBox.tsx
@@ -5,11 +5,13 @@ import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Button, Icon } from 'decentraland-ui'
 import clock from '../../../images/clock.png'
 import { getExpirationDateLabel } from '../../../lib/date'
+import { isEstateListingAffectedByUpgrade } from '../../../lib/estateUpgrade'
 import { getIsLegacyOrderExpired, getIsOrderExpired, isLegacyOrder } from '../../../lib/orders'
 import { AssetType } from '../../../modules/asset/types'
 import { useGetCurrentOrder } from '../../../modules/order/hooks'
 import { locations } from '../../../modules/routing/locations'
 import BidButton from '../../BidButton'
+import EstateUpgradeWarning from '../../EstateUpgradeWarning'
 import PriceComponent from '../PriceComponent'
 import { BuyNFTButtons } from '../SaleActionBox/BuyNFTButtons'
 import { Props } from './BuyNFTBox.types'
@@ -31,6 +33,7 @@ const BuyNFTBox = ({ nft, bids, address, wallet, onFetchBids }: Props) => {
         : order.expiresAt * 1000 // in s
     )
     const isOrderExpired = getIsOrderExpired(order.expiresAt)
+    const isEstateListingBroken = isEstateListingAffectedByUpgrade(nft)
 
     const handleUseCredits = (value: boolean) => {
       setUseCredits(value)
@@ -38,6 +41,7 @@ const BuyNFTBox = ({ nft, bids, address, wallet, onFetchBids }: Props) => {
 
     return (
       <div className={`${styles.containerColumn} ${styles.fullWidth}`}>
+        <EstateUpgradeWarning nft={nft} isOwnListing={!!isOwner} />
         <div className={styles.informationContainer}>
           <div className={styles.columnListing}>
             <span className={styles.informationTitle}>{t('best_buying_option.minting.price').toUpperCase()}</span>
@@ -86,7 +90,7 @@ const BuyNFTBox = ({ nft, bids, address, wallet, onFetchBids }: Props) => {
               </Button>
             )}
           </>
-        ) : !isOrderExpired ? (
+        ) : !isOrderExpired && !isEstateListingBroken ? (
           <BuyNFTButtons
             asset={nft}
             assetType={AssetType.NFT}
@@ -95,7 +99,7 @@ const BuyNFTBox = ({ nft, bids, address, wallet, onFetchBids }: Props) => {
             onUseCredits={handleUseCredits}
           />
         ) : null}
-        {!isOwner && <BidButton asset={nft} alreadyBid={alreadyBid} />}
+        {!isOwner && !isEstateListingBroken && <BidButton asset={nft} alreadyBid={alreadyBid} />}
         {!isOrderExpired ? (
           <span className={styles.expiresAt}>
             <img src={clock} alt="clock" className={styles.mintingIcon} />

--- a/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
+++ b/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
@@ -8,6 +8,7 @@ import { isMobile } from 'decentraland-dapps/dist/lib/utils'
 import { T, t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Button, Popup } from 'decentraland-ui'
 import { builderUrl } from '../../../lib/environment'
+import { isEstateListingAffectedByUpgrade } from '../../../lib/estateUpgrade'
 import { formatWeiMANA } from '../../../lib/mana'
 import { isOwnedBy } from '../../../modules/asset/utils'
 import { isPartOfEstate } from '../../../modules/nft/utils'
@@ -52,6 +53,7 @@ const SaleRentActionBox = ({
   const isRentalOpen = isRentalListingOpen(rental)
   const isOwner = isOwnedBy(nft, wallet, rental ? rental : undefined)
   const isTenant = rental && wallet && addressEquals(rental.tenant ?? undefined, wallet.address)
+  const isEstateListingBroken = isEstateListingAffectedByUpgrade(nft)
 
   const [selectedRentalPeriodIndex, setSelectedRentalPeriodIndex] = useState<number | undefined>(undefined)
   const [view, setView] = useState(!!order || !isRentalOpen ? View.SALE : View.RENT)
@@ -232,8 +234,8 @@ const SaleRentActionBox = ({
                   </Button>
                 ) : null}
                 <div className={styles.saleButtons}>
-                  {order ? <BuyWithCryptoButton asset={nft} onClick={onBuyWithCrypto} /> : null}
-                  {canBid ? (
+                  {order && !isEstateListingBroken ? <BuyWithCryptoButton asset={nft} onClick={onBuyWithCrypto} /> : null}
+                  {canBid && !isEstateListingBroken ? (
                     <Popup
                       content={t('asset_page.sales_rent_action_box.parcel_belongs_to_estate_bid')}
                       position="top center"

--- a/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
+++ b/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
@@ -23,6 +23,7 @@ import { locations } from '../../../modules/routing/locations'
 import { VendorFactory } from '../../../modules/vendor'
 import { addressEquals, formatBalance } from '../../../modules/wallet/utils'
 import BidButton from '../../BidButton'
+import EstateUpgradeWarning from '../../EstateUpgradeWarning'
 import { LinkedProfile } from '../../LinkedProfile'
 import { Mana } from '../../Mana'
 import { ManaToFiat } from '../../ManaToFiat'
@@ -95,6 +96,7 @@ const SaleRentActionBox = ({
 
   return (
     <div className={styles.main}>
+      <EstateUpgradeWarning nft={nft} isOwnListing={isOwner} />
       {isRentalOpen && maxPriceOfPeriods ? (
         <div className={styles.viewSelector}>
           <button

--- a/webapp/src/components/Bid/Bid.tsx
+++ b/webapp/src/components/Bid/Bid.tsx
@@ -9,7 +9,7 @@ import { Loader, Stats, Button } from 'decentraland-ui'
 import { formatDistanceToNow } from '../../lib/date'
 import { formatWeiMANA } from '../../lib/mana'
 import { AssetType } from '../../modules/asset/types'
-import { getAssetName } from '../../modules/asset/utils'
+import { getAssetName, isNFT } from '../../modules/asset/utils'
 import { getAcceptBidStatus, getError } from '../../modules/bid/selectors'
 import { getAcceptBidAuthorizationOptions, isBidTrade } from '../../modules/bid/utils'
 import { useERC721ContractName } from '../../modules/contract/hooks'
@@ -24,7 +24,6 @@ import { Mana } from '../Mana'
 import { AcceptButton } from './AcceptButton'
 import { WarningMessage } from './WarningMessage'
 import { Props } from './Bid.types'
-import { isNFT } from '../../modules/asset/utils'
 import './Bid.css'
 
 const Bid = (props: Props) => {
@@ -141,13 +140,13 @@ const Bid = (props: Props) => {
             ) : null}
           </div>
         </div>
-        {isBidder ? (
-          <AssetProvider type={assetType} contractAddress={bid.contractAddress} tokenId={tokenId}>
-            {asset => <WarningMessage asset={asset} bid={bid} />}
-          </AssetProvider>
-        ) : null}
         <AssetProvider type={assetType} contractAddress={bid.contractAddress} tokenId={tokenId}>
-          {asset => (asset && isNFT(asset) ? <EstateUpgradeWarning nft={asset} isOwnListing={isBidder} /> : null)}
+          {asset => (
+            <>
+              {isBidder ? <WarningMessage asset={asset} bid={bid} /> : null}
+              {asset && isNFT(asset) ? <EstateUpgradeWarning nft={asset} isOwnListing={isBidder} /> : null}
+            </>
+          )}
         </AssetProvider>
       </div>
       {showConfirmationModal ? (

--- a/webapp/src/components/Bid/Bid.tsx
+++ b/webapp/src/components/Bid/Bid.tsx
@@ -18,11 +18,13 @@ import { addressEquals } from '../../modules/wallet/utils'
 import { AssetImage } from '../AssetImage'
 import { AssetProvider } from '../AssetProvider'
 import { ConfirmInputValueModal } from '../ConfirmInputValueModal'
+import EstateUpgradeWarning from '../EstateUpgradeWarning'
 import { LinkedProfile } from '../LinkedProfile'
 import { Mana } from '../Mana'
 import { AcceptButton } from './AcceptButton'
 import { WarningMessage } from './WarningMessage'
 import { Props } from './Bid.types'
+import { isNFT } from '../../modules/asset/utils'
 import './Bid.css'
 
 const Bid = (props: Props) => {
@@ -144,6 +146,9 @@ const Bid = (props: Props) => {
             {asset => <WarningMessage asset={asset} bid={bid} />}
           </AssetProvider>
         ) : null}
+        <AssetProvider type={assetType} contractAddress={bid.contractAddress} tokenId={tokenId}>
+          {asset => (asset && isNFT(asset) ? <EstateUpgradeWarning nft={asset} isOwnListing={isBidder} /> : null)}
+        </AssetProvider>
       </div>
       {showConfirmationModal ? (
         <AssetProvider type={assetType} contractAddress={bid.contractAddress} tokenId={tokenId}>

--- a/webapp/src/components/EstateUpgradeWarning/EstateUpgradeWarning.module.css
+++ b/webapp/src/components/EstateUpgradeWarning/EstateUpgradeWarning.module.css
@@ -1,0 +1,43 @@
+.warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  background: rgba(255, 152, 0, 0.12);
+  border: 1px solid rgba(255, 152, 0, 0.45);
+  border-radius: 8px;
+  color: #ffb84d;
+  font-size: 13px;
+  line-height: 1.4;
+  padding: 10px 12px;
+}
+
+.banner {
+  width: 100%;
+  margin: 8px 0;
+}
+
+.inline {
+  display: inline-flex;
+  font-size: 12px;
+  padding: 6px 10px;
+}
+
+.icon {
+  flex-shrink: 0;
+  margin: 1px 0 0 0 !important;
+  color: #ff9800;
+}
+
+.message {
+  flex: 1;
+}
+
+.warning a {
+  color: #ffb84d;
+  text-decoration: underline;
+  font-weight: 600;
+}
+
+.warning a:hover {
+  color: #ffd285;
+}

--- a/webapp/src/components/EstateUpgradeWarning/EstateUpgradeWarning.module.css
+++ b/webapp/src/components/EstateUpgradeWarning/EstateUpgradeWarning.module.css
@@ -9,17 +9,8 @@
   font-size: 13px;
   line-height: 1.4;
   padding: 10px 12px;
-}
-
-.banner {
   width: 100%;
   margin: 8px 0;
-}
-
-.inline {
-  display: inline-flex;
-  font-size: 12px;
-  padding: 6px 10px;
 }
 
 .icon {
@@ -30,14 +21,4 @@
 
 .message {
   flex: 1;
-}
-
-.warning a {
-  color: #ffb84d;
-  text-decoration: underline;
-  font-weight: 600;
-}
-
-.warning a:hover {
-  color: #ffd285;
 }

--- a/webapp/src/components/EstateUpgradeWarning/EstateUpgradeWarning.tsx
+++ b/webapp/src/components/EstateUpgradeWarning/EstateUpgradeWarning.tsx
@@ -6,24 +6,21 @@ import { isEstateListingAffectedByUpgrade } from '../../lib/estateUpgrade'
 import { NFT } from '../../modules/nft/types'
 import styles from './EstateUpgradeWarning.module.css'
 
-type Variant = 'inline' | 'banner'
-
 type Props = {
   nft: NFT | null | undefined
-  variant?: Variant
   className?: string
   // When true, callers are showing this on the lister's own listing — the wording
   // uses "you" instead of "the seller".
   isOwnListing?: boolean
 }
 
-const EstateUpgradeWarning = ({ nft, variant = 'banner', className, isOwnListing = false }: Props) => {
+const EstateUpgradeWarning = ({ nft, className, isOwnListing = false }: Props) => {
   if (!isEstateListingAffectedByUpgrade(nft)) return null
 
   const messageKey = isOwnListing ? 'estate_upgrade_warning.owner' : 'estate_upgrade_warning.visitor'
 
   return (
-    <div className={classNames(styles.warning, styles[variant], className)} role="alert">
+    <div className={classNames(styles.warning, className)} role="alert">
       <Icon name="exclamation triangle" className={styles.icon} />
       <span className={styles.message}>{t(messageKey)}</span>
     </div>

--- a/webapp/src/components/EstateUpgradeWarning/EstateUpgradeWarning.tsx
+++ b/webapp/src/components/EstateUpgradeWarning/EstateUpgradeWarning.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import classNames from 'classnames'
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
+import { Icon } from 'decentraland-ui'
+import { isEstateListingAffectedByUpgrade } from '../../lib/estateUpgrade'
+import { NFT } from '../../modules/nft/types'
+import styles from './EstateUpgradeWarning.module.css'
+
+type Variant = 'inline' | 'banner'
+
+type Props = {
+  nft: NFT | null | undefined
+  variant?: Variant
+  className?: string
+  // When true, callers are showing this on the lister's own listing — the wording
+  // uses "you" instead of "the seller".
+  isOwnListing?: boolean
+}
+
+const EstateUpgradeWarning = ({ nft, variant = 'banner', className, isOwnListing = false }: Props) => {
+  if (!isEstateListingAffectedByUpgrade(nft)) return null
+
+  const messageKey = isOwnListing ? 'estate_upgrade_warning.owner' : 'estate_upgrade_warning.visitor'
+
+  return (
+    <div className={classNames(styles.warning, styles[variant], className)} role="alert">
+      <Icon name="exclamation triangle" className={styles.icon} />
+      <span className={styles.message}>{t(messageKey)}</span>
+    </div>
+  )
+}
+
+export default React.memo(EstateUpgradeWarning)

--- a/webapp/src/components/EstateUpgradeWarning/index.ts
+++ b/webapp/src/components/EstateUpgradeWarning/index.ts
@@ -1,0 +1,1 @@
+export { default } from './EstateUpgradeWarning'

--- a/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
+++ b/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
@@ -90,7 +90,7 @@ export const ManageAssetPage = (props: Props) => {
                           <Column className={styles.content}>
                             {asset && !isLoading ? (
                               <>
-                                <EstateUpgradeWarning nft={asset as NFT} isOwnListing />
+                                <EstateUpgradeWarning nft={asset} isOwnListing />
                                 <section className={styles.assetDescription}>
                                   <div className={styles.assetDescriptionHeader}>
                                     <h1 className={styles.assetDescriptionTitle}>{asset?.name}</h1>
@@ -139,7 +139,7 @@ export const ManageAssetPage = (props: Props) => {
                             ) : null}
                             {asset && !isLoading ? (
                               <>
-                                <EstateUpgradeWarning nft={asset as NFT} isOwnListing />
+                                <EstateUpgradeWarning nft={asset} isOwnListing />
                                 <section className={styles.assetDescription}>
                                   <div className={styles.assetDescriptionHeader}>
                                     <h1 className={styles.assetDescriptionTitle}>{asset?.name}</h1>

--- a/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
+++ b/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
@@ -12,6 +12,7 @@ import { locations } from '../../modules/routing/locations'
 import { ErrorBoundary } from '../AssetPage/ErrorBoundary'
 import { AssetProvider } from '../AssetProvider'
 import { DetailsBox } from '../DetailsBox'
+import EstateUpgradeWarning from '../EstateUpgradeWarning'
 import { LandLockedPopup } from '../LandLockedPopup'
 import { Column } from '../Layout/Column'
 import { NavigationTab } from '../Navigation/Navigation.types'
@@ -89,6 +90,7 @@ export const ManageAssetPage = (props: Props) => {
                           <Column className={styles.content}>
                             {asset && !isLoading ? (
                               <>
+                                <EstateUpgradeWarning nft={asset as NFT} isOwnListing />
                                 <section className={styles.assetDescription}>
                                   <div className={styles.assetDescriptionHeader}>
                                     <h1 className={styles.assetDescriptionTitle}>{asset?.name}</h1>
@@ -137,6 +139,7 @@ export const ManageAssetPage = (props: Props) => {
                             ) : null}
                             {asset && !isLoading ? (
                               <>
+                                <EstateUpgradeWarning nft={asset as NFT} isOwnListing />
                                 <section className={styles.assetDescription}>
                                   <div className={styles.assetDescriptionHeader}>
                                     <h1 className={styles.assetDescriptionTitle}>{asset?.name}</h1>

--- a/webapp/src/components/OnSaleOrRentList/OnSaleListElement/OnSaleListElement.tsx
+++ b/webapp/src/components/OnSaleOrRentList/OnSaleListElement/OnSaleListElement.tsx
@@ -33,7 +33,7 @@ const OnSaleListElement = ({ nft, item, order, isAuthorized, authorization, onRe
             {formatWeiMANA(item?.price || order!.price)}
           </Mana>
         </div>
-        {nft && isNFT(nft) && isAffectedByEstateUpgrade ? <EstateUpgradeWarning nft={nft} isOwnListing /> : null}
+        {isAffectedByEstateUpgrade ? <EstateUpgradeWarning nft={nft} isOwnListing /> : null}
       </Mobile>
       <NotMobile>
         <Table.Row>
@@ -56,16 +56,12 @@ const OnSaleListElement = ({ nft, item, order, isAuthorized, authorization, onRe
                   on="hover"
                 />
               ) : null}
-              {nft && isNFT(nft) && isAffectedByEstateUpgrade ? (
+              {isAffectedByEstateUpgrade && nft ? (
                 <div className="warningExpiration">
                   <Icon name="exclamation triangle" className={'warningExpiration'} />{' '}
-                  {nft ? (
-                    <Link to={locations.sell(nft.contractAddress, nft.tokenId, cancelOrSellOptions)}>
-                      {t('estate_upgrade_warning.update_listing')}
-                    </Link>
-                  ) : (
-                    t('global.action_required')
-                  )}
+                  <Link to={locations.sell(nft.contractAddress, nft.tokenId, cancelOrSellOptions)}>
+                    {t('estate_upgrade_warning.update_listing')}
+                  </Link>
                 </div>
               ) : null}
               {nft && isNFT(nft) && nft?.owner !== wallet?.address && (

--- a/webapp/src/components/OnSaleOrRentList/OnSaleListElement/OnSaleListElement.tsx
+++ b/webapp/src/components/OnSaleOrRentList/OnSaleListElement/OnSaleListElement.tsx
@@ -2,11 +2,13 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Badge, Button, Icon, InfoTooltip, Mobile, NotMobile, Popup, Table } from 'decentraland-ui'
+import { isEstateListingAffectedByUpgrade } from '../../../lib/estateUpgrade'
 import { formatWeiMANA } from '../../../lib/mana'
 import { getIsLegacyOrderExpired, isLegacyOrder } from '../../../lib/orders'
 import { isNFT } from '../../../modules/asset/utils'
 import { locations } from '../../../modules/routing/locations'
 import { LEGACY_MARKETPLACE_MAINNET_CONTRACT, Section } from '../../../modules/vendor/decentraland'
+import EstateUpgradeWarning from '../../EstateUpgradeWarning'
 import { Mana } from '../../Mana'
 import AssetCell from '../AssetCell'
 import { Props } from './OnSaleListElement.types'
@@ -14,6 +16,7 @@ import './OnSaleListElement.css'
 
 const OnSaleListElement = ({ nft, item, order, isAuthorized, authorization, onRevoke, wallet }: Props) => {
   const category = item?.category || nft!.category
+  const isAffectedByEstateUpgrade = !!nft && isNFT(nft) && isEstateListingAffectedByUpgrade(nft)
 
   const cancelOrSellOptions = {
     redirectTo: locations.currentAccount({
@@ -30,6 +33,7 @@ const OnSaleListElement = ({ nft, item, order, isAuthorized, authorization, onRe
             {formatWeiMANA(item?.price || order!.price)}
           </Mana>
         </div>
+        {nft && isNFT(nft) && isAffectedByEstateUpgrade ? <EstateUpgradeWarning nft={nft} isOwnListing /> : null}
       </Mobile>
       <NotMobile>
         <Table.Row>
@@ -51,6 +55,18 @@ const OnSaleListElement = ({ nft, item, order, isAuthorized, authorization, onRe
                   }
                   on="hover"
                 />
+              ) : null}
+              {nft && isNFT(nft) && isAffectedByEstateUpgrade ? (
+                <div className="warningExpiration">
+                  <Icon name="exclamation triangle" className={'warningExpiration'} />{' '}
+                  {nft ? (
+                    <Link to={locations.sell(nft.contractAddress, nft.tokenId, cancelOrSellOptions)}>
+                      {t('estate_upgrade_warning.update_listing')}
+                    </Link>
+                  ) : (
+                    t('global.action_required')
+                  )}
+                </div>
               ) : null}
               {nft && isNFT(nft) && nft?.owner !== wallet?.address && (
                 <div className="needsAttentionBadge">

--- a/webapp/src/contracts/EstateRegistry.json
+++ b/webapp/src/contracts/EstateRegistry.json
@@ -185,6 +185,25 @@
   },
   {
     "constant": true,
+    "inputs": [
+      {
+        "name": "estateId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getFingerprintV2",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
     "inputs": [],
     "name": "totalSupply",
     "outputs": [

--- a/webapp/src/contracts/EstateRegistry.ts
+++ b/webapp/src/contracts/EstateRegistry.ts
@@ -39,6 +39,7 @@ export interface EstateRegistryInterface extends utils.Interface {
     "landIdEstate(uint256)": FunctionFragment;
     "onERC721Received(address,address,uint256,bytes)": FunctionFragment;
     "getFingerprint(uint256)": FunctionFragment;
+    "getFingerprintV2(uint256)": FunctionFragment;
     "totalSupply()": FunctionFragment;
     "setLandUpdateOperator(uint256,uint256,address)": FunctionFragment;
     "transferFrom(address,address,uint256)": FunctionFragment;
@@ -95,6 +96,7 @@ export interface EstateRegistryInterface extends utils.Interface {
       | "landIdEstate"
       | "onERC721Received"
       | "getFingerprint"
+      | "getFingerprintV2"
       | "totalSupply"
       | "setLandUpdateOperator"
       | "transferFrom"
@@ -180,6 +182,10 @@ export interface EstateRegistryInterface extends utils.Interface {
   ): string;
   encodeFunctionData(
     functionFragment: "getFingerprint",
+    values: [BigNumberish]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "getFingerprintV2",
     values: [BigNumberish]
   ): string;
   encodeFunctionData(
@@ -368,6 +374,10 @@ export interface EstateRegistryInterface extends utils.Interface {
   ): Result;
   decodeFunctionResult(
     functionFragment: "getFingerprint",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "getFingerprintV2",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -759,6 +769,11 @@ export interface EstateRegistry extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string] & { result: string }>;
 
+    getFingerprintV2(
+      estateId: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<[string]>;
+
     totalSupply(overrides?: CallOverrides): Promise<[BigNumber]>;
 
     setLandUpdateOperator(
@@ -1046,6 +1061,11 @@ export interface EstateRegistry extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string>;
 
+  getFingerprintV2(
+    estateId: BigNumberish,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
   totalSupply(overrides?: CallOverrides): Promise<BigNumber>;
 
   setLandUpdateOperator(
@@ -1318,6 +1338,11 @@ export interface EstateRegistry extends BaseContract {
     ): Promise<string>;
 
     getFingerprint(
+      estateId: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    getFingerprintV2(
       estateId: BigNumberish,
       overrides?: CallOverrides
     ): Promise<string>;
@@ -1723,6 +1748,11 @@ export interface EstateRegistry extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
+    getFingerprintV2(
+      estateId: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
     totalSupply(overrides?: CallOverrides): Promise<BigNumber>;
 
     setLandUpdateOperator(
@@ -2007,6 +2037,11 @@ export interface EstateRegistry extends BaseContract {
     ): Promise<PopulatedTransaction>;
 
     getFingerprint(
+      estateId: BigNumberish,
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
+    getFingerprintV2(
       estateId: BigNumberish,
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;

--- a/webapp/src/contracts/factories/EstateRegistry__factory.ts
+++ b/webapp/src/contracts/factories/EstateRegistry__factory.ts
@@ -195,6 +195,25 @@ const _abi = [
   },
   {
     constant: true,
+    inputs: [
+      {
+        name: "estateId",
+        type: "uint256",
+      },
+    ],
+    name: "getFingerprintV2",
+    outputs: [
+      {
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    payable: false,
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    constant: true,
     inputs: [],
     name: "totalSupply",
     outputs: [

--- a/webapp/src/lib/estateUpgrade.spec.ts
+++ b/webapp/src/lib/estateUpgrade.spec.ts
@@ -1,0 +1,51 @@
+import { NFTCategory } from '@dcl/schemas'
+import { NFT } from '../modules/nft/types'
+import { ESTATE_LR_XOR_SAFE_MAX_SIZE, isEstateListingAffectedByUpgrade } from './estateUpgrade'
+
+function makeEstateNFT(size: number | undefined): NFT {
+  return {
+    category: NFTCategory.ESTATE,
+    data: { estate: size !== undefined ? { size, parcels: [], description: '' } : undefined }
+  } as unknown as NFT
+}
+
+function makeParcelNFT(): NFT {
+  return {
+    category: NFTCategory.PARCEL,
+    data: { parcel: { x: '1', y: '1', description: null } }
+  } as unknown as NFT
+}
+
+describe('isEstateListingAffectedByUpgrade', () => {
+  describe('when the NFT is not an Estate', () => {
+    it('should return false', () => {
+      expect(isEstateListingAffectedByUpgrade(makeParcelNFT())).toBe(false)
+    })
+  })
+
+  describe('when the NFT is an Estate', () => {
+    describe('and the Estate size exceeds the safe threshold', () => {
+      it('should return true', () => {
+        expect(isEstateListingAffectedByUpgrade(makeEstateNFT(ESTATE_LR_XOR_SAFE_MAX_SIZE + 1))).toBe(true)
+      })
+    })
+
+    describe('and the Estate size is at the safe threshold', () => {
+      it('should return false', () => {
+        expect(isEstateListingAffectedByUpgrade(makeEstateNFT(ESTATE_LR_XOR_SAFE_MAX_SIZE))).toBe(false)
+      })
+    })
+
+    describe('and the Estate size is below the safe threshold', () => {
+      it('should return false', () => {
+        expect(isEstateListingAffectedByUpgrade(makeEstateNFT(5))).toBe(false)
+      })
+    })
+
+    describe('and the Estate has no size data', () => {
+      it('should return false', () => {
+        expect(isEstateListingAffectedByUpgrade(makeEstateNFT(undefined))).toBe(false)
+      })
+    })
+  })
+})

--- a/webapp/src/lib/estateUpgrade.ts
+++ b/webapp/src/lib/estateUpgrade.ts
@@ -1,0 +1,25 @@
+import { NFTCategory } from '@dcl/schemas'
+import { NFT } from '../modules/nft/types'
+
+// EstateRegistry getFingerprint vulnerability (LR-XOR) — contract upgrade.
+// Estates with strictly more LANDs than this threshold cannot honor the legacy
+// v1 fingerprint after the upgrade. Their pre-upgrade listings (orders, bids,
+// trades) become non-executable on-chain and must be re-created by the seller.
+export const ESTATE_LR_XOR_SAFE_MAX_SIZE = 18
+
+export function isEstateNFT(nft: NFT | null | undefined): boolean {
+  return !!nft && nft.category === NFTCategory.ESTATE
+}
+
+export function getEstateSize(nft: NFT | null | undefined): number | undefined {
+  if (!isEstateNFT(nft)) return undefined
+  return nft?.data.estate?.size
+}
+
+// True when an Estate listing (order / bid / rental) is non-executable on-chain
+// because the underlying Estate exceeds the size that the post-upgrade
+// EstateRegistry can still verify with the legacy v1 fingerprint.
+export function isEstateListingAffectedByUpgrade(nft: NFT | null | undefined): boolean {
+  const size = getEstateSize(nft)
+  return size !== undefined && size > ESTATE_LR_XOR_SAFE_MAX_SIZE
+}

--- a/webapp/src/lib/estateUpgrade.ts
+++ b/webapp/src/lib/estateUpgrade.ts
@@ -7,11 +7,11 @@ import { NFT } from '../modules/nft/types'
 // trades) become non-executable on-chain and must be re-created by the seller.
 export const ESTATE_LR_XOR_SAFE_MAX_SIZE = 18
 
-export function isEstateNFT(nft: NFT | null | undefined): boolean {
+function isEstateNFT(nft: NFT | null | undefined): boolean {
   return !!nft && nft.category === NFTCategory.ESTATE
 }
 
-export function getEstateSize(nft: NFT | null | undefined): number | undefined {
+function getEstateSize(nft: NFT | null | undefined): number | undefined {
   if (!isEstateNFT(nft)) return undefined
   return nft?.data.estate?.size
 }

--- a/webapp/src/modules/nft/estate/utils.ts
+++ b/webapp/src/modules/nft/estate/utils.ts
@@ -47,19 +47,15 @@ export async function generateFingerprint(estateId: string, parcels: { x: number
     estateTokenIds.push(await contract.encodeTokenId(parcel.x, parcel.y))
   }
 
-  let fingerprint = BigInt(ethers.utils.solidityKeccak256(['string', 'uint256'], ['estateId', estateId]))
+  const encoded = ethers.utils.defaultAbiCoder.encode(['string', 'uint256', 'uint256[]'], ['estateId', estateId, estateTokenIds])
 
-  for (const tokenId of estateTokenIds) {
-    fingerprint ^= BigInt(ethers.utils.solidityKeccak256(['uint256'], [tokenId]))
-  }
-
-  return ethers.utils.hexlify(fingerprint)
+  return ethers.utils.keccak256(encoded)
 }
 
 export async function getFingerprint(estateId: string, estateContract: Contract, chainId: ChainId) {
   const provider = await getNetworkProvider(chainId)
   if (provider) {
     const estateRegistry = EstateRegistry__factory.connect(estateContract.address, new ethers.providers.Web3Provider(provider))
-    return estateRegistry.getFingerprint(estateId)
+    return estateRegistry.getFingerprintV2(estateId)
   }
 }

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -1718,5 +1718,10 @@
   "credits": {
     "value": "1 Credit = 1 MANA in value",
     "offline_message": "Marketplace Credits are currently offline.{br} Please check the #product-status channel at {br} {discord_link} for updates if service does not resume shortly."
+  },
+  "estate_upgrade_warning": {
+    "owner": "This listing is no longer available. You need to recreate it.",
+    "visitor": "This listing is no longer available. The seller needs to recreate it.",
+    "update_listing": "Update listing"
   }
 }

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -1680,5 +1680,10 @@
   "credits": {
     "value": "1 Crédito = 1 MANA en valor",
     "offline_message": "Los Créditos del Marketplace están actualmente desconectados. Por favor, comprueba el\n#product-status canal en {discord_link}\npara actualizaciones si el servicio no se reanuda pronto."
+  },
+  "estate_upgrade_warning": {
+    "owner": "Esta publicación ya no está disponible. Debes volver a crearla.",
+    "visitor": "Esta publicación ya no está disponible. El vendedor debe volver a crearla.",
+    "update_listing": "Actualizar publicación"
   }
 }

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -1684,5 +1684,10 @@
   "credits": {
     "value": "1 积分 = 1 MANA 价值",
     "offline_message": "Marketplace Credits 目前离线。请检查 {discord_link} 的 #product-status 频道以获取更新，如果服务没有很快恢复。"
+  },
+  "estate_upgrade_warning": {
+    "owner": "此挂单已不可用。请重新创建。",
+    "visitor": "此挂单已不可用。卖家需要重新创建。",
+    "update_listing": "更新挂单"
   }
 }


### PR DESCRIPTION
## Summary

  Upgrades the marketplace UI and contract ABI to support the new EstateRegistry `getFingerprintV2` introduced to fix the LR-XOR
  collision vulnerability in the legacy `getFingerprint`.
  
  ### Webapp changes

  - Reads `getFingerprintV2` instead of `getFingerprint` when signing new orders / bids / rentals
  - `generateFingerprint` now uses the v2 algorithm (`keccak256(abi.encode("estateId", estateId, uint256[]))`) so the local
  fingerprint matches what the contract returns
  - New `EstateUpgradeWarning` banner shown on Estate listings affected by the upgrade (size > 18 LANDs) across detail page, bids 
  list, account / on-sale list, and manage page
  - Disables Buy / Bid buttons on broken listings to prevent on-chain reverts

  ### Contract artifacts 

  - Adds `getFingerprintV2` to the typechain typings, ABI JSON, and factory ABI for `EstateRegistry`
  - Adds the same entry to the indexer ABI for consistency
  
  ## Test plan

  - [ ] Estate >18 LANDs with active listing shows the warning banner and disables Buy
  - [ ] Estate <=18 LANDs with active listing shows no banner
  - [ ] Non-Estate NFTs are unaffected
  - [ ] Creating a new order / bid for an Estate signs against `getFingerprintV2`
  - [ ] Accepting a rental reads `getFingerprintV2` and passes it to `acceptListing`
  - [ ] Unit tests in `webapp/src/lib/estateUpgrade.spec.ts` pass