### PR TITLE
feat: across V4 as cross-chain provider for credit-paid NAME claim

### DIFF
--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.tsx
@@ -506,7 +506,9 @@ export const BuyWithCryptoModal = (props: Props) => {
       )
     }
 
-    // When polling cross-chain, show a different title and disable navigation
+    // The cross-chain credit states (polling / success / failed) render their own content
+    // and actions, so suppress the default back/close navigation. Polling shows a title;
+    // the terminal success/failed views let their own content carry the message.
     if (isPollingCrossChain) {
       return (
         <ModalNavigation
@@ -516,6 +518,10 @@ export const BuyWithCryptoModal = (props: Props) => {
           })}
         />
       )
+    }
+
+    if (isCrossChainSucceeded || isCrossChainFailed) {
+      return <ModalNavigation title="" />
     }
 
     return (
@@ -528,7 +534,17 @@ export const BuyWithCryptoModal = (props: Props) => {
         onClose={!isBuyingAsset ? onClose : undefined}
       />
     )
-  }, [asset.name, onClose, showChainSelector, showTokenSelector, isBuyingAsset, isPollingCrossChain])
+  }, [
+    asset.name,
+    onClose,
+    onGoBack,
+    showChainSelector,
+    showTokenSelector,
+    isBuyingAsset,
+    isPollingCrossChain,
+    isCrossChainSucceeded,
+    isCrossChainFailed
+  ])
 
   const renderCrossChainPollingContent = useCallback(() => {
     if (!creditsClaimProgress) return null
@@ -600,7 +616,7 @@ export const BuyWithCryptoModal = (props: Props) => {
     onPayWithCredits()
   }, [onClearCreditsClaimProgress, onPayWithCredits])
 
-  const handleCloseFailedCreditsClaim = useCallback(() => {
+  const handleCloseCreditsClaimModal = useCallback(() => {
     handleOnClose()
   }, [handleOnClose])
 
@@ -620,13 +636,13 @@ export const BuyWithCryptoModal = (props: Props) => {
           <Button primary onClick={handleTryAgainCreditsClaim}>
             {t('buy_with_crypto_modal.cross_chain_failed.try_again', { fallback: 'Try again' })}
           </Button>
-          <Button basic onClick={handleCloseFailedCreditsClaim}>
+          <Button basic onClick={handleCloseCreditsClaimModal}>
             {t('buy_with_crypto_modal.cross_chain_failed.close', { fallback: 'Close' })}
           </Button>
         </div>
       </div>
     )
-  }, [handleTryAgainCreditsClaim, handleCloseFailedCreditsClaim])
+  }, [handleTryAgainCreditsClaim, handleCloseCreditsClaimModal])
 
   const renderCrossChainSuccessContent = useCallback(() => {
     if (!creditsClaimProgress) return null
@@ -655,13 +671,13 @@ export const BuyWithCryptoModal = (props: Props) => {
               {t('buy_with_crypto_modal.cross_chain_polling.view_transaction', { fallback: 'View transaction' })}
             </a>
           ) : null}
-          <Button primary onClick={handleCloseFailedCreditsClaim}>
+          <Button primary onClick={handleCloseCreditsClaimModal}>
             {t('buy_with_crypto_modal.cross_chain_success.done', { fallback: 'Done' })}
           </Button>
         </div>
       </div>
     )
-  }, [creditsClaimProgress, handleCloseFailedCreditsClaim])
+  }, [creditsClaimProgress, handleCloseCreditsClaimModal])
 
   const handleShowChainSelector = useCallback(() => {
     setShowChainSelector(true)

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.tsx
@@ -43,6 +43,8 @@ const squidURL = config.get('SQUID_API_URL')
 
 export const CROSS_CHAIN_POLLING_TEST_ID = 'cross-chain-polling'
 export const CORAL_SCAN_LINK_TEST_ID = 'coral-scan-link'
+export const CROSS_CHAIN_FAILED_TEST_ID = 'cross-chain-failed'
+export const CROSS_CHAIN_SUCCESS_TEST_ID = 'cross-chain-success'
 
 export const BuyWithCryptoModal = (props: Props) => {
   const {
@@ -66,10 +68,13 @@ export const BuyWithCryptoModal = (props: Props) => {
     onBuyWithCredits,
     onGetMana,
     onClose,
-    onGoBack
+    onGoBack,
+    onClearCreditsClaimProgress
   } = props
 
   const isPollingCrossChain = creditsClaimProgress?.status === 'polling'
+  const isCrossChainFailed = creditsClaimProgress?.status === 'failed'
+  const isCrossChainSucceeded = creditsClaimProgress?.status === 'success'
 
   const crossChainSupportedChains = useRef<ChainId[]>([])
   const analytics = getAnalytics()
@@ -528,12 +533,27 @@ export const BuyWithCryptoModal = (props: Props) => {
   const renderCrossChainPollingContent = useCallback(() => {
     if (!creditsClaimProgress) return null
 
+    // Friendly, non-technical step copy. 'consuming' = origin tx mining (spending credits),
+    // 'registering' = bridged and finalizing the NAME on the destination.
+    const isConsuming = creditsClaimProgress.stage === 'consuming'
+    const title = isConsuming
+      ? t('buy_with_crypto_modal.cross_chain_polling.consuming_title', { fallback: 'Consuming your credits' })
+      : t('buy_with_crypto_modal.cross_chain_polling.registering_title', { fallback: 'Registering your NAME' })
+    const description = isConsuming
+      ? t('buy_with_crypto_modal.cross_chain_polling.consuming_description', {
+          fallback: 'Hang tight — this only takes a moment.'
+        })
+      : t('buy_with_crypto_modal.cross_chain_polling.registering_description', {
+          fallback: 'Almost done — finishing up your purchase.'
+        })
+
     return (
       <div className={styles.crossChainPollingContainer} data-testid={CROSS_CHAIN_POLLING_TEST_ID}>
         <div className={styles.crossChainPollingContent}>
           <Loader active size="large" inline />
-          <h3 className={styles.crossChainPollingTitle}>{t('buy_with_crypto_modal.cross_chain_polling.processing')}</h3>
-          <p className={styles.crossChainPollingDescription}>{t('buy_with_crypto_modal.cross_chain_polling.description')}</p>
+          <h3 className={styles.crossChainPollingTitle}>{title}</h3>
+          <p className={styles.crossChainPollingDescription}>{description}</p>
+          {/* Subtle, non-technical link to view the on-chain transaction. */}
           <a
             href={creditsClaimProgress.coralScanUrl}
             target="_blank"
@@ -542,7 +562,7 @@ export const BuyWithCryptoModal = (props: Props) => {
             data-testid={CORAL_SCAN_LINK_TEST_ID}
           >
             <Icon name="external alternate" />
-            {t('buy_with_crypto_modal.cross_chain_polling.track_on_coral_scan')}
+            {t('buy_with_crypto_modal.cross_chain_polling.view_transaction', { fallback: 'View transaction' })}
           </a>
           <p className={styles.crossChainPollingNote}>{t('buy_with_crypto_modal.cross_chain_polling.note')}</p>
         </div>
@@ -568,8 +588,80 @@ export const BuyWithCryptoModal = (props: Props) => {
         search: search.toString()
       })
     }
+    // Clear any failed claim progress so a future open starts clean (not on the failed view).
+    onClearCreditsClaimProgress?.()
     onClose()
-  }, [history, location.search, onClose])
+  }, [history, location.search, onClose, onClearCreditsClaimProgress])
+
+  // Retry a failed credits claim: clear the failed progress, then re-trigger the
+  // same credits payment flow (re-fetches a fresh route + re-signs + re-submits).
+  const handleTryAgainCreditsClaim = useCallback(() => {
+    onClearCreditsClaimProgress?.()
+    onPayWithCredits()
+  }, [onClearCreditsClaimProgress, onPayWithCredits])
+
+  const handleCloseFailedCreditsClaim = useCallback(() => {
+    handleOnClose()
+  }, [handleOnClose])
+
+  const renderCrossChainFailedContent = useCallback(() => {
+    return (
+      <div className={styles.crossChainPollingContainer} data-testid={CROSS_CHAIN_FAILED_TEST_ID}>
+        <div className={styles.crossChainPollingContent}>
+          <Icon name="warning circle" size="huge" color="red" />
+          <h3 className={styles.crossChainPollingTitle}>
+            {t('buy_with_crypto_modal.cross_chain_failed.title', { fallback: 'Something went wrong' })}
+          </h3>
+          <p className={styles.crossChainPollingDescription}>
+            {t('buy_with_crypto_modal.cross_chain_failed.description', {
+              fallback: "Your purchase didn't go through. Please try again."
+            })}
+          </p>
+          <Button primary onClick={handleTryAgainCreditsClaim}>
+            {t('buy_with_crypto_modal.cross_chain_failed.try_again', { fallback: 'Try again' })}
+          </Button>
+          <Button basic onClick={handleCloseFailedCreditsClaim}>
+            {t('buy_with_crypto_modal.cross_chain_failed.close', { fallback: 'Close' })}
+          </Button>
+        </div>
+      </div>
+    )
+  }, [handleTryAgainCreditsClaim, handleCloseFailedCreditsClaim])
+
+  const renderCrossChainSuccessContent = useCallback(() => {
+    if (!creditsClaimProgress) return null
+    // Destination tx (where the NAME was registered) → Etherscan; origin tx → its scan URL.
+    // Both links are deliberately neutral ("View transaction") — no chain/explorer jargon.
+    const destinationTxUrl = creditsClaimProgress.destinationTxHash
+      ? `https://etherscan.io/tx/${creditsClaimProgress.destinationTxHash}`
+      : null
+
+    return (
+      <div className={styles.crossChainPollingContainer} data-testid={CROSS_CHAIN_SUCCESS_TEST_ID}>
+        <div className={styles.crossChainPollingContent}>
+          <Icon name="check circle" size="huge" color="green" />
+          <h3 className={styles.crossChainPollingTitle}>
+            {t('buy_with_crypto_modal.cross_chain_success.title', { fallback: 'Your NAME is ready!' })}
+          </h3>
+          <p className={styles.crossChainPollingDescription}>
+            {t('buy_with_crypto_modal.cross_chain_success.description', {
+              name: creditsClaimProgress.name,
+              fallback: `${creditsClaimProgress.name}.dcl.eth is now yours.`
+            })}
+          </p>
+          {destinationTxUrl ? (
+            <a href={destinationTxUrl} target="_blank" rel="noopener noreferrer" className={styles.coralScanLink}>
+              <Icon name="external alternate" />
+              {t('buy_with_crypto_modal.cross_chain_polling.view_transaction', { fallback: 'View transaction' })}
+            </a>
+          ) : null}
+          <Button primary onClick={handleCloseFailedCreditsClaim}>
+            {t('buy_with_crypto_modal.cross_chain_success.done', { fallback: 'Done' })}
+          </Button>
+        </div>
+      </div>
+    )
+  }, [creditsClaimProgress, handleCloseFailedCreditsClaim])
 
   const handleShowChainSelector = useCallback(() => {
     setShowChainSelector(true)
@@ -610,6 +702,10 @@ export const BuyWithCryptoModal = (props: Props) => {
         <>
           {isPollingCrossChain ? (
             renderCrossChainPollingContent()
+          ) : isCrossChainSucceeded ? (
+            renderCrossChainSuccessContent()
+          ) : isCrossChainFailed ? (
+            renderCrossChainFailedContent()
           ) : showChainSelector || showTokenSelector ? (
             <div>
               {showChainSelector && wallet ? (
@@ -768,7 +864,7 @@ export const BuyWithCryptoModal = (props: Props) => {
           )}
         </>
       </Modal.Content>
-      {showChainSelector || showTokenSelector || isPollingCrossChain ? null : (
+      {showChainSelector || showTokenSelector || isPollingCrossChain || isCrossChainFailed || isCrossChainSucceeded ? null : (
         <Modal.Actions>
           <div className={classNames(styles.buttons, isWearableOrEmote(asset) && 'with-mana')}>{renderMainActionButton()}</div>
           {isWearableOrEmote(asset) && isBuyWithCardPage ? (

--- a/webapp/src/modules/ens/actions.ts
+++ b/webapp/src/modules/ens/actions.ts
@@ -2,7 +2,7 @@ import { action } from 'typesafe-actions'
 import { ChainId } from '@dcl/schemas'
 import { buildTransactionPayload } from 'decentraland-dapps/dist/modules/transaction/utils'
 import type { Route } from 'decentraland-transactions/crossChain'
-import { ENS, ENSError } from './types'
+import { CreditsClaimProgressStage, ENS, ENSError } from './types'
 
 // Claim a new name
 export const CLAIM_NAME_REQUEST = '[Request] Claim Name'
@@ -76,11 +76,17 @@ export const claimNameWithCreditsTransactionSubmitted = (subdomain: string, addr
     })
   })
 
-export const claimNameWithCreditsCrossChainPolling = (name: string, polygonTxHash: string, coralScanUrl: string) =>
+export const claimNameWithCreditsCrossChainPolling = (
+  name: string,
+  polygonTxHash: string,
+  coralScanUrl: string,
+  stage: CreditsClaimProgressStage = 'registering'
+) =>
   action(CLAIM_NAME_WITH_CREDITS_CROSS_CHAIN_POLLING, {
     name,
     polygonTxHash,
-    coralScanUrl
+    coralScanUrl,
+    stage
   })
 
 export const claimNameWithCreditsSuccess = (ens: ENS, name: string, txHash: string) =>

--- a/webapp/src/modules/ens/reducer.spec.ts
+++ b/webapp/src/modules/ens/reducer.spec.ts
@@ -122,7 +122,8 @@ describe('ENS Reducer', () => {
         },
         creditsClaimProgress: {
           ...initialState.creditsClaimProgress,
-          status: 'success'
+          status: 'success',
+          destinationTxHash: 'aTxHash'
         }
       })
     })
@@ -197,7 +198,8 @@ describe('ENS Reducer', () => {
           name: 'example',
           polygonTxHash: '0x123',
           coralScanUrl: 'https://coralscan.squidrouter.com/tx/0x123',
-          status: 'polling'
+          status: 'polling',
+          stage: 'registering'
         }
       })
     })

--- a/webapp/src/modules/ens/reducer.ts
+++ b/webapp/src/modules/ens/reducer.ts
@@ -73,14 +73,15 @@ export function ensReducer(state: ENSState = INITIAL_STATE, action: ENSReducerAc
     }
 
     case CLAIM_NAME_WITH_CREDITS_CROSS_CHAIN_POLLING: {
-      const { name, polygonTxHash, coralScanUrl } = action.payload
+      const { name, polygonTxHash, coralScanUrl, stage } = action.payload
       return {
         ...state,
         creditsClaimProgress: {
           name,
           polygonTxHash,
           coralScanUrl,
-          status: 'polling'
+          status: 'polling',
+          stage
         }
       }
     }
@@ -102,7 +103,7 @@ export function ensReducer(state: ENSState = INITIAL_STATE, action: ENSReducerAc
     }
 
     case CLAIM_NAME_WITH_CREDITS_SUCCESS: {
-      const { ens } = action.payload
+      const { ens, txHash } = action.payload
       return {
         ...state,
         loading: loadingReducer(state.loading, action),
@@ -113,7 +114,9 @@ export function ensReducer(state: ENSState = INITIAL_STATE, action: ENSReducerAc
             ...ens
           }
         },
-        creditsClaimProgress: state.creditsClaimProgress ? { ...state.creditsClaimProgress, status: 'success' } : null
+        creditsClaimProgress: state.creditsClaimProgress
+          ? { ...state.creditsClaimProgress, status: 'success', destinationTxHash: txHash }
+          : null
       }
     }
 
@@ -133,7 +136,15 @@ export function ensReducer(state: ENSState = INITIAL_STATE, action: ENSReducerAc
         ...state,
         loading: loadingReducer(state.loading, action),
         error,
-        creditsClaimProgress: state.creditsClaimProgress ? { ...state.creditsClaimProgress, status: 'failed' } : null
+        // Always surface a 'failed' progress so the modal can render the failure view
+        // (with a retry), even when the claim failed before cross-chain polling started
+        // (e.g. the Polygon useCredits tx reverted). Preserve any tx hash/scan URL we had.
+        creditsClaimProgress: {
+          name: action.payload.name,
+          polygonTxHash: state.creditsClaimProgress?.polygonTxHash ?? '',
+          coralScanUrl: state.creditsClaimProgress?.coralScanUrl ?? '',
+          status: 'failed'
+        }
       }
     }
 

--- a/webapp/src/modules/ens/sagas.spec.ts
+++ b/webapp/src/modules/ens/sagas.spec.ts
@@ -416,7 +416,7 @@ describe('ENS Saga', () => {
         mockIdentity = {} as AuthIdentity
       })
 
-      it('should show a route-unavailable toast, put a failure action with the route-unavailable message, and close the modal', () => {
+      it('should show a route-unavailable toast and put a failure action with the route-unavailable message (modal stays open for retry)', () => {
         const clientError = new Error('Server error: Something went wrong')
         const routeUnavailableMessage = t('toast.claim_name_with_credits_route_unavailable.body')
 
@@ -432,7 +432,6 @@ describe('ENS Saga', () => {
           ])
           .put(showToast(getClaimNameWithCreditsRouteUnavailableToast()))
           .put(claimNameWithCreditsFailure(mockName, routeUnavailableMessage))
-          .put(closeModal('BuyWithCryptoModal'))
           .dispatch(claimNameWithCreditsRequest(mockName))
           .silentRun()
       })
@@ -524,13 +523,13 @@ describe('ENS Saga', () => {
             [select(getCurrentIdentity), mockIdentity],
             [matchers.call.fn(CreditsClient.prototype.fetchCreditsNameRoute as (...args: unknown[]) => Promise<unknown>), mockRouteData],
             [matchers.call.fn(CreditsService.prototype.useCreditsWithExternalCall as (...args: unknown[]) => Promise<string>), mockTxHash],
+            [matchers.call.fn(waitForTx), null],
             [matchers.call.fn(pollSquidRouteStatus), mockSquidResponse],
             [matchers.call.fn(getTokenIdFromEthereumContract), mockTokenId]
           ])
           .put(claimNameWithCreditsTransactionSubmitted(mockName, mockWallet.address, ChainId.MATIC_MAINNET, mockTxHash))
           .put(claimNameWithCreditsCrossChainPolling(mockName, mockTxHash, coralScanUrl))
           .put(claimNameWithCreditsSuccess(expectedENS, mockName, '0xEthereumTxHash'))
-          .put(closeModal('BuyWithCryptoModal'))
           .dispatch(claimNameWithCreditsRequest(mockName))
           .silentRun()
       })
@@ -573,7 +572,7 @@ describe('ENS Saga', () => {
         mockTxHash = '0xTransactionHash'
       })
 
-      it('should dispatch transaction submitted, polling action, failure action, and close modal', () => {
+      it('should dispatch transaction submitted, polling action, and failure action (modal stays open for retry)', () => {
         const pollingError = new Error('Cross-chain transaction polling timeout')
         const coralScanUrl = `${CORAL_SCAN_BASE_URL}/${mockTxHash}`
 
@@ -584,12 +583,12 @@ describe('ENS Saga', () => {
             [select(getCurrentIdentity), mockIdentity],
             [matchers.call.fn(CreditsClient.prototype.fetchCreditsNameRoute as (...args: unknown[]) => Promise<unknown>), mockRouteData],
             [matchers.call.fn(CreditsService.prototype.useCreditsWithExternalCall as (...args: unknown[]) => Promise<string>), mockTxHash],
+            [matchers.call.fn(waitForTx), null],
             [matchers.call.fn(pollSquidRouteStatus), Promise.reject(pollingError)]
           ])
           .put(claimNameWithCreditsTransactionSubmitted(mockName, mockWallet.address, ChainId.MATIC_MAINNET, mockTxHash))
           .put(claimNameWithCreditsCrossChainPolling(mockName, mockTxHash, coralScanUrl))
           .put(claimNameWithCreditsFailure(mockName, pollingError.message))
-          .put(closeModal('BuyWithCryptoModal'))
           .dispatch(claimNameWithCreditsRequest(mockName))
           .silentRun()
       })

--- a/webapp/src/modules/ens/sagas.ts
+++ b/webapp/src/modules/ens/sagas.ts
@@ -211,24 +211,10 @@ export function* ensSaga() {
       // The credits-server returns Axelar/Squid (CORAL) or Across V4 calldata
       // depending on the ?provider query param.
       const providerName: ReturnType<typeof getCrossChainNameProvider> = yield select(getCrossChainNameProvider)
-      console.log('[NAME-CLAIM] Starting credits-paid claim', {
-        name,
-        wallet: wallet.address,
-        chainId: ChainId.MATIC_MAINNET,
-        provider: providerName,
-        creditsTotal: credits.totalCredits,
-        creditsCount: credits.credits?.length
-      })
 
       const creditsServerUrl = config.get('CREDITS_SERVER_URL')
       const creditsClient = new CreditsClient(creditsServerUrl, { identity })
       let routeData: CreditsNameRouteResponse & { provider?: 'axelar' | 'across' }
-      console.log('[NAME-CLAIM] Requesting route from credits-server', {
-        url: creditsServerUrl,
-        provider: providerName,
-        name,
-        chainId: ChainId.MATIC_MAINNET
-      })
       try {
         if (providerName === 'across') {
           // CreditsClient.fetchCreditsNameRoute doesn't expose a `provider` param yet,
@@ -245,20 +231,7 @@ export function* ensSaga() {
         } else {
           routeData = (yield call([creditsClient, 'fetchCreditsNameRoute'], name, ChainId.MATIC_MAINNET)) as CreditsNameRouteResponse
         }
-        console.log('[NAME-CLAIM] Route received from credits-server', {
-          provider: (routeData as any).provider || 'axelar',
-          target: routeData.externalCall?.target,
-          selector: routeData.externalCall?.selector,
-          dataLength: routeData.externalCall?.data?.length,
-          expiresAt: routeData.externalCall?.expiresAt,
-          salt: routeData.externalCall?.salt,
-          quoteId: routeData.quoteId,
-          estimatedRouteDurationSec: routeData.estimatedRouteDuration,
-          fromChainId: routeData.fromChainId,
-          toChainId: routeData.toChainId
-        })
       } catch (routeError) {
-        console.error('[NAME-CLAIM] Failed to fetch route', { error: routeError, provider: providerName })
         captureException(routeError, { tags: { saga: 'handleClaimNameWithCreditsRequest', phase: 'fetch-route', provider: providerName } })
         const routeUnavailableMessage = t('toast.claim_name_with_credits_route_unavailable.body')
         yield put(showToast(getClaimNameWithCreditsRouteUnavailableToast()))
@@ -267,12 +240,6 @@ export function* ensSaga() {
         yield put(claimNameWithCreditsFailure(name, routeUnavailableMessage))
         return
       }
-
-      console.log('[NAME-CLAIM] Submitting useCredits tx on Polygon', {
-        provider: (routeData as any).provider,
-        externalCallTarget: routeData.externalCall.target,
-        externalCallSelector: routeData.externalCall.selector
-      })
 
       const creditsService = new CreditsService()
       const txHash = (yield call(
@@ -283,10 +250,6 @@ export function* ensSaga() {
         routeData.externalCall,
         routeData.customExternalCallSignature
       )) as string
-      console.log('[NAME-CLAIM] useCredits tx submitted', {
-        txHash,
-        polygonscanUrl: `https://polygonscan.com/tx/${txHash}`
-      })
 
       // Dispatch transaction submitted action (registers the tx for tracking)
       yield put(claimNameWithCreditsTransactionSubmitted(name, wallet.address, ChainId.MATIC_MAINNET, txHash))
@@ -307,10 +270,6 @@ export function* ensSaga() {
       try {
         yield call(waitForTx, txHash)
       } catch (txError) {
-        console.error('[NAME-CLAIM] useCredits tx reverted on Polygon — no bridge deposit was made', {
-          txHash,
-          error: txError
-        })
         captureException(txError, {
           tags: { saga: 'handleClaimNameWithCreditsRequest', phase: 'wait-polygon-tx', provider: providerName }
         })
@@ -329,7 +288,6 @@ export function* ensSaga() {
       try {
         let ethereumTxHash: string
         if (isAcross) {
-          console.log('[NAME-CLAIM] Polling Across status', { txHash, scanUrl })
           // Poll Across status until the deposit reaches a terminal state.
           const acrossResult: { destinationTxHash: string | null; status: string; actionsSucceeded: boolean } = (yield call(
             pollAcrossRouteStatus,
@@ -339,11 +297,12 @@ export function* ensSaga() {
             status: string
             actionsSucceeded: boolean
           }
-          console.log('[NAME-CLAIM] Across polling resolved', acrossResult)
           // Success requires BOTH a fill AND the destination actions (the register) to
           // have succeeded. A filled deposit whose actions reverted means the bridged MANA
           // went to the recovery wallet and the NAME was NOT minted — treat as failure.
-          if (acrossResult.status !== 'filled' || !acrossResult.actionsSucceeded) {
+          // Require actionsSucceeded === true explicitly so that a future `filled` response
+          // missing the field (which defaults to true upstream) can't mask a failed register.
+          if (acrossResult.status !== 'filled' || acrossResult.actionsSucceeded !== true) {
             throw new Error(
               `Across delivery did not complete the registration (status: ${acrossResult.status}, actionsSucceeded: ${acrossResult.actionsSucceeded})`
             )
@@ -351,12 +310,6 @@ export function* ensSaga() {
           // The fill hash is the Ethereum-side tx; fall back to the origin tx for the tokenId lookup.
           ethereumTxHash = acrossResult.destinationTxHash || txHash
         } else {
-          console.log('[NAME-CLAIM] Polling Squid status', {
-            txHash,
-            fromChainId: routeData.fromChainId,
-            toChainId: routeData.toChainId,
-            quoteId: routeData.quoteId
-          })
           // Poll for cross-chain transaction completion via Squid
           const statusResponse: SquidStatusResponse = yield call(pollSquidRouteStatus, {
             transactionId: txHash,
@@ -366,16 +319,8 @@ export function* ensSaga() {
             integratorId: squidIntegratorId,
             apiUrl: squidRouterApiUrl
           })
-          console.log('[NAME-CLAIM] Squid polling resolved', {
-            squidStatus: (statusResponse as any).squidTransactionStatus,
-            ethereumTxHash: statusResponse.toChain?.transactionId
-          })
           ethereumTxHash = statusResponse.toChain?.transactionId || txHash
         }
-        console.log('[NAME-CLAIM] Destination tx detected', {
-          ethereumTxHash,
-          etherscanUrl: `https://etherscan.io/tx/${ethereumTxHash}`
-        })
 
         // Get the real tokenId from the DCLRegistrar contract on Ethereum
         // The polling success means the Ethereum tx is confirmed, so we can query the contract
@@ -454,12 +399,7 @@ async function pollAcrossRouteStatus(
     const url = `${apiUrl}/deposit/status?originChainId=137&depositTxHash=${originChainTxHash}`
     const response = await fetch(url)
     if (!response.ok) {
-      console.warn('[NAME-CLAIM][ACROSS-POLL] non-ok response, will retry', {
-        attempt: i + 1,
-        maxAttempts,
-        status: response.status,
-        statusText: response.statusText
-      })
+      // Transient non-ok (e.g. the deposit isn't indexed yet) — back off and retry.
       await new Promise(resolve => setTimeout(resolve, intervalMs))
       continue
     }
@@ -478,14 +418,12 @@ async function pollAcrossRouteStatus(
     const status = (data.status || 'pending').toLowerCase()
     const fillTx = data.fillTx || data.fillTxnRef || null
     const actionsSucceeded = data.actionsSucceeded !== false
-    console.log('[NAME-CLAIM][ACROSS-POLL] tick', { attempt: i + 1, status, fillTx, actionsSucceeded })
 
     if (status === 'filled') {
       // Filled is terminal — resolve regardless of whether the fill hash is present yet.
       return { destinationTxHash: fillTx, status, actionsSucceeded }
     }
     if (status === 'refunded' || status === 'expired') {
-      console.warn('[NAME-CLAIM][ACROSS-POLL] terminal failure detected', { status })
       return { destinationTxHash: null, status, actionsSucceeded: false }
     }
     await new Promise(resolve => setTimeout(resolve, intervalMs))

--- a/webapp/src/modules/ens/sagas.ts
+++ b/webapp/src/modules/ens/sagas.ts
@@ -22,6 +22,7 @@ import { DCLRegistrar } from '../../contracts/DCLRegistrar'
 import { DCLRegistrar__factory } from '../../contracts/factories/DCLRegistrar__factory'
 import { isErrorWithMessage } from '../../lib/error'
 import { pollSquidRouteStatus, SquidStatusResponse } from '../../lib/squid'
+import { getCrossChainNameProvider } from '../features/selectors'
 import { getCurrentIdentity } from '../identity/selectors'
 import { getClaimNameWithCreditsRouteUnavailableToast } from '../toast/toasts'
 import { getWallet } from '../wallet/selectors'
@@ -163,10 +164,15 @@ export function* ensSaga() {
         throw new Error('A connected provider is required claim a name')
       }
 
-      const crossChainModule = import('decentraland-transactions/crossChain')
-      const { AxelarProvider }: Awaited<typeof crossChainModule> = (yield crossChainModule) as Awaited<typeof crossChainModule>
+      // Crypto-paid claim (NOT credits) — always uses Axelar/Squid. The user signs
+      // the bridge tx themselves with their own MANA, so the Across V4 alternative
+      // doesn't apply (there's no executor in the middle to refactor). The credits-paid
+      // saga below is where we branch on `provider`.
+      const crossChainModule = (yield import(
+        'decentraland-transactions/crossChain'
+      )) as typeof import('decentraland-transactions/crossChain')
+      const crossChainProvider = new crossChainModule.AxelarProvider(config.get('SQUID_API_URL'))
 
-      const crossChainProvider = new AxelarProvider(config.get('SQUID_API_URL'))
       const txResponse: ethers.providers.TransactionReceipt = (yield call(
         [crossChainProvider, 'executeRoute'],
         route,
@@ -201,55 +207,175 @@ export function* ensSaga() {
         throw new Error('No identity available for signed fetch')
       }
 
+      // Pick the bridge provider based on the feature flag variant.
+      // The credits-server returns Axelar/Squid (CORAL) or Across V4 calldata
+      // depending on the ?provider query param.
+      const providerName: ReturnType<typeof getCrossChainNameProvider> = yield select(getCrossChainNameProvider)
+      console.log('[NAME-CLAIM] Starting credits-paid claim', {
+        name,
+        wallet: wallet.address,
+        chainId: ChainId.MATIC_MAINNET,
+        provider: providerName,
+        creditsTotal: credits.totalCredits,
+        creditsCount: credits.credits?.length
+      })
+
       const creditsServerUrl = config.get('CREDITS_SERVER_URL')
       const creditsClient = new CreditsClient(creditsServerUrl, { identity })
-      let routeData: CreditsNameRouteResponse
+      let routeData: CreditsNameRouteResponse & { provider?: 'axelar' | 'across' }
+      console.log('[NAME-CLAIM] Requesting route from credits-server', {
+        url: creditsServerUrl,
+        provider: providerName,
+        name,
+        chainId: ChainId.MATIC_MAINNET
+      })
       try {
-        routeData = (yield call([creditsClient, 'fetchCreditsNameRoute'], name, ChainId.MATIC_MAINNET)) as CreditsNameRouteResponse
+        if (providerName === 'across') {
+          // CreditsClient.fetchCreditsNameRoute doesn't expose a `provider` param yet,
+          // so we hit the endpoint directly here. Once dapps adds the param this can
+          // be simplified.
+          routeData = (yield call(
+            fetchCreditsNameRouteWithProvider,
+            creditsServerUrl,
+            identity,
+            name,
+            ChainId.MATIC_MAINNET,
+            'across'
+          )) as CreditsNameRouteResponse & { provider: 'across' }
+        } else {
+          routeData = (yield call([creditsClient, 'fetchCreditsNameRoute'], name, ChainId.MATIC_MAINNET)) as CreditsNameRouteResponse
+        }
+        console.log('[NAME-CLAIM] Route received from credits-server', {
+          provider: (routeData as any).provider || 'axelar',
+          target: routeData.externalCall?.target,
+          selector: routeData.externalCall?.selector,
+          dataLength: routeData.externalCall?.data?.length,
+          expiresAt: routeData.externalCall?.expiresAt,
+          salt: routeData.externalCall?.salt,
+          quoteId: routeData.quoteId,
+          estimatedRouteDurationSec: routeData.estimatedRouteDuration,
+          fromChainId: routeData.fromChainId,
+          toChainId: routeData.toChainId
+        })
       } catch (routeError) {
-        captureException(routeError, { tags: { saga: 'handleClaimNameWithCreditsRequest', phase: 'fetch-route' } })
+        console.error('[NAME-CLAIM] Failed to fetch route', { error: routeError, provider: providerName })
+        captureException(routeError, { tags: { saga: 'handleClaimNameWithCreditsRequest', phase: 'fetch-route', provider: providerName } })
         const routeUnavailableMessage = t('toast.claim_name_with_credits_route_unavailable.body')
         yield put(showToast(getClaimNameWithCreditsRouteUnavailableToast()))
+        // Keep the modal open and surface the failure view (with retry) instead of
+        // closing — the failed creditsClaimProgress drives the modal's failed state.
         yield put(claimNameWithCreditsFailure(name, routeUnavailableMessage))
-        yield put(closeModal('BuyWithCryptoModal'))
         return
       }
 
-      // Use CreditsService to handle the transaction
+      console.log('[NAME-CLAIM] Submitting useCredits tx on Polygon', {
+        provider: (routeData as any).provider,
+        externalCallTarget: routeData.externalCall.target,
+        externalCallSelector: routeData.externalCall.selector
+      })
+
       const creditsService = new CreditsService()
-      const txHash: string = yield call(
+      const txHash = (yield call(
         [creditsService, 'useCreditsWithExternalCall'],
         PRICE_IN_WEI,
         credits.credits,
         ChainId.MATIC_MAINNET,
         routeData.externalCall,
         routeData.customExternalCallSignature
-      )
+      )) as string
+      console.log('[NAME-CLAIM] useCredits tx submitted', {
+        txHash,
+        polygonscanUrl: `https://polygonscan.com/tx/${txHash}`
+      })
 
-      // Dispatch transaction submitted action
+      // Dispatch transaction submitted action (registers the tx for tracking)
       yield put(claimNameWithCreditsTransactionSubmitted(name, wallet.address, ChainId.MATIC_MAINNET, txHash))
 
-      // Dispatch polling action with CoralScan URL - the modal will show this link
-      const coralScanUrl = `${CORAL_SCAN_BASE_URL}/${txHash}`
-      yield put(claimNameWithCreditsCrossChainPolling(name, txHash, coralScanUrl))
+      // The origin-tx link: Across's explorer has no reliable public deep-link for a single
+      // deposit (the /transactions/<hash> route 404s), so for Across we link the origin tx on
+      // Polygonscan, which always resolves. Squid keeps using CoralScan.
+      const isAcross = routeData.provider === 'across' || providerName === 'across'
+      const scanUrl = isAcross ? `https://polygonscan.com/tx/${txHash}` : `${CORAL_SCAN_BASE_URL}/${txHash}`
 
-      // Get Squid Router API configuration
+      // Stage 1 — "consuming credits": the origin (Polygon) tx is mining.
+      yield put(claimNameWithCreditsCrossChainPolling(name, txHash, scanUrl, 'consuming'))
+
+      // Wait for the Polygon useCredits tx to actually mine BEFORE moving to the next stage.
+      // If it reverts (e.g. the executor's Chainlink staleness check, an InvalidTarget, etc.),
+      // no bridge deposit was ever made — surface a friendly failure instead of a stuck tracker.
+      // waitForTx throws on a reverted/failed tx.
+      try {
+        yield call(waitForTx, txHash)
+      } catch (txError) {
+        console.error('[NAME-CLAIM] useCredits tx reverted on Polygon — no bridge deposit was made', {
+          txHash,
+          error: txError
+        })
+        captureException(txError, {
+          tags: { saga: 'handleClaimNameWithCreditsRequest', phase: 'wait-polygon-tx', provider: providerName }
+        })
+        yield put(showToast(getClaimNameWithCreditsRouteUnavailableToast()))
+        yield put(claimNameWithCreditsFailure(name, t('toast.claim_name_with_credits_route_unavailable.body')))
+        return
+      }
+
+      // Stage 2 — "registering NAME": origin tx confirmed; now bridging + registering on destination.
+      yield put(claimNameWithCreditsCrossChainPolling(name, txHash, scanUrl, 'registering'))
+
+      // Get Squid Router API configuration (only used in the Axelar path)
       const squidRouterApiUrl = config.get('REACT_APP_SQUID_ROUTER_API_URL', 'https://v2.api.squidrouter.com')
       const squidIntegratorId = config.get('REACT_APP_SQUID_INTEGRATOR_ID', 'decentraland-sdk-coral-test')
 
       try {
-        // Poll for cross-chain transaction completion
-        const statusResponse: SquidStatusResponse = yield call(pollSquidRouteStatus, {
-          transactionId: txHash,
-          fromChainId: routeData.fromChainId,
-          toChainId: routeData.toChainId,
-          quoteId: routeData.quoteId,
-          integratorId: squidIntegratorId,
-          apiUrl: squidRouterApiUrl
+        let ethereumTxHash: string
+        if (isAcross) {
+          console.log('[NAME-CLAIM] Polling Across status', { txHash, scanUrl })
+          // Poll Across status until the deposit reaches a terminal state.
+          const acrossResult: { destinationTxHash: string | null; status: string; actionsSucceeded: boolean } = (yield call(
+            pollAcrossRouteStatus,
+            txHash
+          )) as {
+            destinationTxHash: string | null
+            status: string
+            actionsSucceeded: boolean
+          }
+          console.log('[NAME-CLAIM] Across polling resolved', acrossResult)
+          // Success requires BOTH a fill AND the destination actions (the register) to
+          // have succeeded. A filled deposit whose actions reverted means the bridged MANA
+          // went to the recovery wallet and the NAME was NOT minted — treat as failure.
+          if (acrossResult.status !== 'filled' || !acrossResult.actionsSucceeded) {
+            throw new Error(
+              `Across delivery did not complete the registration (status: ${acrossResult.status}, actionsSucceeded: ${acrossResult.actionsSucceeded})`
+            )
+          }
+          // The fill hash is the Ethereum-side tx; fall back to the origin tx for the tokenId lookup.
+          ethereumTxHash = acrossResult.destinationTxHash || txHash
+        } else {
+          console.log('[NAME-CLAIM] Polling Squid status', {
+            txHash,
+            fromChainId: routeData.fromChainId,
+            toChainId: routeData.toChainId,
+            quoteId: routeData.quoteId
+          })
+          // Poll for cross-chain transaction completion via Squid
+          const statusResponse: SquidStatusResponse = yield call(pollSquidRouteStatus, {
+            transactionId: txHash,
+            fromChainId: routeData.fromChainId,
+            toChainId: routeData.toChainId,
+            quoteId: routeData.quoteId,
+            integratorId: squidIntegratorId,
+            apiUrl: squidRouterApiUrl
+          })
+          console.log('[NAME-CLAIM] Squid polling resolved', {
+            squidStatus: (statusResponse as any).squidTransactionStatus,
+            ethereumTxHash: statusResponse.toChain?.transactionId
+          })
+          ethereumTxHash = statusResponse.toChain?.transactionId || txHash
+        }
+        console.log('[NAME-CLAIM] Destination tx detected', {
+          ethereumTxHash,
+          etherscanUrl: `https://etherscan.io/tx/${ethereumTxHash}`
         })
-
-        // Extract the Ethereum (destination chain) transaction hash
-        const ethereumTxHash = statusResponse.toChain?.transactionId || txHash
 
         // Get the real tokenId from the DCLRegistrar contract on Ethereum
         // The polling success means the Ethereum tx is confirmed, so we can query the contract
@@ -267,13 +393,12 @@ export function* ensSaga() {
           contractAddress: REGISTRAR_ADDRESS
         }
 
-        // Dispatch success action with the Ethereum transaction hash
+        // Dispatch success action with the Ethereum transaction hash. The modal stays open
+        // and shows the success view (the saga no longer force-closes it).
         yield put(claimNameWithCreditsSuccess(ens, name, ethereumTxHash))
-        // Close modal after success
-        yield put(closeModal('BuyWithCryptoModal'))
       } catch (pollingError) {
         captureException(pollingError, { tags: { saga: 'handleClaimNameWithCreditsRequest', phase: 'polling' } })
-        // Dispatch failure action
+        // Surface the failure view (with retry) in the modal instead of closing.
         yield put(
           claimNameWithCreditsFailure(
             name,
@@ -282,8 +407,6 @@ export function* ensSaga() {
               : 'Cross-chain transaction failed. Please check the Activity page for details.'
           )
         )
-        // Close modal after failure - user will see error in toast/notification
-        yield put(closeModal('BuyWithCryptoModal'))
       }
     } catch (error) {
       captureException(error, { tags: { saga: 'handleClaimNameWithCreditsRequest', phase: 'setup' } })
@@ -291,4 +414,81 @@ export function* ensSaga() {
       // Don't close modal here - error will be shown in the modal UI
     }
   }
+}
+
+/**
+ * Hits the credits-server `/credits-name-route` endpoint with a `provider` query param.
+ * The vanilla `CreditsClient.fetchCreditsNameRoute` doesn't expose this param yet —
+ * once `decentraland-dapps` updates the client signature, this helper can be removed.
+ */
+async function fetchCreditsNameRouteWithProvider(
+  creditsServerUrl: string,
+  identity: AuthIdentity,
+  name: string,
+  chainId: ChainId,
+  provider: 'axelar' | 'across'
+): Promise<CreditsNameRouteResponse & { provider: 'axelar' | 'across' }> {
+  const url = `${creditsServerUrl}/credits-name-route?name=${encodeURIComponent(name)}&chainId=${chainId}&provider=${provider}`
+  // decentraland-crypto-fetch exposes a default-exported signed fetch.
+  const signedFetch = (await import('decentraland-crypto-fetch')).default
+  const response = await signedFetch(url, { method: 'GET', identity })
+  if (!response.ok) {
+    throw new Error(`Credits route request failed: ${response.status} ${response.statusText}`)
+  }
+  return response.json() as Promise<CreditsNameRouteResponse & { provider: 'axelar' | 'across' }>
+}
+
+/**
+ * Poll Across status API until we observe the destination tx or a terminal failure.
+ * Across exposes the deposit status via their app API: /api/deposit/status?originChainId=137&depositId=<txHash>
+ * Status values: 'pending' | 'filled' | 'expired' | 'refunded'
+ */
+async function pollAcrossRouteStatus(
+  originChainTxHash: string
+): Promise<{ destinationTxHash: string | null; status: string; actionsSucceeded: boolean }> {
+  const apiUrl = config.get('ACROSS_API_URL', 'https://app.across.to/api')
+  const maxAttempts = 60 // ~10 min with 10s intervals
+  const intervalMs = 10_000
+
+  for (let i = 0; i < maxAttempts; i++) {
+    const url = `${apiUrl}/deposit/status?originChainId=137&depositTxHash=${originChainTxHash}`
+    const response = await fetch(url)
+    if (!response.ok) {
+      console.warn('[NAME-CLAIM][ACROSS-POLL] non-ok response, will retry', {
+        attempt: i + 1,
+        maxAttempts,
+        status: response.status,
+        statusText: response.statusText
+      })
+      await new Promise(resolve => setTimeout(resolve, intervalMs))
+      continue
+    }
+    // Across `/deposit/status` returns the destination fill hash as `fillTx` / `fillTxnRef`
+    // (NOT `fillTxHash`), and `actionsSucceeded` tells us whether the embedded
+    // MulticallHandler actions (approve + register + sweep) ran — i.e. whether the NAME
+    // was actually minted. If `actionsSucceeded` is false, the deposit filled but the
+    // register reverted and the bridged MANA went to the recovery wallet.
+    const data: {
+      status?: string
+      fillTx?: string
+      fillTxnRef?: string
+      depositRefundTxHash?: string | null
+      actionsSucceeded?: boolean
+    } = await response.json()
+    const status = (data.status || 'pending').toLowerCase()
+    const fillTx = data.fillTx || data.fillTxnRef || null
+    const actionsSucceeded = data.actionsSucceeded !== false
+    console.log('[NAME-CLAIM][ACROSS-POLL] tick', { attempt: i + 1, status, fillTx, actionsSucceeded })
+
+    if (status === 'filled') {
+      // Filled is terminal — resolve regardless of whether the fill hash is present yet.
+      return { destinationTxHash: fillTx, status, actionsSucceeded }
+    }
+    if (status === 'refunded' || status === 'expired') {
+      console.warn('[NAME-CLAIM][ACROSS-POLL] terminal failure detected', { status })
+      return { destinationTxHash: null, status, actionsSucceeded: false }
+    }
+    await new Promise(resolve => setTimeout(resolve, intervalMs))
+  }
+  throw new Error('Across status polling timed out after 10 minutes')
 }

--- a/webapp/src/modules/ens/types.ts
+++ b/webapp/src/modules/ens/types.ts
@@ -50,9 +50,17 @@ export type WorldStatus = {
 
 export type CreditsClaimProgressStatus = 'polling' | 'success' | 'failed'
 
+// Sub-stage within the 'polling' status, to drive a friendly step-by-step UI:
+//  - 'consuming'   → the origin (Polygon) tx is being mined (credits being spent)
+//  - 'registering' → the origin tx is done; the NAME is being registered on the destination
+export type CreditsClaimProgressStage = 'consuming' | 'registering'
+
 export type CreditsClaimProgress = {
   name: string
   polygonTxHash: string
   coralScanUrl: string
   status: CreditsClaimProgressStatus
+  stage?: CreditsClaimProgressStage
+  // Destination (Ethereum) tx hash where the NAME was registered — set on success.
+  destinationTxHash?: string
 }

--- a/webapp/src/modules/features/selectors.ts
+++ b/webapp/src/modules/features/selectors.ts
@@ -1,4 +1,5 @@
 import {
+  getFeatureVariant,
   getIsFeatureEnabled,
   getLoading,
   hasLoadedInitialFlags,
@@ -8,6 +9,8 @@ import { ApplicationName } from 'decentraland-dapps/dist/modules/features/types'
 import { RootState } from '../reducer'
 import { getWallet } from '../wallet/selectors'
 import { FeatureName } from './types'
+
+export type CrossChainNameProvider = 'axelar' | 'across'
 
 export const isLoadingFeatureFlags = (state: RootState) => {
   return getLoading(state)
@@ -118,4 +121,23 @@ export const getIsNAMEsWithCreditsEnabled = (state: RootState) => {
     return getIsFeatureEnabled(state, ApplicationName.MARKETPLACE, FeatureName.NAMES_WITH_CREDITS)
   }
   return false
+}
+
+/**
+ * Reads which cross-chain bridge provider should be used for the name-claim flow.
+ * The `names-with-credits` feature flag supports two variants:
+ *   - payload.value === 'across'  → Across V4 (SpokePoolPeriphery + MulticallHandler)
+ *   - payload.value === 'axelar'  → Axelar/Squid/CORAL (legacy default)
+ * If no variant is configured or it's not recognised, defaults to 'axelar'
+ * so we don't accidentally route traffic to an unintended path.
+ */
+export const getCrossChainNameProvider = (state: RootState): CrossChainNameProvider => {
+  try {
+    const variant = getFeatureVariant(state, ApplicationName.MARKETPLACE, FeatureName.NAMES_WITH_CREDITS)
+    const value = variant?.payload?.value?.toLowerCase()
+    if (value === 'across') return 'across'
+    return 'axelar'
+  } catch (e) {
+    return 'axelar'
+  }
 }

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -913,8 +913,24 @@
       "title": "Processing Purchase",
       "processing": "Processing your cross-chain transaction...",
       "description": "Your transaction is being processed across chains. This may take a few minutes.",
+      "consuming_title": "Consuming your credits",
+      "consuming_description": "Hang tight — this only takes a moment.",
+      "registering_title": "Registering your NAME",
+      "registering_description": "Almost done — finishing up your purchase.",
       "track_on_coral_scan": "Track on CoralScan",
+      "view_transaction": "View transaction",
       "note": "Please keep this window open. You will be redirected automatically when the transaction completes."
+    },
+    "cross_chain_success": {
+      "title": "Your NAME is ready!",
+      "description": "{name}.dcl.eth is now yours.",
+      "done": "Done"
+    },
+    "cross_chain_failed": {
+      "title": "Something went wrong",
+      "description": "Your purchase didn't go through. Please try again.",
+      "try_again": "Try again",
+      "close": "Close"
     }
   },
   "partially_supported_network_card": {

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -896,8 +896,24 @@
       "title": "Procesando compra",
       "processing": "Procesando tu transacción cruzada...",
       "description": "Tu transacción está siendo procesada a través de redes. Esto puede tomar unos minutos.",
+      "consuming_title": "Usando tus créditos",
+      "consuming_description": "Aguantá un momento — esto tarda solo unos segundos.",
+      "registering_title": "Registrando tu NAME",
+      "registering_description": "Ya casi — estamos finalizando tu compra.",
       "track_on_coral_scan": "Seguir en CoralScan",
+      "view_transaction": "Ver transacción",
       "note": "Por favor, mantén esta ventana abierta. Serás redirigido automáticamente cuando la transacción se complete."
+    },
+    "cross_chain_success": {
+      "title": "¡Tu NAME está listo!",
+      "description": "{name}.dcl.eth ya es tuyo.",
+      "done": "Listo"
+    },
+    "cross_chain_failed": {
+      "title": "Algo salió mal",
+      "description": "Tu compra no se completó. Por favor, intentá de nuevo.",
+      "try_again": "Intentar de nuevo",
+      "close": "Cerrar"
     }
   },
   "partially_supported_network_card": {

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -898,8 +898,24 @@
       "title": "处理购买",
       "processing": "处理您的跨链交易...",
       "description": "您的交易正在跨链处理。这可能需要几分钟。",
+      "consuming_title": "正在使用您的积分",
+      "consuming_description": "请稍候 — 只需片刻。",
+      "registering_title": "正在注册您的 NAME",
+      "registering_description": "即将完成 — 正在收尾您的购买。",
       "track_on_coral_scan": "在 CoralScan 上跟踪",
+      "view_transaction": "查看交易",
       "note": "请保持此窗口打开。当交易完成时，您将被自动重定向。"
+    },
+    "cross_chain_success": {
+      "title": "您的 NAME 已就绪！",
+      "description": "{name}.dcl.eth 现在归您所有。",
+      "done": "完成"
+    },
+    "cross_chain_failed": {
+      "title": "出了点问题",
+      "description": "您的购买未完成。请重试。",
+      "try_again": "重试",
+      "close": "关闭"
     }
   },
   "partially_supported_network_card": {


### PR DESCRIPTION
## What

Adds **Across V4** as a cross-chain bridge provider for the credit-paid NAME claim, selectable via the `names-with-credits` feature flag, alongside the existing Axelar/Squid (CORAL) path.

When the flag variant is `across`, the credits-paid claim:
1. Fetches the route from the credits-server with `?provider=across` (the server builds the Across `externalCall` targeting the Across executor).
2. Submits `useCreditsWithExternalCall` on Polygon (consuming credits).
3. Waits for the origin tx to mine, then polls Across `/deposit/status` until the destination fill.
4. On a successful fill **with** the register having run, shows the NAME as ready.

The default remains `axelar` — no behavior change unless the flag variant is explicitly set to `across`.

## Why

Axelar GMP refunds were intermittently failing on the credit flow, burning credits. Across V4's relayer-fronted fills + recovery wallet give a more reliable settlement path for the executor-driven register.

## Key details

- **`features/selectors.ts`** — new `getCrossChainNameProvider` reads the flag variant (`'across' | 'axelar'`, defaults to `'axelar'`).
- **`ens/sagas.ts`** — branches on provider. For Across it polls deposit status and requires **both** a `filled` status **and** `actionsSucceeded`. A filled deposit whose embedded register reverted means the bridged MANA went to the recovery wallet and the NAME was *not* minted — that's treated as a failure, not a success. The saga also waits for the Polygon `useCredits` tx to mine before advancing, so a reverted origin tx surfaces a friendly failure instead of a stuck tracker.
- **`BuyWithCryptoModal.tsx`** — staged, non-technical progress UI (*Consuming your credits* → *Registering your NAME*) plus dedicated **success** and **failure (with retry)** views. The saga no longer force-closes the modal; the user sees the outcome.
- **Transaction link** — an Across deposit has no reliable public explorer deep-link (the app's `/transactions/<hash>` route 404s), so the origin tx is linked on Polygonscan.
- **i18n** — en/es/zh copy for the new stages and the success/failure views.

The Across `/deposit/status` field handling (`fillTx`/`fillTxnRef`, `actionsSucceeded`) matches the indexer side in credits-squid-core#25.

## Notes / follow-ups

- This PR does **not** touch dependencies — the Across route is built server-side and the deposit status is polled directly, so no `decentraland-transactions` change is required for the credits flow.
- Depends on the credits-server `?provider=across` route (already merged) and an Across executor allowlisted on the production CreditsManager.

## Testing

- `ens` saga + reducer unit tests updated and green (26/26).
- `tsc --noEmit` clean; eslint clean.