### PR TITLE
fix: guard undefined asset.urn in SuccessPage IAP deep link

### DIFF
--- a/webapp/src/components/SuccessPage/SuccessPage.tsx
+++ b/webapp/src/components/SuccessPage/SuccessPage.tsx
@@ -192,7 +192,7 @@ export function SuccessPage(props: Props) {
                       (isIAP ? (
                         <Button
                           as="a"
-                          href={`decentraland://open?iap_enabled=true&urn=${encodeURIComponent(asset.urn)}`}
+                          href={`decentraland://open?iap_enabled=true&urn=${encodeURIComponent(asset.urn ?? '')}`}
                           className={styles.successButton}
                           primary
                         >


### PR DESCRIPTION
Fixes the `tsc` error `TS2345` at `SuccessPage.tsx:195` (`asset.urn` is `string | undefined` since `NFT.urn` is optional), which broke the `build-release` job on master and the Vercel deploy on #2647. Guards with `?? ''`.