### PR TITLE
fix: prevent emote preview spinner from sticking on fast hover

### DIFF
--- a/webapp/src/components/EmotePreviewPlayer/EmotePreviewPlayer.spec.tsx
+++ b/webapp/src/components/EmotePreviewPlayer/EmotePreviewPlayer.spec.tsx
@@ -5,10 +5,11 @@ import { Network } from '@dcl/schemas'
 import { renderWithProviders } from '../../utils/test'
 import { EmotePreviewPlayerProvider, EmotePreviewSource, useEmotePreviewPlayer } from './EmotePreviewPlayer'
 
-// Capture the latest onLoad handed to the WearablePreview iframe so tests can
-// drive the LOAD lifecycle, and render a real iframe element carrying the id
-// the provider looks up via document.getElementById.
+// Capture the latest onLoad/onError handed to the WearablePreview iframe so
+// tests can drive the LOAD lifecycle, and render a real iframe element
+// carrying the id the provider looks up via document.getElementById.
 let capturedOnLoad: (() => void) | undefined
+let capturedOnError: (() => void) | undefined
 
 // Mirror the global decentraland-ui2 mock (see beforeSetupTests.ts) so the
 // store/saga import chain still resolves styled() at module-eval time, but
@@ -43,8 +44,9 @@ jest.mock('decentraland-ui2', () => {
     CreditsToggle: MockComponent,
     JumpIn: MockComponent,
     styled: styledMock,
-    WearablePreview: (props: { id?: string; onLoad?: () => void }) => {
+    WearablePreview: (props: { id?: string; onLoad?: () => void; onError?: () => void }) => {
       capturedOnLoad = props.onLoad
+      capturedOnError = props.onError
       return React.createElement('iframe', { id: props.id, title: 'wearable-preview' })
     }
   }
@@ -84,10 +86,15 @@ const fireLoad = () =>
   act(() => {
     capturedOnLoad?.()
   })
+const fireError = () =>
+  act(() => {
+    capturedOnError?.()
+  })
 
 describe('EmotePreviewPlayer', () => {
   beforeEach(() => {
     capturedOnLoad = undefined
+    capturedOnError = undefined
     // The rect-tracking rAF loop is irrelevant to these lifecycle assertions;
     // stub it so it doesn't schedule state updates outside act().
     jest.spyOn(window, 'requestAnimationFrame').mockReturnValue(0)
@@ -171,19 +178,37 @@ describe('EmotePreviewPlayer', () => {
       })
     })
 
-    describe('and a second emote is hovered before the first LOAD arrives', () => {
-      it('should keep the spinner until the latest emote LOAD arrives', async () => {
+    describe('and the same already-loaded emote is hovered again', () => {
+      it('should not show the spinner since no reload will occur', async () => {
         const { getByText } = renderWithProviders(
           <EmotePreviewPlayerProvider enabled>
             <Probe />
           </EmotePreviewPlayerProvider>
         )
         fireLoad() // boot
-        await userEvent.click(getByText('show')) // emote A requested (seq 1)
-        await userEvent.click(getByText('show')) // emote B requested (seq 2)
-        fireLoad() // stale LOAD for A
+        await userEvent.click(getByText('show')) // request emote
+        fireLoad() // emote finished loading
+        expect(getSpinner()).toBeNull()
+        await userEvent.click(getByText('hide'))
+        // Re-hovering the same emote sends an identical UPDATE that won't
+        // rebuild the scene (no LOAD will follow), so the spinner must not
+        // appear — otherwise it would stay stuck forever.
+        await userEvent.click(getByText('show'))
+        expect(getSpinner()).toBeNull()
+      })
+    })
+
+    describe('and the emote fails to load', () => {
+      it('should clear the spinner on error', async () => {
+        const { getByText } = renderWithProviders(
+          <EmotePreviewPlayerProvider enabled>
+            <Probe />
+          </EmotePreviewPlayerProvider>
+        )
+        fireLoad() // boot
+        await userEvent.click(getByText('show'))
         expect(getSpinner()).not.toBeNull()
-        fireLoad() // LOAD for B
+        fireError()
         expect(getSpinner()).toBeNull()
       })
     })

--- a/webapp/src/components/EmotePreviewPlayer/EmotePreviewPlayer.tsx
+++ b/webapp/src/components/EmotePreviewPlayer/EmotePreviewPlayer.tsx
@@ -69,6 +69,17 @@ const dispatchUpdate = (src: EmotePreviewSource, env: PreviewEnvConfig): boolean
   return true
 }
 
+// Stable identity of an emote, matching the discriminator used in
+// sourceToOptions. Used to tell whether a hover targets the emote that's
+// already rendered in the iframe (so we don't wait on a LOAD that will
+// never come) versus a genuinely new one.
+const keyOf = (src: EmotePreviewSource): string => {
+  if (src.network === Network.ETHEREUM && src.urn) {
+    return `eth:${src.urn}`
+  }
+  return `${src.contractAddress ?? ''}:${src.itemId ?? src.tokenId ?? ''}`
+}
+
 export const EmotePreviewPlayerProvider: React.FC<ProviderProps> = ({ enabled = true, children }) => {
   const [rect, setRect] = useState<Rect | null>(null)
   const [isVisible, setIsVisible] = useState(false)
@@ -78,12 +89,14 @@ export const EmotePreviewPlayerProvider: React.FC<ProviderProps> = ({ enabled = 
   const targetRef = useRef<HTMLElement | null>(null)
   const pendingSourceRef = useRef<EmotePreviewSource | null>(null)
   const hasInitiallyLoadedRef = useRef(false)
-  // Each emote swap we request bumps `dispatchSeqRef`; each emote LOAD we
-  // observe bumps `loadSeqRef`. We only clear the spinner once we've caught
-  // up (loadSeq >= dispatchSeq), so a stale LOAD from a previously-hovered
-  // card can't clear the spinner while a newer emote is still rendering.
-  const dispatchSeqRef = useRef(0)
-  const loadSeqRef = useRef(0)
+  // Identity of the emote the user is currently hovering, and of the one the
+  // iframe last finished loading. We drive the spinner off these instead of
+  // counting LOAD events: re-hovering an already-loaded emote (or rapid
+  // enter/exit on the same card) sends an UPDATE with identical options, so
+  // the iframe doesn't rebuild its scene and never emits a LOAD — a LOAD
+  // counter would then drift and leave the spinner stuck forever.
+  const currentKeyRef = useRef<string | null>(null)
+  const loadedKeyRef = useRef<string | null>(null)
 
   const wallet = useSelector(getWallet)
   const profiles = useSelector(getProfiles)
@@ -144,9 +157,12 @@ export const EmotePreviewPlayerProvider: React.FC<ProviderProps> = ({ enabled = 
       const r = target.getBoundingClientRect()
       setRect({ top: r.top, left: r.left, width: r.width, height: r.height })
       setIsVisible(true)
-      setIsEmoteLoading(true)
-      // One swap requested → expect one more LOAD before the spinner clears.
-      dispatchSeqRef.current += 1
+      const key = keyOf(source)
+      currentKeyRef.current = key
+      // If this emote is already rendered in the iframe the UPDATE won't
+      // trigger a rebuild (no LOAD will follow), so don't show a spinner that
+      // would never clear. Otherwise wait for its LOAD.
+      setIsEmoteLoading(key !== loadedKeyRef.current)
       if (isControllable) {
         dispatchUpdate(source, envConfig)
         pendingSourceRef.current = null
@@ -162,6 +178,7 @@ export const EmotePreviewPlayerProvider: React.FC<ProviderProps> = ({ enabled = 
     setIsVisible(false)
     setIsEmoteLoading(false)
     pendingSourceRef.current = null
+    // Keep loadedKeyRef so re-hovering the same emote stays instant.
   }, [])
 
   // Flush any pending hover request once the iframe is controllable.
@@ -180,8 +197,8 @@ export const EmotePreviewPlayerProvider: React.FC<ProviderProps> = ({ enabled = 
   useEffect(() => {
     if (!enabled) {
       hasInitiallyLoadedRef.current = false
-      dispatchSeqRef.current = 0
-      loadSeqRef.current = 0
+      currentKeyRef.current = null
+      loadedKeyRef.current = null
       targetRef.current = null
       pendingSourceRef.current = null
       setIsControllable(false)
@@ -191,22 +208,24 @@ export const EmotePreviewPlayerProvider: React.FC<ProviderProps> = ({ enabled = 
   }, [enabled])
 
   // onLoad fires once on initial iframe boot (with the default profile, no
-  // emote) and AGAIN every time we send an UPDATE that swaps the urn/itemId
-  // — the iframe rebuilds the Babylon scene and re-emits LOAD. We use the
-  // first LOAD only to mark the iframe controllable (and to keep the
-  // spinner up if a hover request is still queued). Subsequent LOADs mean
-  // an emote scene finished rendering; we clear the spinner only once we've
-  // caught up to the latest requested swap so a stale LOAD can't clear it.
+  // emote) and AGAIN every time an UPDATE swaps the urn/itemId — the iframe
+  // rebuilds the Babylon scene and re-emits LOAD. The first LOAD only marks
+  // the iframe controllable. Subsequent LOADs mean an emote scene finished
+  // rendering, so we record what's now loaded and clear the spinner.
   const handlePreviewLoad = useCallback(() => {
     if (!hasInitiallyLoadedRef.current) {
       hasInitiallyLoadedRef.current = true
       setIsControllable(true)
       return
     }
-    loadSeqRef.current += 1
-    if (loadSeqRef.current >= dispatchSeqRef.current) {
-      setIsEmoteLoading(false)
-    }
+    loadedKeyRef.current = currentKeyRef.current
+    setIsEmoteLoading(false)
+  }, [])
+
+  // If the iframe fails to render an emote it emits ERROR instead of LOAD, so
+  // clear the spinner here too — otherwise a failed load would leave it stuck.
+  const handlePreviewError = useCallback(() => {
+    setIsEmoteLoading(false)
   }, [])
 
   const contextValue = useMemo<EmotePreviewPlayerContextValue>(() => ({ show, hide }), [show, hide])
@@ -243,6 +262,7 @@ export const EmotePreviewPlayerProvider: React.FC<ProviderProps> = ({ enabled = 
         dev={isPreviewDev}
         unityMode={PreviewUnityMode.MARKETPLACE}
         onLoad={handlePreviewLoad}
+        onError={handlePreviewError}
       />
       {isVisible && isEmoteLoading ? <Loader className="EmotePreviewPlayer__spinner" active size="large" /> : null}
     </div>


### PR DESCRIPTION
## Problem

Entering and exiting emote cards quickly (or re-hovering the same card) sometimes left the loading spinner stuck on top forever, even though the 3D preview rendered correctly underneath.

The spinner was driven by a `dispatchSeq`/`loadSeq` counter that assumed every emote `UPDATE` we postMessage to the iframe produces exactly one `LOAD` event. That assumption breaks:

- Re-hovering an **already-loaded** emote (or fast enter/exit on the same card) sends an UPDATE with identical options, so the iframe doesn't rebuild its Babylon scene and never emits a `LOAD`. `dispatchSeq` still incremented, so `loadSeq >= dispatchSeq` was never satisfied again and the spinner stayed up permanently.
- A failed render emits `ERROR` (not `LOAD`), which was never handled — another path to a stuck spinner.

## Changes

- Replace the LOAD counter with emote-identity tracking (`currentKeyRef` / `loadedKeyRef`, keyed the same way as `sourceToOptions`):
  - On hover, if the emote is already loaded in the iframe, don't show a spinner (no rebuild ⇒ no LOAD will follow).
  - On `LOAD`, record what's now loaded and clear the spinner.
- Handle `onError` to clear the spinner when a scene fails to render.
- Update the lifecycle reset (disable) and unit tests for the new model; add coverage for re-hovering an already-loaded emote and for the error path.

## Test plan

- [x] Unit tests pass (`EmotePreviewPlayer.spec.tsx`, 9 tests)
- [ ] On `/browse?section=emotes`, rapidly enter/exit cards and re-hover the same card: spinner shows only while a new emote is actually loading and always clears; the preview renders correctly with no stuck overlay.