### PR TITLE
fix: gate cross-chain MANA buy on the route source chain

### DIFF
--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.spec.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.spec.tsx
@@ -1160,6 +1160,46 @@ describe('BuyWithCryptoModal', () => {
             expect(getByTestId(BUY_WITH_CARD_TEST_ID)).toBeInTheDocument()
           })
         })
+
+        describe('and wants to pay with MANA bridged from Ethereum but is still connected to Polygon', () => {
+          beforeEach(() => {
+            modalProps.price = '10000000000000000' // 0.1 MANA
+            modalProps.wallet = {
+              ...modalProps.wallet,
+              networks: {
+                [Network.ETHEREUM]: {
+                  mana: 1000000000000000000 // 1 MANA on Ethereum to cover the cross-chain route
+                },
+                [Network.MATIC]: {
+                  mana: 0
+                }
+              }
+            } as Wallet
+            modalProps.onGetCrossChainRoute = jest.fn().mockResolvedValue(undefined)
+            modalProps.onSwitchNetwork = jest.fn()
+          })
+
+          it('should render the switch network button so the wallet moves to the route source chain before buying', async () => {
+            const { getByTestId, findByTestId, findByText } = await renderBuyWithCryptoModal(modalProps)
+
+            // pay with MANA but sourced from Ethereum: pick the Ethereum chain in the selector
+            const chainSelector = getByTestId(CHAIN_SELECTOR_DATA_TEST_ID)
+            fireEvent.click(chainSelector)
+
+            const ethereumNetworkOption = await findByText('Ethereum')
+            fireEvent.click(ethereumNetworkOption)
+
+            // The wallet is on Polygon (the asset/destination chain) while the route source is Ethereum,
+            // so the modal must ask the user to switch networks instead of letting the buy proceed —
+            // otherwise the cross-chain SDK queries MANA.balanceOf on the wrong chain and reverts with a
+            // cryptic "balanceOf returned 0x" decode error.
+            const switchNetworkButton = await findByTestId(SWITCH_NETWORK_BUTTON_TEST_ID)
+            expect(switchNetworkButton).toBeInTheDocument()
+
+            fireEvent.click(switchNetworkButton)
+            await waitFor(() => expect(modalProps.onSwitchNetwork).toHaveBeenCalledWith(ChainId.ETHEREUM_MAINNET))
+          })
+        })
       })
 
       describe('and wants to pay with another Ethereum token', () => {

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.tsx
@@ -431,8 +431,13 @@ export const BuyWithCryptoModal = (props: Props) => {
             : renderBuyNowButton()
       }
 
-      // can buy it with MANA from other chain through the provider
-      return renderBuyNowButton()
+      // Paying with MANA from another chain (cross-chain MANA→MANA via the provider): the wallet
+      // must be on the route's source chain before buying. The cross-chain SDK executes the
+      // source swap+bridge there and queries the source token's balanceOf on that chain — if the
+      // wallet is on the destination chain instead, the call hits a chain where the source MANA
+      // has no code and fails with a cryptic "balanceOf returned 0x" decode error. Gate it like
+      // the non-MANA branch above.
+      return selectedChain === wallet.chainId ? renderBuyNowButton() : renderSwitchNetworkButton()
     } else if (!route && routeFailed) {
       // can't buy Get Mana and Buy With Card buttons
       return renderGetMANAButton()


### PR DESCRIPTION
## Why

Buying a cross-chain asset with **MANA bridged from another chain** while the wallet is still connected to the **destination** chain fails with a cryptic decode error:

```
could not decode result data (value="0x", method="balanceOf", code=BAD_DATA, version=6.8.1)
```

Real repro: a **Polygon** item, paid with **MANA on Ethereum**, with the wallet still on **Polygon**. The cross-chain SDK executes the source swap+bridge on the route's source chain and calls `MANA.balanceOf(sender)` there. If the wallet is on the destination chain instead, the call lands on a chain where the source MANA token has no code → returns `0x` → ethers v6 throws `BAD_DATA`.

## Root cause

In `BuyWithCryptoModal.renderMainActionButton`, every other token path already gates the buy on being connected to the route's source chain (`selectedChain === wallet.chainId`, else show *Switch Network*). The **"MANA from another chain"** fall-through did **not** — it returned `renderBuyNowButton()` unconditionally, letting the user fire a cross-chain buy from the wrong network.

## What

- Gate the cross-chain MANA branch on `selectedChain === wallet.chainId`, mirroring the existing non-MANA branch: render the **Switch Network** button when the wallet is on the wrong chain, so the user moves to the route's source chain before buying.
- Add a regression test: a Polygon wearable paid with MANA sourced from Ethereum, wallet still on Polygon → asserts the switch-network button (and that it fails without the gate).

## Testing

`tsc` clean, eslint clean, full `BuyWithCryptoModal` suite green (28/28). The new test was confirmed to **fail** without the gate (`Unable to find [data-testid="switch-network"]`) and **pass** with it.
