### PR TITLE
ci: disable npm provenance to diagnose 404 publish failure

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -30,7 +30,7 @@ jobs:
           cwd: ./webapp
           deterministic-snapshot: true
           only-update-versions: true
-          provenance: true
+          provenance: false
       - name: Install
         run: npm install
       - name: Build
@@ -44,7 +44,7 @@ jobs:
           deterministic-snapshot: true
           registry-url: "https://registry.npmjs.org"
           access: public
-          provenance: true
+          provenance: false
           gitlab-token: ${{ secrets.GITLAB_CDN_DEPLOYER_TOKEN }}
           gitlab-pipeline-url: ${{ secrets.GITLAB_CDN_DEPLOYER_URL }}
         env:


### PR DESCRIPTION
## Why

The `build-release` workflow keeps failing with a `404 Not Found - PUT https://registry.npmjs.org/@dcl%2fmarketplace-site` on every publish attempt since 2026-05-19 08:52 UTC — the moment after `8.17.0` was successfully released. Symptom is consistent across runs (e.g. [#26172434756](https://github.com/decentraland/marketplace/actions/runs/26172434756) with pinned oddish, [#26173645425](https://github.com/decentraland/marketplace/actions/runs/26173645425) with reverted oddish).

In every failing run the provenance attestation is **signed and published to the Sigstore transparency log successfully**, but the subsequent `PUT` to the registry returns 404.

That points to one of two upstream causes:

1. **Trusted Publishing was enabled** on the `@dcl/marketplace-site` package settings (npmjs.com) — once a trusted publisher is configured, classic-token publishes with provenance can be rejected with a misleading 404
2. The **`NPM_TOKEN`** lost write access (token rotated, expired, or migrated to a granular token without `publish` scope on this package)

This PR sets `provenance: false` to isolate which one it is.

## Expected outcomes

- **Publish succeeds**: confirms it's a provenance / Trusted Publishing issue. Fix is to either configure Trusted Publishing on npmjs.com or use a granular token, then re-enable provenance.
- **Publish still fails with 404**: confirms it's a pure token / permission issue. Fix is to rotate `NPM_TOKEN` with proper publish scope.

## Test plan

- [ ] Merge this PR
- [ ] Trigger build-release (a master push or new release)
- [ ] Inspect the run:
  - If green → flip back to `provenance: true` AFTER configuring Trusted Publishing for this repo+workflow on npmjs.com
  - If still red → escalate to whoever owns `decentralandbot` on npm; verify `NPM_TOKEN` permissions

## Rollback

Once the root cause is fixed, revert this PR (or just set `provenance: true` again in a follow-up).