### PR TITLE
feat: install npm 11 explicitly for Trusted Publishing support

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -22,13 +22,16 @@ jobs:
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # @v4.3.0
       - name: Use Node.js 22.x
-        # npm Trusted Publishing requires npm CLI >= 11.5.1, which ships with
-        # Node 22.18.0+. Using the 22.x LTS line for a single-major bump from 20.x.
+        # Node 22.x LTS — single-major bump from 20.x.
         uses: actions/setup-node@v4.0.1
         with:
           node-version: 22.x
           cache: "npm"
           cache-dependency-path: webapp/package-lock.json
+      - name: Upgrade npm to 11.x
+        # npm Trusted Publishing requires npm CLI >= 11.5.1. The runner's toolcache
+        # ships Node 22.x with npm 10.9.x bundled, so we explicitly install npm 11.
+        run: npm install -g npm@11
       - name: Set package.json version
         uses: decentraland/oddish-action@master
         with:


### PR DESCRIPTION
## Why

The build-release run on master after [#2635](https://github.com/decentraland/marketplace/pull/2635) merged failed with:

```
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

Even though the oddish patch (decentraland/oddish-action#10) correctly detected OIDC and skipped writing `_authToken` to `.npmrc` — confirmed in the log:

```
using OIDC (npm Trusted Publishing) — skipping _authToken in .npmrc
```

Root cause: the GitHub Actions runner's Node 22.x toolcache (`22.22.2`) bundles **npm 10.9.7**, not npm 11.x. npm 10 does not implement the Trusted Publishing OIDC handshake, so without an auth token it just errors out with "need auth".

See failing run: https://github.com/decentraland/marketplace/actions/runs/26184343064/job/77035643160

## Fix

Add an explicit `npm install -g npm@11` step right after `setup-node` so the publish runs under npm 11.x, which supports the OIDC handshake that Trusted Publishing requires.

## Note on the Trusted Publisher configuration

This PR fixes the npm version side. The other prerequisite — configuring the Trusted Publisher entry for `@dcl/marketplace-site` on npmjs.com — is documented in #2635 and must be done by a package maintainer (steps in that PR's description). If not done before this merge, the publish will still fail, just with a 404 instead of "need auth".

## Test plan

- [ ] Confirm Trusted Publisher is configured on npmjs.com for `@dcl/marketplace-site`
- [ ] Merge this PR
- [ ] Verify the next build-release run on master succeeds
- [ ] Confirm npm version in the log is `npm: 11.x.x`