### PR TITLE
feat: handle ROUTE_COST_TOO_HIGH as a retryable network-cost message

### DIFF
--- a/webapp/src/modules/ens/sagas.ts
+++ b/webapp/src/modules/ens/sagas.ts
@@ -24,7 +24,7 @@ import { isErrorWithMessage } from '../../lib/error'
 import { pollSquidRouteStatus, SquidStatusResponse } from '../../lib/squid'
 import { getCrossChainNameProvider } from '../features/selectors'
 import { getCurrentIdentity } from '../identity/selectors'
-import { getClaimNameWithCreditsRouteUnavailableToast } from '../toast/toasts'
+import { getClaimNameWithCreditsCostUnavailableToast, getClaimNameWithCreditsRouteUnavailableToast } from '../toast/toasts'
 import { getWallet } from '../wallet/selectors'
 import {
   CLAIM_NAME_REQUEST,
@@ -233,10 +233,17 @@ export function* ensSaga() {
         }
       } catch (routeError) {
         captureException(routeError, { tags: { saga: 'handleClaimNameWithCreditsRequest', phase: 'fetch-route', provider: providerName } })
+        // Keep the modal open and surface the failure view (with retry) instead of closing —
+        // the failed creditsClaimProgress drives the modal's failed state.
+        if (routeError instanceof RouteCostTooHighError) {
+          // The route is withheld because the bridge cost is over budget right now. Tell the
+          // user it's a temporary, network-cost condition and to try again later.
+          yield put(showToast(getClaimNameWithCreditsCostUnavailableToast()))
+          yield put(claimNameWithCreditsFailure(name, t('toast.claim_name_with_credits_cost_unavailable.body')))
+          return
+        }
         const routeUnavailableMessage = t('toast.claim_name_with_credits_route_unavailable.body')
         yield put(showToast(getClaimNameWithCreditsRouteUnavailableToast()))
-        // Keep the modal open and surface the failure view (with retry) instead of
-        // closing — the failed creditsClaimProgress drives the modal's failed state.
         yield put(claimNameWithCreditsFailure(name, routeUnavailableMessage))
         return
       }
@@ -366,6 +373,18 @@ export function* ensSaga() {
  * The vanilla `CreditsClient.fetchCreditsNameRoute` doesn't expose this param yet —
  * once `decentraland-dapps` updates the client signature, this helper can be removed.
  */
+/**
+ * Thrown when the credits-server withholds the route because the Across bridge cost exceeds
+ * what the executor can cover (HTTP 503 + code ROUTE_COST_TOO_HIGH). Distinct from a generic
+ * route failure so the saga can show a "temporarily unavailable due to network costs" message.
+ */
+export class RouteCostTooHighError extends Error {
+  constructor() {
+    super('Name registration is temporarily unavailable due to high network costs')
+    this.name = 'RouteCostTooHighError'
+  }
+}
+
 async function fetchCreditsNameRouteWithProvider(
   creditsServerUrl: string,
   identity: AuthIdentity,
@@ -378,6 +397,20 @@ async function fetchCreditsNameRouteWithProvider(
   const signedFetch = (await import('decentraland-crypto-fetch')).default
   const response = await signedFetch(url, { method: 'GET', identity })
   if (!response.ok) {
+    // The credits-server returns 503 + code ROUTE_COST_TOO_HIGH when Across's required input
+    // exceeds what the executor can cover (bridge cost over the buffer cap). The route would
+    // revert on-chain, so it's withheld — surface it as a distinct, retryable condition rather
+    // than the generic route-unavailable error.
+    let code: string | undefined
+    try {
+      const body = (await response.json()) as { code?: string }
+      code = body?.code
+    } catch {
+      // Non-JSON error body — fall through to the generic error below.
+    }
+    if (code === 'ROUTE_COST_TOO_HIGH') {
+      throw new RouteCostTooHighError()
+    }
     throw new Error(`Credits route request failed: ${response.status} ${response.statusText}`)
   }
   return response.json() as Promise<CreditsNameRouteResponse & { provider: 'axelar' | 'across' }>

--- a/webapp/src/modules/toast/toasts.tsx
+++ b/webapp/src/modules/toast/toasts.tsx
@@ -142,6 +142,17 @@ export function getClaimNameWithCreditsRouteUnavailableToast(): Omit<Toast, 'id'
   }
 }
 
+export function getClaimNameWithCreditsCostUnavailableToast(): Omit<Toast, 'id'> {
+  return {
+    type: ToastType.WARN,
+    title: t('toast.claim_name_with_credits_cost_unavailable.title'),
+    body: <p>{t('toast.claim_name_with_credits_cost_unavailable.body')}</p>,
+    icon: <Icon size="big" name="exclamation circle" />,
+    closable: true,
+    timeout: 15000
+  }
+}
+
 export function getFetchAssetsFailureToast(error: string): Omit<Toast, 'id'> {
   return {
     type: ToastType.ERROR,

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -1271,6 +1271,10 @@
       "title": "Service temporarily unavailable",
       "body": "This feature is not available at the moment. Please try again later."
     },
+    "claim_name_with_credits_cost_unavailable": {
+      "title": "Temporarily unavailable",
+      "body": "NAME registration with credits is temporarily paused due to high network costs. Please try again later."
+    },
     "cross_chain_tx": {
       "body": "The transaction can take up to <highlight>3 minutes</highlight> to be processed.<br></br>You can also track its progress in the links below:",
       "view_transaction": "View transaction"

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -1239,6 +1239,10 @@
       "title": "Servicio temporalmente no disponible",
       "body": "Esta función no está disponible en este momento. Por favor, inténtalo de nuevo más tarde."
     },
+    "claim_name_with_credits_cost_unavailable": {
+      "title": "Temporalmente no disponible",
+      "body": "El registro de NAME con créditos está temporalmente pausado por los altos costos de la red. Por favor, inténtalo de nuevo más tarde."
+    },
     "cross_chain_tx": {
       "body": "La transacción puede tardar hasta <highlight>3 miuntos</highlight> para ser procesada.<br></br>Puedes seguir su progreso en los siguientes enlaces:",
       "view_transaction": "Ver transacción"

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -1242,6 +1242,10 @@
       "title": "服务暂时不可用",
       "body": "此功能目前不可用。请稍后再试。"
     },
+    "claim_name_with_credits_cost_unavailable": {
+      "title": "暂时不可用",
+      "body": "由于网络费用较高，使用积分注册 NAME 暂时暂停。请稍后再试。"
+    },
     "cross_chain_tx": {
       "body": "处理该交易最多可能需要 <highlight>3 分钟</highlight>。<br></br>您还可以在以下链接中跟踪其进度：",
       "view_transaction": "查看交易"


### PR DESCRIPTION
## Why

Pairs with credits-server #496. When the Across bridge cost exceeds what the executor can cover, the credits-server now **withholds the route** (HTTP 503 + `code: ROUTE_COST_TOO_HIGH`) instead of returning a route that's guaranteed to revert on-chain with `ERC20: transfer amount exceeds allowance`. The marketplace should surface this as a clear, temporary, retryable condition — not a generic failure.

## What

- `fetchCreditsNameRouteWithProvider` parses the error body on a non-ok response; when `code === 'ROUTE_COST_TOO_HIGH'` it throws a typed **`RouteCostTooHighError`**.
- The credits route-fetch catch handles that error specifically: shows a **warning toast** and a failure message — *"NAME registration with credits is temporarily paused due to high network costs. Please try again later."* — instead of the generic route-unavailable error. The modal stays open on its failure view (with retry).
- New toast `getClaimNameWithCreditsCostUnavailableToast` + en/es/zh copy.

Generic route failures are unchanged. This branch only adds the cost-specific path (Across provider only — the cost guard is Across-only server-side).

## Testing

`tsc` + eslint clean; existing ens saga tests green (15/15). The threshold/decision logic itself is unit-tested server-side in credits-server #496.

> Depends on credits-server #496 being deployed for the 503/code to be emitted; harmless before then (the branch only adds handling for a response that won't occur yet).