### PR TITLE
chore: use canonical git+https url in webapp package.json files

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -127,6 +127,6 @@
   "homepage": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/decentraland/marketplace.git"
+    "url": "git+https://github.com/decentraland/marketplace.git"
   }
 }

--- a/webapp/public/package.json
+++ b/webapp/public/package.json
@@ -12,6 +12,6 @@
   "homepage": "",
   "repository": {
     "type": "git",
-    "url": "https://github.com/decentraland/marketplace.git"
+    "url": "git+https://github.com/decentraland/marketplace.git"
   }
 }


### PR DESCRIPTION
The `Build and release` workflow logs show `npm warn publish "repository.url" was normalized to "git+https://..."` on every publish. npm rewrites the URL at publish time and the rewritten form is what ends up in the tarball metadata.

`webapp/package.json` and `webapp/public/package.json` (the latter becomes `webapp/dist/package.json` after the vite build copy) both used the shorter `https://...` form. The root `package.json` already used the canonical `git+https://...` form, so this aligns the webapp files with it.

Not a fix for the current publish 404 — that turned out to be caused by npm invalidating granular access tokens with write access that bypass 2FA (Mini Shai Hulud mitigation). The NPM_TOKEN secret needs to be regenerated as a classic Automation token. This PR is just a cleanup that silences the warning and makes the published metadata match what npm stores anyway.

## Test plan

- [ ] CI passes on this branch
- [ ] After merge, the next `Build and release` run no longer logs `npm warn publish "repository.url" was normalized`