### PR TITLE
feat: revert oddish-action pin and set provenance explicitly

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -25,11 +25,12 @@ jobs:
           cache: "npm"
           cache-dependency-path: webapp/package-lock.json
       - name: Set package.json version
-        uses: decentraland/oddish-action@914e7c59e93e708152aa703c50196740c0526c1d
+        uses: decentraland/oddish-action@master
         with:
           cwd: ./webapp
           deterministic-snapshot: true
           only-update-versions: true
+          provenance: true
       - name: Install
         run: npm install
       - name: Build
@@ -37,12 +38,13 @@ jobs:
           NODE_OPTIONS: "--max_old_space_size=4096"
         run: npm run build
       - name: Publish
-        uses: decentraland/oddish-action@914e7c59e93e708152aa703c50196740c0526c1d
+        uses: decentraland/oddish-action@master
         with:
           cwd: ./webapp/dist
           deterministic-snapshot: true
           registry-url: "https://registry.npmjs.org"
           access: public
+          provenance: true
           gitlab-token: ${{ secrets.GITLAB_CDN_DEPLOYER_TOKEN }}
           gitlab-pipeline-url: ${{ secrets.GITLAB_CDN_DEPLOYER_URL }}
         env:


### PR DESCRIPTION
## Summary

The pin to `decentraland/oddish-action@914e7c5` introduced in #2629 (and refined to the full SHA in #2631) did **not** fix the publish failure — see run [#26172434756](https://github.com/decentraland/marketplace/actions/runs/26172434756/job/76993554803) where the pinned pre-node24 oddish version still hits the same `404 Not Found - PUT https://registry.npmjs.org/@dcl%2fmarketplace-site` error.

That confirms the root cause is **not** the node24 runtime bump in oddish. The pin was treating a symptom, not the cause. Real cause is upstream — likely on the NPM token / registry side — and will be diagnosed separately.

This PR:

- Reverts the workflow back to `decentraland/oddish-action@master` (the pre-#2629 state).
- Sets `provenance: true` explicitly in both `Set package.json version` and `Publish` steps for clarity (it was relying on the action's default).

The rollback on the oddish side will be handled separately if/when needed.

## Test plan

- [ ] Merge this PR
- [ ] Confirm the `build-release` workflow runs on master. We expect it to **still fail** with the same 404 until the underlying token/registry issue is fixed — but at least we're back to the original config.
- [ ] Track the token/registry investigation in a separate thread with the platform team.