### PR TITLE
ci: bump Node to 24.x for bundled npm 11

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -21,17 +21,18 @@ jobs:
         working-directory: ./webapp
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # @v4.3.0
-      - name: Use Node.js 22.x
-        # Node 22.x LTS — single-major bump from 20.x.
+      - name: Use Node.js 24.x
+        # Node 24.x LTS ships with npm 11.x bundled, which is required for
+        # Trusted Publishing (npm >= 11.5.1). Previous attempt was Node 22.x +
+        # `npm install -g npm@11` but the runner's bundled npm 10.9.7 has a
+        # broken dependency tree (missing promise-retry from @npmcli/arborist)
+        # that prevents in-place upgrades. Node 24's bundled npm 11 sidesteps
+        # the issue entirely.
         uses: actions/setup-node@v4.0.1
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: "npm"
           cache-dependency-path: webapp/package-lock.json
-      - name: Upgrade npm to 11.x
-        # npm Trusted Publishing requires npm CLI >= 11.5.1. The runner's toolcache
-        # ships Node 22.x with npm 10.9.x bundled, so we explicitly install npm 11.
-        run: npm install -g npm@11
       - name: Set package.json version
         uses: decentraland/oddish-action@master
         with:


### PR DESCRIPTION
## Why

Fixes the failure from PR #2636 / [run 26184554822](https://github.com/decentraland/marketplace/actions). The previous approach (Node 22.x + `npm install -g npm@11`) crashed during the npm upgrade step:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - .../node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
```

Root cause: the GHA hosted runner toolcache for Node 22.22.2 has a broken `@npmcli/arborist` package shipped with its bundled npm 10.9.7 — it's missing the `promise-retry` dependency. Any `npm install -g ...` from that broken npm fails with a stack trace before doing anything.

## Fix

Bump `node-version` from `22.x` to `24.x`. Node 24.x is LTS (since Oct 2025) and ships with npm 11.x bundled out of the box. We get the version we need without any in-place upgrade dance.

Earlier feedback from Jarvis recommended staying on the next LTS (Node 22). That's defensible, but in this concrete case the Node 22 toolcache is broken — sticking with 22 needs a workaround that's flakier than the major bump itself.

## Test plan

- [ ] Confirm Trusted Publisher is configured on npmjs.com for `@dcl/marketplace-site` (still a prerequisite — see #2635)
- [ ] Merge this PR
- [ ] Verify the next build-release run on master logs `npm: 11.x.x`
- [ ] Verify the publish step finishes without "need auth" or 404

## Rollback

Revert to Node 20.x and a working `NPM_TOKEN` if Trusted Publishing path can't be made to work. But the token side is the original problem we're trying to solve (npm invalidated those tokens).