### PR TITLE
feat: use npm Trusted Publishing for marketplace-site

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -21,11 +21,12 @@ jobs:
         working-directory: ./webapp
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # @v4.3.0
-      - name: Use Node.js 24.x
-        # npm Trusted Publishing requires npm CLI >= 11.5.1, which ships with Node 24.x.
+      - name: Use Node.js 22.x
+        # npm Trusted Publishing requires npm CLI >= 11.5.1, which ships with
+        # Node 22.18.0+. Using the 22.x LTS line for a single-major bump from 20.x.
         uses: actions/setup-node@v4.0.1
         with:
-          node-version: 24.x
+          node-version: 22.x
           cache: "npm"
           cache-dependency-path: webapp/package-lock.json
       - name: Set package.json version

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -11,17 +11,21 @@ on:
 jobs:
   build-release:
     permissions:
+      # Required for npm Trusted Publishing — npm exchanges this OIDC token for
+      # publish credentials instead of using a long-lived NPM_TOKEN.
       id-token: write
+      contents: read
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ./webapp
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # @v4.3.0
-      - name: Use Node.js 20.x
+      - name: Use Node.js 24.x
+        # npm Trusted Publishing requires npm CLI >= 11.5.1, which ships with Node 24.x.
         uses: actions/setup-node@v4.0.1
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: "npm"
           cache-dependency-path: webapp/package-lock.json
       - name: Set package.json version
@@ -38,6 +42,9 @@ jobs:
           NODE_OPTIONS: "--max_old_space_size=4096"
         run: npm run build
       - name: Publish
+        # No NODE_AUTH_TOKEN — npm authenticates via OIDC against the Trusted
+        # Publisher configured for @dcl/marketplace-site on npmjs.com. Provenance
+        # is automatic under Trusted Publishing but we keep the flag for clarity.
         uses: decentraland/oddish-action@master
         with:
           cwd: ./webapp/dist
@@ -47,8 +54,6 @@ jobs:
           provenance: true
           gitlab-token: ${{ secrets.GITLAB_CDN_DEPLOYER_TOKEN }}
           gitlab-pipeline-url: ${{ secrets.GITLAB_CDN_DEPLOYER_URL }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Create Sentry release
         if: github.event_name == 'release' && github.event.action == 'created'
         uses: getsentry/action-release@v1

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1442,53 +1442,6 @@
         "pbts": "bin/pbts"
       }
     },
-    "node_modules/@contentful/rich-text-react-renderer": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-16.0.0.tgz",
-      "integrity": "sha512-0jVuTe9f+DvQjNfhta7zYYUwtRBPz01nS2kS1CzGSi/EjAy9CFFQ+M0G1OHAzNNvFyAtDs5/4rndHuVzsedV5g==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@contentful/rich-text-types": "^17.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.6 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@contentful/rich-text-types": {
-      "version": "17.2.5",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.2.5.tgz",
-      "integrity": "sha512-EA5vTfROZePoPmSlqLVd+luL/ev8CjnI20y6vWFVPlLRxQbv4XytXRzatydPE63CqfsPylF7NCn2z8rTLhnWfg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@lingui/core": "^5.4.1",
-        "is-plain-obj": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@contentful/rich-text-types/node_modules/is-plain-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@cosmjs/amino": {
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.4.tgz",
@@ -2151,21 +2104,6 @@
         "@formatjs/fast-memoize": "2.2.7",
         "@formatjs/icu-messageformat-parser": "2.11.4",
         "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@dcl/hooks/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@dcl/schemas": {
@@ -4658,48 +4596,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/@lingui/core": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-5.8.0.tgz",
-      "integrity": "sha512-YHl7ej5jgQqCjvFWVQBWZY46SSROycHDx760KE1iOxp4dpzAAwHeKbXxERz3Tgu+o+aIIY2Pg3G9GLeOGiFaWA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@lingui/message-utils": "5.8.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@lingui/babel-plugin-lingui-macro": "5.8.0",
-        "babel-plugin-macros": "2 || 3"
-      },
-      "peerDependenciesMeta": {
-        "@lingui/babel-plugin-lingui-macro": {
-          "optional": true
-        },
-        "babel-plugin-macros": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@lingui/message-utils": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@lingui/message-utils/-/message-utils-5.8.0.tgz",
-      "integrity": "sha512-w6GtFPnd3QDsRHFvsITcflueeB/lLusB7tmwhXt9Vo3RV1ffRmCraAbVS1+iuRYTDC/Yq35UyweHwMG7Q2nAYw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@messageformat/parser": "^5.0.0",
-        "js-sha256": "^0.10.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.0.tgz",
@@ -4785,17 +4681,6 @@
       "resolved": "https://registry.npmjs.org/@magic-sdk/types/-/types-23.0.0.tgz",
       "integrity": "sha512-NTjgGPJVYxoncSrHtDZLDiJzdSbxHV0jCy6J+YvT+LY7QUiGY3zzu+NhLqgLxE6KZODXERhSLYSimotcokZbmw==",
       "license": "MIT"
-    },
-    "node_modules/@messageformat/parser": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@messageformat/parser/-/parser-5.1.1.tgz",
-      "integrity": "sha512-3p0YRGCcTUCYvBKLIxtDDyrJ0YijGIwrTRu1DT8gIviIDZru8H23+FkY6MJBzM1n9n20CiM4VeDYuBsrrwnLjg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "moo": "^0.5.1"
-      }
     },
     "node_modules/@metamask/eth-json-rpc-provider": {
       "version": "1.0.1",
@@ -15825,16 +15710,6 @@
       "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==",
       "license": "MIT"
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -20196,14 +20071,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/js-sha256": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.10.1.tgz",
-      "integrity": "sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -21006,14 +20873,6 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
-    },
-    "node_modules/moo": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
     },
     "node_modules/moo-color": {
       "version": "1.0.3",


### PR DESCRIPTION
## Summary

Migrates `@dcl/marketplace-site` publishing from a long-lived `NPM_TOKEN` to **npm Trusted Publishing** (OIDC). Addresses the publish outage triggered by [@npmjs invalidating granular tokens that bypass 2FA](https://x.com/npmjs/status/2056960835030016286) on 2026-05-20 in response to the Mini Shai Hulud supply-chain attack pattern.

Following the [npm Trusted Publishers guide](https://docs.npmjs.com/trusted-publishers).

## Changes in this PR

- **Bump Node.js**: `20.x` → `24.x` — Trusted Publishing requires npm CLI ≥ 11.5.1, which ships with Node 24.
- **Drop `NODE_AUTH_TOKEN`** from the Publish step — npm now exchanges the GitHub OIDC token for publish credentials.
- **Add `contents: read` permission** alongside the existing `id-token: write`.
- Inline comments documenting why each change is needed.

The `package.json#repository.url` field was already normalized to the canonical `git+https://` form in #2634, which is a prerequisite.

## Required configuration on npmjs.com (must happen before merging)

`@dcl/marketplace-site` must be configured as a Trusted Publisher target **before** this PR is merged, otherwise the next `build-release` run will fail with the same 404.

Whoever owns `@dcl/marketplace-site` (current maintainers: `decentralandbot`, `imazzara`) needs to:

1. Open https://www.npmjs.com/package/@dcl/marketplace-site/access
2. Scroll to **Trusted Publishers** section → **Add publisher**
3. Fill in:
   - **Provider**: GitHub Actions
   - **Organization or user**: `decentraland`
   - **Repository**: `marketplace`
   - **Workflow filename**: `build-release.yaml` (with the `.yaml` extension)
   - **Environment name**: *(leave empty — no GitHub environment is used)*
   - **Allowed actions**: `npm publish`
4. Save

Once saved, this PR can be merged and the next push to `master` (or a release) should publish successfully via OIDC.

## Test plan

- [ ] Trusted Publisher configured on npmjs.com (see steps above)
- [ ] Merge this PR
- [ ] Verify the next `build-release` run on master publishes successfully (no 404)
- [ ] Confirm the published version on npm registry: https://www.npmjs.com/package/@dcl/marketplace-site
- [ ] Confirm provenance attestation appears on the published version (Trusted Publishing auto-generates provenance)

## Rollback / safety net

If the Trusted Publishing setup has any issue and the publish breaks, we can quickly fall back by reverting this PR — but in that scenario we'd still need a valid `NPM_TOKEN` (which was invalidated). So the rollback is risky and **the npmjs.com config MUST be done first**.

Once stable, the `NPM_TOKEN` secret in repo settings can be deleted (follow-up).

## Why not just rotate the token?

The new tokens that npm allows (Granular with "Bypass 2FA" tick) are in the same bucket they just invalidated and will likely be invalidated again in future sweeps. Trusted Publishing is what npm itself recommends in [their follow-up tweet](https://x.com/npmjs/status/2056960835030016286) and removes the token-management surface entirely.