### PR TITLE
feat: animated wearable preview on emote card hover

### DIFF
--- a/webapp/src/components/AssetCard/AssetCard.tsx
+++ b/webapp/src/components/AssetCard/AssetCard.tsx
@@ -104,7 +104,7 @@ const AssetCard = (props: Props) => {
   // capability too — on touch-only devices `mouseenter` fires on tap and
   // would race the click that navigates to the asset detail page.
   const supportsHover = useMemo(() => typeof window !== 'undefined' && window.matchMedia('(hover: hover) and (pointer: fine)').matches, [])
-  const canShowEmotePreview = isEmoteCard && !isMobile && supportsHover
+  const canShowEmotePreview = isEmoteCard && !isMobile && supportsHover && !!emotePreviewPlayer
 
   const title = getAssetName(asset)
   const { parcel, estate, wearable, emote, ens } = asset.data

--- a/webapp/src/components/AssetCard/AssetCard.tsx
+++ b/webapp/src/components/AssetCard/AssetCard.tsx
@@ -103,10 +103,7 @@ const AssetCard = (props: Props) => {
   // touch laptops/large tablets. Gate the hover preview on pointer
   // capability too — on touch-only devices `mouseenter` fires on tap and
   // would race the click that navigates to the asset detail page.
-  const supportsHover = useMemo(
-    () => typeof window !== 'undefined' && window.matchMedia('(hover: hover) and (pointer: fine)').matches,
-    []
-  )
+  const supportsHover = useMemo(() => typeof window !== 'undefined' && window.matchMedia('(hover: hover) and (pointer: fine)').matches, [])
   const canShowEmotePreview = isEmoteCard && !isMobile && supportsHover
 
   const title = getAssetName(asset)

--- a/webapp/src/components/AssetCard/AssetCard.tsx
+++ b/webapp/src/components/AssetCard/AssetCard.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useMemo, useRef } from 'react'
 import { useInView } from 'react-intersection-observer'
 import { Link, useLocation } from 'react-router-dom'
-import { Item, Network, RentalListing } from '@dcl/schemas'
+import { Item, Network, NFTCategory, RentalListing } from '@dcl/schemas'
 import { Profile } from 'decentraland-dapps/dist/containers'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Card, Icon, useMobileMediaQuery } from 'decentraland-ui'
@@ -19,6 +19,7 @@ import {
 import { locations } from '../../modules/routing/locations'
 import { PageName, SortBy } from '../../modules/routing/types'
 import { AssetImage } from '../AssetImage'
+import { useEmotePreviewPlayer } from '../EmotePreviewPlayer'
 import { FavoritesCounter } from '../FavoritesCounter'
 import { Mana } from '../Mana'
 import { EmoteTags } from './EmoteTags'
@@ -95,9 +96,42 @@ const AssetCard = (props: Props) => {
   const isMobile = useMobileMediaQuery()
   const location = useLocation()
   const showListedTag = pageName === PageName.ACCOUNT && Boolean(price) && location.pathname !== locations.root()
+  const emotePreviewPlayer = useEmotePreviewPlayer()
+  const cardContainerRef = useRef<HTMLDivElement | null>(null)
+  const isEmoteCard = asset.category === NFTCategory.EMOTE
+  // `useMobileMediaQuery` is viewport-width based, so it returns false on
+  // touch laptops/large tablets. Gate the hover preview on pointer
+  // capability too — on touch-only devices `mouseenter` fires on tap and
+  // would race the click that navigates to the asset detail page.
+  const supportsHover = useMemo(
+    () => typeof window !== 'undefined' && window.matchMedia('(hover: hover) and (pointer: fine)').matches,
+    []
+  )
+  const canShowEmotePreview = isEmoteCard && !isMobile && supportsHover
 
   const title = getAssetName(asset)
   const { parcel, estate, wearable, emote, ens } = asset.data
+
+  const handleEmoteHoverEnter = useCallback(() => {
+    if (!emotePreviewPlayer || !canShowEmotePreview) return
+    const container = cardContainerRef.current
+    if (!container) return
+    const imageEl = container.querySelector<HTMLElement>('.AssetImage')
+    if (!imageEl) return
+    emotePreviewPlayer.show(imageEl, {
+      contractAddress: asset.contractAddress,
+      itemId: 'itemId' in asset ? asset.itemId : null,
+      tokenId: 'tokenId' in asset ? asset.tokenId : null,
+      urn: 'urn' in asset ? asset.urn ?? null : null,
+      network: asset.network,
+      rarity: asset.data.emote?.rarity
+    })
+  }, [emotePreviewPlayer, canShowEmotePreview, asset])
+
+  const handleEmoteHoverLeave = useCallback(() => {
+    if (!emotePreviewPlayer || !canShowEmotePreview) return
+    emotePreviewPlayer.hide()
+  }, [emotePreviewPlayer, canShowEmotePreview])
   const rentalPricePerDay: string | null = useMemo(() => (isRentalListingOpen(rental) ? getMaxPriceOfPeriods(rental!) : null), [rental])
 
   const catalogItemInformation = useMemo(() => {
@@ -141,8 +175,20 @@ const AssetCard = (props: Props) => {
     ) : null
   }, [asset, catalogItemInformation])
 
+  const setWrapperRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      cardContainerRef.current = node
+      ref(node)
+    },
+    [ref]
+  )
+
   return (
-    <div ref={ref}>
+    <div
+      ref={setWrapperRef}
+      onMouseEnter={canShowEmotePreview ? handleEmoteHoverEnter : undefined}
+      onMouseLeave={canShowEmotePreview ? handleEmoteHoverLeave : undefined}
+    >
       <Card
         className={`AssetCard ${isCatalogItem(asset) ? 'catalog' : ''}`}
         link

--- a/webapp/src/components/BrowsePage/BrowsePage.tsx
+++ b/webapp/src/components/BrowsePage/BrowsePage.tsx
@@ -5,6 +5,7 @@ import { Section } from '../../modules/vendor/decentraland'
 import { VendorName } from '../../modules/vendor/types'
 import { isVendor } from '../../modules/vendor/utils'
 import { AssetBrowse } from '../AssetBrowse'
+import { EmotePreviewPlayerProvider } from '../EmotePreviewPlayer'
 import { NavigationTab } from '../Navigation/Navigation.types'
 import { PageLayout } from '../PageLayout'
 import { Props } from './BrowsePage.types'
@@ -17,23 +18,26 @@ const BrowsePage = (props: Props) => {
   const vendor = isVendor(props.vendor) ? props.vendor : VendorName.DECENTRALAND
 
   const activeTab = NavigationTab.COLLECTIBLES
+  const isEmotesSection = typeof section === 'string' && section.startsWith('emotes')
 
   return (
-    <PageLayout activeTab={activeTab}>
-      {isCampaignCollectiblesBannerEnabled ? (
-        <div className={styles.banner}>
-          <Banner id={MARKETPLACE_COLLECTIBLES_BANNER_ID} />
-        </div>
-      ) : null}
-      <AssetBrowse
-        vendor={vendor}
-        isFullscreen={Boolean(isFullscreen)}
-        view={View.MARKET}
-        section={section}
-        sections={[Section.WEARABLES, Section.EMOTES]}
-        contracts={contracts}
-      />
-    </PageLayout>
+    <EmotePreviewPlayerProvider enabled={isEmotesSection}>
+      <PageLayout activeTab={activeTab}>
+        {isCampaignCollectiblesBannerEnabled ? (
+          <div className={styles.banner}>
+            <Banner id={MARKETPLACE_COLLECTIBLES_BANNER_ID} />
+          </div>
+        ) : null}
+        <AssetBrowse
+          vendor={vendor}
+          isFullscreen={Boolean(isFullscreen)}
+          view={View.MARKET}
+          section={section}
+          sections={[Section.WEARABLES, Section.EMOTES]}
+          contracts={contracts}
+        />
+      </PageLayout>
+    </EmotePreviewPlayerProvider>
   )
 }
 

--- a/webapp/src/components/EmotePreviewPlayer/EmotePreviewPlayer.css
+++ b/webapp/src/components/EmotePreviewPlayer/EmotePreviewPlayer.css
@@ -1,0 +1,56 @@
+.EmotePreviewPlayer {
+  position: fixed;
+  z-index: 2147483000;
+  border-radius: 10px;
+  overflow: hidden;
+  pointer-events: none;
+  background-color: transparent;
+  opacity: 0;
+  transition: opacity 120ms ease-out;
+  contain: layout paint;
+}
+
+/* While warming we keep the iframe rendered (not visibility:hidden, which can
+   pause iframe rendering in some browsers) but invisible to the user. */
+.EmotePreviewPlayer.is-warming {
+  top: 0;
+  left: 0;
+  width: 320px;
+  height: 320px;
+  opacity: 0;
+  pointer-events: none;
+  clip-path: inset(50%);
+}
+
+.EmotePreviewPlayer.is-visible {
+  opacity: 1;
+  clip-path: none;
+}
+
+.EmotePreviewPlayer iframe {
+  width: 100% !important;
+  height: 100% !important;
+  border: 0 !important;
+  display: block;
+  background: transparent;
+}
+
+/* Semantic UI's Loader is positioned via top/left:50% with translate. We
+   anchor it to the overlay rather than to its (non-existent) Dimmer parent. */
+.EmotePreviewPlayer .ui.loader.EmotePreviewPlayer__spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 2;
+}
+
+.EmotePreviewPlayer .ui.loader.EmotePreviewPlayer__spinner:before,
+.EmotePreviewPlayer .ui.loader.EmotePreviewPlayer__spinner:after {
+  /* Force the spinner ring to be visible regardless of any inherited dimmer
+     styling from the page. */
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.EmotePreviewPlayer .ui.loader.EmotePreviewPlayer__spinner:after {
+  border-top-color: #fff;
+}

--- a/webapp/src/components/EmotePreviewPlayer/EmotePreviewPlayer.css
+++ b/webapp/src/components/EmotePreviewPlayer/EmotePreviewPlayer.css
@@ -1,6 +1,9 @@
 .EmotePreviewPlayer {
   position: fixed;
-  z-index: 2147483000;
+  /* Above the browse grid content but below Semantic UI's fixed navbar (101),
+     modals/dimmers (1000) and popups (1900) so the ephemeral preview never
+     paints over chrome. pointer-events:none already prevents interaction. */
+  z-index: 100;
   border-radius: 10px;
   overflow: hidden;
   pointer-events: none;

--- a/webapp/src/components/EmotePreviewPlayer/EmotePreviewPlayer.spec.tsx
+++ b/webapp/src/components/EmotePreviewPlayer/EmotePreviewPlayer.spec.tsx
@@ -1,0 +1,219 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-var-requires */
+import { act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Network } from '@dcl/schemas'
+import { renderWithProviders } from '../../utils/test'
+import { EmotePreviewPlayerProvider, EmotePreviewSource, useEmotePreviewPlayer } from './EmotePreviewPlayer'
+
+// Capture the latest onLoad handed to the WearablePreview iframe so tests can
+// drive the LOAD lifecycle, and render a real iframe element carrying the id
+// the provider looks up via document.getElementById.
+let capturedOnLoad: (() => void) | undefined
+
+// Mirror the global decentraland-ui2 mock (see beforeSetupTests.ts) so the
+// store/saga import chain still resolves styled() at module-eval time, but
+// override WearablePreview to capture onLoad and render an iframe with the id
+// the provider drives via document.getElementById.
+jest.mock('decentraland-ui2', () => {
+  const React = require('react')
+  const createStyledComponent = () => () => React.createElement('div')
+  const styledMock: any = () => createStyledComponent()
+  styledMock.div = () => createStyledComponent()
+  styledMock.span = () => createStyledComponent()
+  styledMock.button = () => createStyledComponent()
+  styledMock.a = () => createStyledComponent()
+  styledMock.nav = () => createStyledComponent()
+  styledMock.section = () => createStyledComponent()
+  styledMock.header = () => createStyledComponent()
+  const MockComponent = () => React.createElement('div')
+  return {
+    darkTheme: {},
+    lightTheme: {},
+    DclThemeProvider: ({ children }: { children: React.ReactNode }) => children,
+    Navbar2: MockComponent,
+    DownloadButton: MockComponent,
+    Switch: MockComponent,
+    AnimationControls: MockComponent,
+    EmoteControls: MockComponent,
+    ZoomControls: MockComponent,
+    ButtonGroup: MockComponent,
+    Button: MockComponent,
+    Menu: MockComponent,
+    MenuItem: MockComponent,
+    CreditsToggle: MockComponent,
+    JumpIn: MockComponent,
+    styled: styledMock,
+    WearablePreview: (props: { id?: string; onLoad?: () => void }) => {
+      capturedOnLoad = props.onLoad
+      return React.createElement('iframe', { id: props.id, title: 'wearable-preview' })
+    }
+  }
+})
+
+const TARGET_TEST_ID = 'preview-target'
+const DEFAULT_SOURCE: EmotePreviewSource = {
+  contractAddress: '0xcontract',
+  itemId: '1',
+  network: Network.MATIC
+}
+
+const Probe = ({ source = DEFAULT_SOURCE }: { source?: EmotePreviewSource }) => {
+  const player = useEmotePreviewPlayer()
+  return (
+    <>
+      <div data-testid={TARGET_TEST_ID} />
+      <span data-testid="has-player">{player ? 'yes' : 'no'}</span>
+      <button
+        onClick={() => {
+          const target = document.querySelector(`[data-testid="${TARGET_TEST_ID}"]`)
+          if (target) {
+            player?.show(target as HTMLElement, source)
+          }
+        }}
+      >
+        show
+      </button>
+      <button onClick={() => player?.hide()}>hide</button>
+    </>
+  )
+}
+
+const getOverlay = () => document.querySelector('.EmotePreviewPlayer')
+const getSpinner = () => document.querySelector('.EmotePreviewPlayer__spinner')
+const fireLoad = () =>
+  act(() => {
+    capturedOnLoad?.()
+  })
+
+describe('EmotePreviewPlayer', () => {
+  beforeEach(() => {
+    capturedOnLoad = undefined
+    // The rect-tracking rAF loop is irrelevant to these lifecycle assertions;
+    // stub it so it doesn't schedule state updates outside act().
+    jest.spyOn(window, 'requestAnimationFrame').mockReturnValue(0)
+    jest.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('when used outside of a provider', () => {
+    it('should expose a null controller', () => {
+      const { getByTestId } = renderWithProviders(<Probe />)
+      expect(getByTestId('has-player')).toHaveTextContent('no')
+    })
+  })
+
+  describe('when the provider is disabled', () => {
+    it('should not render the preview overlay', () => {
+      renderWithProviders(
+        <EmotePreviewPlayerProvider enabled={false}>
+          <Probe />
+        </EmotePreviewPlayerProvider>
+      )
+      expect(getOverlay()).toBeNull()
+    })
+  })
+
+  describe('when the provider is enabled', () => {
+    it('should render the overlay in the warming (hidden) state', () => {
+      renderWithProviders(
+        <EmotePreviewPlayerProvider enabled>
+          <Probe />
+        </EmotePreviewPlayerProvider>
+      )
+      expect(getOverlay()).toHaveClass('is-warming')
+      expect(getSpinner()).toBeNull()
+    })
+
+    describe('and show is called', () => {
+      it('should make the overlay visible and display the spinner', async () => {
+        const { getByText } = renderWithProviders(
+          <EmotePreviewPlayerProvider enabled>
+            <Probe />
+          </EmotePreviewPlayerProvider>
+        )
+        await userEvent.click(getByText('show'))
+        expect(getOverlay()).toHaveClass('is-visible')
+        expect(getSpinner()).not.toBeNull()
+      })
+    })
+
+    describe('and hide is called after show', () => {
+      it('should hide the overlay and remove the spinner', async () => {
+        const { getByText } = renderWithProviders(
+          <EmotePreviewPlayerProvider enabled>
+            <Probe />
+          </EmotePreviewPlayerProvider>
+        )
+        await userEvent.click(getByText('show'))
+        await userEvent.click(getByText('hide'))
+        expect(getOverlay()).toHaveClass('is-warming')
+        expect(getSpinner()).toBeNull()
+      })
+    })
+
+    describe('and the emote finishes loading after the initial boot', () => {
+      it('should clear the spinner', async () => {
+        const { getByText } = renderWithProviders(
+          <EmotePreviewPlayerProvider enabled>
+            <Probe />
+          </EmotePreviewPlayerProvider>
+        )
+        // First LOAD = iframe boot, marks it controllable.
+        fireLoad()
+        await userEvent.click(getByText('show'))
+        expect(getSpinner()).not.toBeNull()
+        // Second LOAD = the emote scene finished rendering.
+        fireLoad()
+        expect(getSpinner()).toBeNull()
+      })
+    })
+
+    describe('and a second emote is hovered before the first LOAD arrives', () => {
+      it('should keep the spinner until the latest emote LOAD arrives', async () => {
+        const { getByText } = renderWithProviders(
+          <EmotePreviewPlayerProvider enabled>
+            <Probe />
+          </EmotePreviewPlayerProvider>
+        )
+        fireLoad() // boot
+        await userEvent.click(getByText('show')) // emote A requested (seq 1)
+        await userEvent.click(getByText('show')) // emote B requested (seq 2)
+        fireLoad() // stale LOAD for A
+        expect(getSpinner()).not.toBeNull()
+        fireLoad() // LOAD for B
+        expect(getSpinner()).toBeNull()
+      })
+    })
+
+    describe('and the provider is re-enabled after being disabled', () => {
+      it('should treat the next iframe boot LOAD as initialization again', async () => {
+        const { getByText, rerender } = renderWithProviders(
+          <EmotePreviewPlayerProvider enabled>
+            <Probe />
+          </EmotePreviewPlayerProvider>
+        )
+        fireLoad() // boot of the first iframe → controllable
+
+        rerender(
+          <EmotePreviewPlayerProvider enabled={false}>
+            <Probe />
+          </EmotePreviewPlayerProvider>
+        )
+        rerender(
+          <EmotePreviewPlayerProvider enabled>
+            <Probe />
+          </EmotePreviewPlayerProvider>
+        )
+
+        await userEvent.click(getByText('show'))
+        // After the reset, the first LOAD of the fresh iframe is treated as a
+        // boot (not an emote render), so it must NOT clear the spinner.
+        fireLoad()
+        expect(getSpinner()).not.toBeNull()
+      })
+    })
+  })
+})

--- a/webapp/src/components/EmotePreviewPlayer/EmotePreviewPlayer.tsx
+++ b/webapp/src/components/EmotePreviewPlayer/EmotePreviewPlayer.tsx
@@ -1,0 +1,227 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useSelector } from 'react-redux'
+import { Network, PreviewMessageType, PreviewOptions, PreviewUnityMode, Rarity, sendMessage } from '@dcl/schemas'
+import { getData as getProfiles } from 'decentraland-dapps/dist/modules/profile/selectors'
+import { Loader } from 'decentraland-ui'
+import { WearablePreview } from 'decentraland-ui2'
+import { config } from '../../config'
+import { getWallet } from '../../modules/wallet/selectors'
+import './EmotePreviewPlayer.css'
+
+const PREVIEW_IFRAME_ID = 'emote-preview-player-iframe'
+
+export type EmotePreviewSource = {
+  contractAddress?: string
+  itemId?: string | null
+  tokenId?: string | null
+  urn?: string | null
+  network?: Network
+  rarity?: Rarity
+}
+
+type EmotePreviewPlayerContextValue = {
+  show: (target: HTMLElement, source: EmotePreviewSource) => void
+  hide: () => void
+}
+
+const EmotePreviewPlayerContext = createContext<EmotePreviewPlayerContextValue | null>(null)
+
+export const useEmotePreviewPlayer = (): EmotePreviewPlayerContextValue | null => useContext(EmotePreviewPlayerContext)
+
+type Rect = { top: number; left: number; width: number; height: number }
+
+type ProviderProps = {
+  enabled?: boolean
+  children: React.ReactNode
+}
+
+type PreviewEnvConfig = {
+  profile: string
+  peerUrl: string
+  marketplaceServerUrl: string
+}
+
+const sourceToOptions = (src: EmotePreviewSource, env: PreviewEnvConfig): PreviewOptions => {
+  const base: PreviewOptions = {
+    profile: env.profile,
+    peerUrl: env.peerUrl,
+    marketplaceServerUrl: env.marketplaceServerUrl,
+    background: Rarity.getColor(src.rarity ?? Rarity.COMMON)
+  }
+  if (src.network === Network.ETHEREUM && src.urn) {
+    return { ...base, urns: [src.urn] }
+  }
+  return {
+    ...base,
+    contractAddress: src.contractAddress ?? null,
+    itemId: src.itemId ?? null,
+    tokenId: src.tokenId ?? null
+  }
+}
+
+const dispatchUpdate = (src: EmotePreviewSource, env: PreviewEnvConfig): boolean => {
+  const iframe = document.getElementById(PREVIEW_IFRAME_ID) as HTMLIFrameElement | null
+  if (!iframe?.contentWindow) return false
+  sendMessage(iframe.contentWindow, PreviewMessageType.UPDATE, {
+    options: sourceToOptions(src, env)
+  })
+  return true
+}
+
+export const EmotePreviewPlayerProvider: React.FC<ProviderProps> = ({ enabled = true, children }) => {
+  const [rect, setRect] = useState<Rect | null>(null)
+  const [isVisible, setIsVisible] = useState(false)
+  const [rarity, setRarity] = useState<Rarity>(Rarity.COMMON)
+  const [isControllable, setIsControllable] = useState(false)
+  const [isEmoteLoading, setIsEmoteLoading] = useState(false)
+  const targetRef = useRef<HTMLElement | null>(null)
+  const pendingSourceRef = useRef<EmotePreviewSource | null>(null)
+  const hasInitiallyLoadedRef = useRef(false)
+
+  const wallet = useSelector(getWallet)
+  const profiles = useSelector(getProfiles)
+
+  // Resolve the user's profile address whenever wallet/profile data changes.
+  // We DON'T pass `profile` to the React WearablePreview component (the
+  // iframe is mounted once with profile=default to keep its URL stable and
+  // avoid full reloads when the profile becomes available mid-session).
+  // Instead we inject `profile` into every UPDATE we send on hover, so the
+  // emote is rendered on the user's avatar when they're logged in.
+  const profileAddress = useMemo(() => {
+    if (wallet?.address && profiles[wallet.address]?.avatars[0]) {
+      return wallet.address.toLowerCase()
+    }
+    return 'default'
+  }, [wallet?.address, profiles])
+
+  const envConfig = useMemo<PreviewEnvConfig>(
+    () => ({
+      profile: profileAddress,
+      peerUrl: config.get('PEER_URL'),
+      marketplaceServerUrl: config.get('MARKETPLACE_SERVER_URL')
+    }),
+    [profileAddress]
+  )
+
+  // Source of truth for whether the iframe should run against testnets:
+  // tied to the configured peer URL, not to VITE_DCL_DEFAULT_ENV. Lets you
+  // copy prod values into dev.json and have the iframe follow.
+  const isPreviewDev = useMemo(() => !envConfig.peerUrl.includes('decentraland.org'), [envConfig.peerUrl])
+
+  // Track the hovered target's position every frame while visible so the overlay
+  // follows the card image as it shrinks on hover and as the page scrolls.
+  useEffect(() => {
+    if (!isVisible) return
+    let rafId = 0
+    const tick = () => {
+      const el = targetRef.current
+      if (el) {
+        const r = el.getBoundingClientRect()
+        setRect(prev => {
+          if (prev && prev.top === r.top && prev.left === r.left && prev.width === r.width && prev.height === r.height) {
+            return prev
+          }
+          return { top: r.top, left: r.left, width: r.width, height: r.height }
+        })
+      }
+      rafId = requestAnimationFrame(tick)
+    }
+    rafId = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(rafId)
+  }, [isVisible])
+
+  const show = useCallback(
+    (target: HTMLElement, source: EmotePreviewSource) => {
+      targetRef.current = target
+      setRarity(source.rarity ?? Rarity.COMMON)
+      const r = target.getBoundingClientRect()
+      setRect({ top: r.top, left: r.left, width: r.width, height: r.height })
+      setIsVisible(true)
+      setIsEmoteLoading(true)
+      if (isControllable) {
+        dispatchUpdate(source, envConfig)
+        pendingSourceRef.current = null
+      } else {
+        pendingSourceRef.current = source
+      }
+    },
+    [isControllable, envConfig]
+  )
+
+  const hide = useCallback(() => {
+    targetRef.current = null
+    setIsVisible(false)
+    setIsEmoteLoading(false)
+    pendingSourceRef.current = null
+  }, [])
+
+  // Flush any pending hover request once the iframe is controllable.
+  useEffect(() => {
+    if (isControllable && pendingSourceRef.current) {
+      dispatchUpdate(pendingSourceRef.current, envConfig)
+      pendingSourceRef.current = null
+    }
+  }, [isControllable, envConfig])
+
+  // onLoad fires once on initial iframe boot (with the default profile, no
+  // emote) and AGAIN every time we send an UPDATE that swaps the urn/itemId
+  // — the iframe rebuilds the Babylon scene and re-emits LOAD. We use the
+  // first LOAD only to mark the iframe controllable (and to keep the
+  // spinner up if a hover request is still queued). Subsequent LOADs mean
+  // the emote scene finished rendering, so we clear the spinner.
+  const handlePreviewLoad = useCallback(() => {
+    if (!hasInitiallyLoadedRef.current) {
+      hasInitiallyLoadedRef.current = true
+      setIsControllable(true)
+      return
+    }
+    setIsEmoteLoading(false)
+  }, [])
+
+  const contextValue = useMemo<EmotePreviewPlayerContextValue>(() => ({ show, hide }), [show, hide])
+
+  const overlayStyle = useMemo<React.CSSProperties | undefined>(() => {
+    if (!isVisible || !rect) return undefined
+    const [light, dark] = Rarity.getGradient(rarity)
+    return {
+      top: rect.top,
+      left: rect.left,
+      width: rect.width,
+      height: rect.height,
+      backgroundImage: `radial-gradient(${light}, ${dark})`
+    }
+  }, [isVisible, rect, rarity])
+
+  const overlay = enabled ? (
+    <div className={`EmotePreviewPlayer ${isVisible ? 'is-visible' : 'is-warming'}`} style={overlayStyle} aria-hidden>
+      <WearablePreview
+        id={PREVIEW_IFRAME_ID}
+        profile="default"
+        peerUrl={envConfig.peerUrl}
+        marketplaceServerUrl={envConfig.marketplaceServerUrl}
+        background={Rarity.getColor(Rarity.COMMON)}
+        wheelZoom={1.5}
+        wheelStart={100}
+        disableAutoRotate
+        disableFadeEffect
+        // The iframe uses `?env=dev` (set by dev={true}) to talk to testnets
+        // (Amoy for Matic, Sepolia for Ethereum). We resolve "is dev" from
+        // the configured PEER_URL — if it's pointing at .org we want the
+        // iframe in prod mode regardless of VITE_DCL_DEFAULT_ENV, otherwise
+        // contractAddress+itemId from the prod catalog won't resolve.
+        dev={isPreviewDev}
+        unityMode={PreviewUnityMode.MARKETPLACE}
+        onLoad={handlePreviewLoad}
+      />
+      {isVisible && isEmoteLoading ? <Loader className="EmotePreviewPlayer__spinner" active size="large" /> : null}
+    </div>
+  ) : null
+
+  return (
+    <EmotePreviewPlayerContext.Provider value={contextValue}>
+      {children}
+      {overlay && typeof document !== 'undefined' ? createPortal(overlay, document.body) : null}
+    </EmotePreviewPlayerContext.Provider>
+  )
+}

--- a/webapp/src/components/EmotePreviewPlayer/EmotePreviewPlayer.tsx
+++ b/webapp/src/components/EmotePreviewPlayer/EmotePreviewPlayer.tsx
@@ -78,6 +78,12 @@ export const EmotePreviewPlayerProvider: React.FC<ProviderProps> = ({ enabled = 
   const targetRef = useRef<HTMLElement | null>(null)
   const pendingSourceRef = useRef<EmotePreviewSource | null>(null)
   const hasInitiallyLoadedRef = useRef(false)
+  // Each emote swap we request bumps `dispatchSeqRef`; each emote LOAD we
+  // observe bumps `loadSeqRef`. We only clear the spinner once we've caught
+  // up (loadSeq >= dispatchSeq), so a stale LOAD from a previously-hovered
+  // card can't clear the spinner while a newer emote is still rendering.
+  const dispatchSeqRef = useRef(0)
+  const loadSeqRef = useRef(0)
 
   const wallet = useSelector(getWallet)
   const profiles = useSelector(getProfiles)
@@ -139,6 +145,8 @@ export const EmotePreviewPlayerProvider: React.FC<ProviderProps> = ({ enabled = 
       setRect({ top: r.top, left: r.left, width: r.width, height: r.height })
       setIsVisible(true)
       setIsEmoteLoading(true)
+      // One swap requested → expect one more LOAD before the spinner clears.
+      dispatchSeqRef.current += 1
       if (isControllable) {
         dispatchUpdate(source, envConfig)
         pendingSourceRef.current = null
@@ -164,19 +172,41 @@ export const EmotePreviewPlayerProvider: React.FC<ProviderProps> = ({ enabled = 
     }
   }, [isControllable, envConfig])
 
+  // When the provider is disabled (user left the emotes section) the overlay
+  // and its iframe unmount. Reset the lifecycle refs/state so that when the
+  // section is re-entered a fresh iframe boots and is treated as not-yet
+  // controllable — otherwise the first hover would postMessage an UPDATE to
+  // an iframe that hasn't finished initializing and the emote silently fails.
+  useEffect(() => {
+    if (!enabled) {
+      hasInitiallyLoadedRef.current = false
+      dispatchSeqRef.current = 0
+      loadSeqRef.current = 0
+      targetRef.current = null
+      pendingSourceRef.current = null
+      setIsControllable(false)
+      setIsVisible(false)
+      setIsEmoteLoading(false)
+    }
+  }, [enabled])
+
   // onLoad fires once on initial iframe boot (with the default profile, no
   // emote) and AGAIN every time we send an UPDATE that swaps the urn/itemId
   // — the iframe rebuilds the Babylon scene and re-emits LOAD. We use the
   // first LOAD only to mark the iframe controllable (and to keep the
   // spinner up if a hover request is still queued). Subsequent LOADs mean
-  // the emote scene finished rendering, so we clear the spinner.
+  // an emote scene finished rendering; we clear the spinner only once we've
+  // caught up to the latest requested swap so a stale LOAD can't clear it.
   const handlePreviewLoad = useCallback(() => {
     if (!hasInitiallyLoadedRef.current) {
       hasInitiallyLoadedRef.current = true
       setIsControllable(true)
       return
     }
-    setIsEmoteLoading(false)
+    loadSeqRef.current += 1
+    if (loadSeqRef.current >= dispatchSeqRef.current) {
+      setIsEmoteLoading(false)
+    }
   }, [])
 
   const contextValue = useMemo<EmotePreviewPlayerContextValue>(() => ({ show, hide }), [show, hide])

--- a/webapp/src/components/EmotePreviewPlayer/index.ts
+++ b/webapp/src/components/EmotePreviewPlayer/index.ts
@@ -1,0 +1,2 @@
+export { EmotePreviewPlayerProvider, useEmotePreviewPlayer } from './EmotePreviewPlayer'
+export type { EmotePreviewSource } from './EmotePreviewPlayer'


### PR DESCRIPTION
## Changes

- Add `EmotePreviewPlayer` provider that pre-warms a single hidden `WearablePreview` iframe (rendered via Portal to `document.body`) when the user lands on `/browse?section=emotes*`, so hovering an emote card swaps the emote via `postMessage(UPDATE)` instead of mounting a new iframe per card.
- `AssetCard` attaches `onMouseEnter`/`onMouseLeave` only for emote cards on hover-capable pointer devices (`useMobileMediaQuery` + `(hover: hover) and (pointer: fine)` media query). On hover, the overlay tracks the `.AssetImage` rect via rAF so it follows the card's CSS hover transition and scroll position; on leave, it hides without unmounting the iframe.
- Loading spinner overlaid on top of the rarity-gradient background while the iframe is fetching/rendering the new emote (gated by a `hasInitiallyLoadedRef` so the first boot `LOAD` doesn't prematurely clear the spinner if a hover request is still queued).
- When the user is logged in and the profile is loaded, the emote is rendered on their avatar by sending `profile=<wallet.address>` in the manual `UPDATE` (the React `WearablePreview` is mounted with `profile=default` to keep its src URL stable so login-mid-session doesn't trigger a full iframe reload).
- Pass `peerUrl` and `marketplaceServerUrl` from app config to the iframe, and derive the iframe's `dev` flag from the configured `PEER_URL` (`.org` → prod, anything else → dev/zone) so the iframe network resolution follows the data env without depending on `VITE_DCL_DEFAULT_ENV`.

## Test plan

- [ ] On `/browse?assetType=item&section=emotes` (desktop), hovering an emote card replaces the thumbnail with the animated preview after a short loading spinner; moving cursor between cards swaps the emote smoothly with no full iframe reload (no Babylon teardown logs in console).
- [ ] Card hover-shrink CSS transition stays in sync with the overlay (overlay follows the resizing `.AssetImage` rect).
- [ ] Page scroll while hovering keeps the overlay anchored to the card.
- [ ] Click on a hovered card still navigates to the asset detail page (overlay has `pointer-events: none`).
- [ ] On non-emote sections (`section=wearables`, etc.) the provider is not enabled, no iframe is mounted, and existing wearable cards behave unchanged.
- [ ] On touch-only devices and small viewports, no overlay appears on tap; click goes to detail page as before.
- [ ] Logged-in user sees the emote played on their own avatar; logged-out user sees the default avatar.