### PR TITLE
fix: use on-chain getFingerprintV2 result instead of local hash for estate trades

### DIFF
--- a/webapp/src/components/Bid/AcceptButton/AcceptButton.tsx
+++ b/webapp/src/components/Bid/AcceptButton/AcceptButton.tsx
@@ -11,7 +11,9 @@ import { Props } from './AcceptButton.types'
 const AcceptButton = (props: Props) => {
   const { asset, bid, onClick, rental, userAddress } = props
 
-  const [fingerprint, isLoadingFingerprint] = useFingerprint(asset && isNFT(asset) ? asset : null)
+  // Compare bid.fingerprint against the on-chain getFingerprintV2 (not the
+  // locally derived hash) — the contract verifies the bid's `extra` against V2.
+  const [, isLoadingFingerprint, contractFingerprint] = useFingerprint(asset && isNFT(asset) ? asset : null)
   const [hasInsufficientMANA, setHasInsufficientMANA] = useState(false)
   const isCurrentlyLocked = rental && asset && isLandLocked(userAddress, rental, asset)
 
@@ -21,7 +23,7 @@ const AcceptButton = (props: Props) => {
       .catch(error => console.error(`Could not get the MANA from bidder ${bid.bidder}`, error))
   }, [bid])
 
-  const isValidFingerprint = checkFingerprint(bid, fingerprint)
+  const isValidFingerprint = checkFingerprint(bid, contractFingerprint)
   const assetOwner = !!asset && (isNFT(asset) ? asset.owner : asset?.creator)
   const isValidSeller = assetOwner && assetOwner === userAddress
   const isItemAvailable = !!asset && (isNFT(asset) || asset.available > 0)

--- a/webapp/src/components/Bid/WarningMessage/WarningMessage.tsx
+++ b/webapp/src/components/Bid/WarningMessage/WarningMessage.tsx
@@ -9,7 +9,9 @@ import './WarningMessage.css'
 const WarningMessage = (props: Props) => {
   const { asset, bid } = props
 
-  const [fingerprint] = useFingerprint(asset && isNFT(asset) ? asset : null)
+  // Compare bid.fingerprint against the on-chain getFingerprintV2 (not the
+  // locally derived hash) — the contract verifies the bid's `extra` against V2.
+  const [, , contractFingerprint] = useFingerprint(asset && isNFT(asset) ? asset : null)
   const [hasInsufficientMANA, setHasInsufficientMANA] = useState(false)
 
   useEffect(() => {
@@ -18,7 +20,7 @@ const WarningMessage = (props: Props) => {
       .catch(error => console.error(`Could not get the MANA from bidder ${bid.bidder}`, error))
   }, [bid])
 
-  const isValidFingerprint = checkFingerprint(bid, fingerprint)
+  const isValidFingerprint = checkFingerprint(bid, contractFingerprint)
 
   if (hasInsufficientMANA) {
     return <div className="WarningMessage">{t('bid.not_enough_mana_on_bid_placed')}</div>

--- a/webapp/src/components/BidPage/BidModal/BidModal.tsx
+++ b/webapp/src/components/BidPage/BidModal/BidModal.tsx
@@ -32,13 +32,15 @@ const BidModal = (props: Props) => {
   const [price, setPrice] = useState('')
   const [expiresAt, setExpiresAt] = useState(getDefaultExpirationDate())
 
-  const [fingerprint, isLoadingFingerprint, contractFingerprint] = useFingerprint(isNFT(asset) ? asset : null)
+  // The server validates `extra` against on-chain getFingerprintV2, so we must
+  // send the value the contract returns, not the locally derived one.
+  const [, isLoadingFingerprint, contractFingerprint] = useFingerprint(isNFT(asset) ? asset : null)
 
   const [showConfirmationModal, setShowConfirmationModal] = useState(false)
 
   const handlePlaceBid = useCallback(
-    () => onPlaceBid(asset, parseMANANumber(price), +new Date(`${expiresAt} 00:00:00`), fingerprint),
-    [asset, price, expiresAt, fingerprint, onPlaceBid]
+    () => onPlaceBid(asset, parseMANANumber(price), +new Date(`${expiresAt} 00:00:00`), contractFingerprint),
+    [asset, price, expiresAt, contractFingerprint, onPlaceBid]
   )
 
   const contractNames = getContractNames()
@@ -97,8 +99,7 @@ const BidModal = (props: Props) => {
     isLoadingFingerprint ||
     isPlacingBid ||
     hasLowPriceForMetaTx ||
-    (!fingerprint && asset.category === NFTCategory.ESTATE) ||
-    contractFingerprint !== fingerprint
+    (asset.category === NFTCategory.ESTATE && !contractFingerprint)
 
   return (
     <AssetAction asset={asset}>
@@ -146,7 +147,7 @@ const BidModal = (props: Props) => {
               error={isInvalidDate}
               message={isInvalidDate ? t('bid_page.invalid_date') : undefined}
             />
-            {!isLoadingFingerprint && contractFingerprint !== fingerprint ? (
+            {!isLoadingFingerprint && asset.category === NFTCategory.ESTATE && !contractFingerprint ? (
               <ErrorBanner info={t('atlas_updated_warning.fingerprint_missmatch')} />
             ) : null}
           </div>

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyNftWithCryptoModal/BuyNftWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyNftWithCryptoModal/BuyNftWithCryptoModal.tsx
@@ -87,8 +87,7 @@ const BuyNftWithCryptoModalHOC = (props: Props) => {
       targetContract: mana as Contract,
       authorizedContractLabel,
       requiredAllowanceInWei: useCredits && credits ? (BigInt(order.price) - BigInt(credits.totalCredits)).toString() : order.price,
-      onAuthorized: (alreadyAuthorized: boolean) =>
-        onExecuteOrder(order, nft, contractFingerprint, !alreadyAuthorized, useCredits)
+      onAuthorized: (alreadyAuthorized: boolean) => onExecuteOrder(order, nft, contractFingerprint, !alreadyAuthorized, useCredits)
     })
   }, [nft, order, contractFingerprint, getContract, onAuthorizedAction, onExecuteOrder, useCredits, credits])
 
@@ -103,8 +102,7 @@ const BuyNftWithCryptoModalHOC = (props: Props) => {
     [order]
   )
   const onGetGasCost: OnGetGasCost = useCallback(
-    (selectedToken, chainNativeToken, wallet) =>
-      useBuyNftGasCost(nft, order, selectedToken, chainNativeToken, wallet, contractFingerprint),
+    (selectedToken, chainNativeToken, wallet) => useBuyNftGasCost(nft, order, selectedToken, chainNativeToken, wallet, contractFingerprint),
     [nft, order, contractFingerprint]
   )
 

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyNftWithCryptoModal/BuyNftWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyNftWithCryptoModal/BuyNftWithCryptoModal.tsx
@@ -33,7 +33,10 @@ const BuyNftWithCryptoModalHOC = (props: Props) => {
     metadata: { nft, order, slippage = 1, useCredits = false }
   } = props
 
-  const [fingerprint] = useFingerprint(nft)
+  // Legacy `safeExecuteOrder` on V1 marketplace verifies the fingerprint
+  // against the upgraded EstateRegistry (getFingerprintV2). Use the contract
+  // value so the on-chain check passes; the locally derived hash does not match.
+  const [, , contractFingerprint] = useFingerprint(nft)
 
   const onBuyNatively = useCallback(() => {
     const contractNames = getContractNames()
@@ -84,9 +87,10 @@ const BuyNftWithCryptoModalHOC = (props: Props) => {
       targetContract: mana as Contract,
       authorizedContractLabel,
       requiredAllowanceInWei: useCredits && credits ? (BigInt(order.price) - BigInt(credits.totalCredits)).toString() : order.price,
-      onAuthorized: (alreadyAuthorized: boolean) => onExecuteOrder(order, nft, fingerprint, !alreadyAuthorized, useCredits) // undefined as fingerprint
+      onAuthorized: (alreadyAuthorized: boolean) =>
+        onExecuteOrder(order, nft, contractFingerprint, !alreadyAuthorized, useCredits)
     })
-  }, [nft, order, fingerprint, getContract, onAuthorizedAction, onExecuteOrder, useCredits, credits])
+  }, [nft, order, contractFingerprint, getContract, onAuthorizedAction, onExecuteOrder, useCredits, credits])
 
   const onBuyWithCard = useCallback(() => {
     getAnalytics()?.track(events.CLICK_BUY_NFT_WITH_CARD)
@@ -99,8 +103,9 @@ const BuyNftWithCryptoModalHOC = (props: Props) => {
     [order]
   )
   const onGetGasCost: OnGetGasCost = useCallback(
-    (selectedToken, chainNativeToken, wallet) => useBuyNftGasCost(nft, order, selectedToken, chainNativeToken, wallet, fingerprint),
-    [nft, order, fingerprint]
+    (selectedToken, chainNativeToken, wallet) =>
+      useBuyNftGasCost(nft, order, selectedToken, chainNativeToken, wallet, contractFingerprint),
+    [nft, order, contractFingerprint]
   )
 
   const price = useMemo(() => {

--- a/webapp/src/components/Modals/SellModal/SellModal.tsx
+++ b/webapp/src/components/Modals/SellModal/SellModal.tsx
@@ -120,8 +120,7 @@ const SellModal = ({
 
   const isInvalidDate = new Date(`${expiresAt} 00:00:00`).getTime() < Date.now()
   const isInvalidPrice = useMemo(() => parseMANANumber(price) <= 0 || parseFloat(price) !== parseMANANumber(price), [price])
-  const isEstateFingerprintNotReady =
-    nft.category === NFTCategory.ESTATE && (isLoadingFingerprint || !contractFingerprint)
+  const isEstateFingerprintNotReady = nft.category === NFTCategory.ESTATE && (isLoadingFingerprint || !contractFingerprint)
   const isDisabledSell =
     !orderService.canSell() || !isOwnedBy(nft, wallet) || isInvalidPrice || isInvalidDate || isEstateFingerprintNotReady
 

--- a/webapp/src/components/Modals/SellModal/SellModal.tsx
+++ b/webapp/src/components/Modals/SellModal/SellModal.tsx
@@ -79,15 +79,17 @@ const SellModal = ({
   const offChainOrdersContract = getDecentralandContract(ContractName.OffChainMarketplaceV2, nft.chainId)
 
   const authorizedContract = offChainOrdersContract || marketplaceContract
-  const [fingerprint] = useFingerprint(nft)
+  // The server validates `extra` against on-chain getFingerprintV2, so we must
+  // send the value the contract returns, not the locally derived one.
+  const [, isLoadingFingerprint, contractFingerprint] = useFingerprint(nft)
 
   if (!wallet) {
     return null
   }
 
   const handleCreateOrder = useCallback(
-    () => onCreateOrder(nft, parseMANANumber(price), new Date(`${expiresAt} 00:00:00`).getTime(), fingerprint),
-    [expiresAt, fingerprint, nft, price, onCreateOrder]
+    () => onCreateOrder(nft, parseMANANumber(price), new Date(`${expiresAt} 00:00:00`).getTime(), contractFingerprint),
+    [expiresAt, contractFingerprint, nft, price, onCreateOrder]
   )
 
   const handleOnConfirm = useCallback(() => {
@@ -118,7 +120,10 @@ const SellModal = ({
 
   const isInvalidDate = new Date(`${expiresAt} 00:00:00`).getTime() < Date.now()
   const isInvalidPrice = useMemo(() => parseMANANumber(price) <= 0 || parseFloat(price) !== parseMANANumber(price), [price])
-  const isDisabledSell = !orderService.canSell() || !isOwnedBy(nft, wallet) || isInvalidPrice || isInvalidDate
+  const isEstateFingerprintNotReady =
+    nft.category === NFTCategory.ESTATE && (isLoadingFingerprint || !contractFingerprint)
+  const isDisabledSell =
+    !orderService.canSell() || !isOwnedBy(nft, wallet) || isInvalidPrice || isInvalidDate || isEstateFingerprintNotReady
 
   const handleBackOrCancel = useCallback(() => {
     if (isUpdate) {

--- a/webapp/src/components/SellPage/SellModal/SellModal.tsx
+++ b/webapp/src/components/SellPage/SellModal/SellModal.tsx
@@ -140,10 +140,8 @@ const SellModal = (props: Props) => {
 
   const isInvalidDate = new Date(`${expiresAt} 00:00:00`).getTime() < Date.now()
   const isInvalidPrice = parseMANANumber(price) <= 0 || parseFloat(price) !== parseMANANumber(price)
-  const isEstateFingerprintNotReady =
-    nft.category === NFTCategory.ESTATE && (isLoadingFingerprint || !contractFingerprint)
-  const isDisabled =
-    !orderService.canSell() || !isOwnedBy(nft, wallet) || isInvalidPrice || isInvalidDate || isEstateFingerprintNotReady
+  const isEstateFingerprintNotReady = nft.category === NFTCategory.ESTATE && (isLoadingFingerprint || !contractFingerprint)
+  const isDisabled = !orderService.canSell() || !isOwnedBy(nft, wallet) || isInvalidPrice || isInvalidDate || isEstateFingerprintNotReady
 
   return (
     <AssetAction asset={nft}>

--- a/webapp/src/components/SellPage/SellModal/SellModal.tsx
+++ b/webapp/src/components/SellPage/SellModal/SellModal.tsx
@@ -49,7 +49,9 @@ const SellModal = (props: Props) => {
   const isUpdate = order !== null
   const shouldRemoveListing = order?.tradeId
   const [price, setPrice] = useState<string>(isUpdate ? ethers.utils.formatEther(order.price) : '')
-  const [fingerprint] = useFingerprint(nft)
+  // The server validates `extra` against on-chain getFingerprintV2, so we must
+  // send the value the contract returns, not the locally derived one.
+  const [, isLoadingFingerprint, contractFingerprint] = useFingerprint(nft)
 
   const [expiresAt, setExpiresAt] = useState(() => {
     let exp = order?.expiresAt
@@ -112,7 +114,8 @@ const SellModal = (props: Props) => {
 
   const offchainOrdersContract = getDecentralandContract(ContractName.OffChainMarketplaceV2, nft.chainId)
 
-  const handleCreateOrder = () => onCreateOrder(nft, parseMANANumber(price), new Date(`${expiresAt} 00:00:00`).getTime(), fingerprint)
+  const handleCreateOrder = () =>
+    onCreateOrder(nft, parseMANANumber(price), new Date(`${expiresAt} 00:00:00`).getTime(), contractFingerprint)
 
   const handleCancelTrade = () => order && onCancelOrder(order, nft)
 
@@ -137,7 +140,10 @@ const SellModal = (props: Props) => {
 
   const isInvalidDate = new Date(`${expiresAt} 00:00:00`).getTime() < Date.now()
   const isInvalidPrice = parseMANANumber(price) <= 0 || parseFloat(price) !== parseMANANumber(price)
-  const isDisabled = !orderService.canSell() || !isOwnedBy(nft, wallet) || isInvalidPrice || isInvalidDate
+  const isEstateFingerprintNotReady =
+    nft.category === NFTCategory.ESTATE && (isLoadingFingerprint || !contractFingerprint)
+  const isDisabled =
+    !orderService.canSell() || !isOwnedBy(nft, wallet) || isInvalidPrice || isInvalidDate || isEstateFingerprintNotReady
 
   return (
     <AssetAction asset={nft}>


### PR DESCRIPTION
## Problem

Estate trades and bids on mainnet are being rejected by marketplace-server with `400 The Estate trade is invalid, check for the fingerprint to see if it matches the Estate's one`.

Reproduced live with Estate \`#6408\` (https://decentraland.org/marketplace/contracts/0x959e104e1a4db6317fa58f8295f586e1a978c297/tokens/6408):

| Source | Value |
|---|---|
| Webapp sends in trade payload (\`extra\`) | \`0x12dc9a29443215aa3b14d59598f95c8738d20b3160fbae32c8107363d6863e89\` |
| On-chain \`getFingerprintV2(6408)\` (verified via \`eth_call\` to EstateRegistry on mainnet) | \`0x2a6305f91c101448cb6ebe36ec0c767946050f9c6088c1caff94dab358d28276\` |

The marketplace-server compares the trade's \`extra\` against the on-chain value (see [\`isEstateFingerprintValid\` in marketplace-server](https://github.com/decentraland/marketplace-server/blob/main/src/logic/trades/utils.ts)). Since they differ, every Estate trade gets rejected.

## Root cause

\`useFingerprint(nft)\` returns two values for Estates:

1. **Local** — computed by \`generateFingerprint()\` in \`webapp/src/modules/nft/estate/utils.ts\` with \`keccak256(abi.encode(['string','uint256','uint256[]'], ['estateId', estateId, tokenIds]))\`
2. **Contract** — read directly from \`EstateRegistry.getFingerprintV2(tokenId)\`

The local algorithm does **not** match the Solidity implementation of \`getFingerprintV2\` post-upgrade. We don't yet have a clear root-cause for the discrepancy (magic prefix, encoding scheme, or land-id ordering — TBD investigation in a follow-up), but empirically they produce different bytes32 for every Estate.

All consumers were destructuring only the local value (\`const [fingerprint] = useFingerprint(...)\`) and sending it to the trade / contract. The contract value was computed but never used.

## Fix

Switch every consumer to use \`contractFingerprint\`. Both webapp and server now read from the same source (on-chain \`getFingerprintV2\`), so the comparison can't drift.

| File | Change |
|---|---|
| \`SellPage/SellModal/SellModal.tsx\` | Use \`contractFingerprint\` for \`onCreateOrder\`. Disable submit while contract value is loading. |
| \`Modals/SellModal/SellModal.tsx\` | Same. |
| \`BidPage/BidModal/BidModal.tsx\` | Use \`contractFingerprint\` for \`onPlaceBid\`. Removed the now-misleading \`contractFingerprint !== fingerprint\` guard (it was permanently true due to the local bug and blocked every Estate bid). Banner now triggers only when the contract value can't be fetched. |
| \`Bid/AcceptButton/AcceptButton.tsx\` | Compare \`bid.fingerprint\` against \`contractFingerprint\`. Previously the seller couldn't accept any valid Estate bid because the local hash never matched the bid's signed fingerprint. |
| \`Bid/WarningMessage/WarningMessage.tsx\` | Same comparison fix. |
| \`Modals/BuyWithCryptoModal/BuyNftWithCryptoModal/BuyNftWithCryptoModal.tsx\` | Pass \`contractFingerprint\` to \`onExecuteOrder\` (used by legacy V1 \`safeExecuteOrder\`, which calls \`verifyFingerprint\` → \`getFingerprintV2\` post-upgrade). |

The \`useFingerprint\` hook itself is **unchanged** — the local computation is still performed but its result is no longer consumed. Cleaning that up (and the \`generateFingerprint\` helper) is left for a follow-up to keep this PR scoped to the fix.

## Why this is correct

For new trades / bids, both webapp and server query the same on-chain function. They cannot disagree.

For accepting a bid (\`AcceptButton\`), comparing \`contractFingerprint\` against \`bid.fingerprint\` is what matters: the bidder signed with the contract value, and the on-chain \`accept\` will run \`verifyFingerprint\` against the current contract state. If the Estate's land composition changed between bid and acceptance, the comparison correctly disables the accept button. If unchanged, it correctly enables it.

For legacy \`safeExecuteOrder\`, the V1 marketplace's \`verifyFingerprint\` was redirected to the V2 hash by the EstateRegistry upgrade. Passing \`contractFingerprint\` is what the contract now expects.

## Out of scope (follow-ups)

- Diagnose and fix or remove \`generateFingerprint\` in \`webapp/src/modules/nft/estate/utils.ts\` (currently dead code post-this-PR).
- Add logging in marketplace-server \`addTradeHandler\` so 400s appear in Grafana with context (only the bare HTTP status reaches logs today, making this bug very slow to diagnose).

## Test plan

- [ ] Estate listing on mainnet: try to create a sell order on an Estate you own. Should succeed (previously 400).
- [ ] Estate listing while \`contractFingerprint\` is loading: submit button stays disabled (no race condition where we POST an empty \`extra\`).
- [ ] Estate bid: place a bid on an Estate you don't own. Should succeed.
- [ ] Estate bid acceptance: as the owner, view received bids on an Estate. Accept button should be enabled for currently-valid bids.
- [ ] Non-Estate trades (Wearables, ENS, Parcels): regression check — submit path should behave exactly as before (the new \`isEstateFingerprintNotReady\` guard is scoped to \`NFTCategory.ESTATE\`).
- [ ] Buy an Estate via legacy V1 order: \`safeExecuteOrder\` should succeed if the listing was already valid (i.e. created with the contract fingerprint).