### PR TITLE
feat: pin oddish-action to 914e7c5 to avoid node24 publish regression

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -25,7 +25,9 @@ jobs:
           cache: "npm"
           cache-dependency-path: webapp/package-lock.json
       - name: Set package.json version
-        uses: decentraland/oddish-action@master
+        # Pinned to last stable commit before the node24 runtime bump (oddish PR #4)
+        # which broke npm publish on this repo. Revisit once upstream confirms a fix.
+        uses: decentraland/oddish-action@914e7c5
         with:
           cwd: ./webapp
           deterministic-snapshot: true
@@ -37,7 +39,8 @@ jobs:
           NODE_OPTIONS: "--max_old_space_size=4096"
         run: npm run build
       - name: Publish
-        uses: decentraland/oddish-action@master
+        # Pinned — see comment above.
+        uses: decentraland/oddish-action@914e7c5
         with:
           cwd: ./webapp/dist
           deterministic-snapshot: true


### PR DESCRIPTION
## Summary

`decentraland/oddish-action@master` was bumped to a `node24` runtime in PR #4 (merged 2026-05-20). After that bump, `npm publish` from the marketplace `build-release` workflow started failing with a `404 Not Found - PUT https://registry.npmjs.org/@dcl%2fmarketplace-site` error — the provenance attestation succeeds but the registry PUT is rejected.

This PR temporarily pins the action to `914e7c5` (last stable merge before the node24 bump, from Feb 2025) so post-merge deploys can run again while upstream investigates.

## Test plan

- [ ] Merge this PR
- [ ] Confirm the `build-release` workflow on master goes green and publishes `@dcl/marketplace-site` successfully

## Follow-up

- Report the 404 regression to `decentraland/oddish-action` so the upstream can fix the node24 runtime
- Once upstream is fixed, either re-target `@master` or pin to a known-good SHA post-fix