### PR TITLE
feat: hide social emotes from marketplace browse

### DIFF
--- a/webapp/src/modules/vendor/decentraland/catalog/api.ts
+++ b/webapp/src/modules/vendor/decentraland/catalog/api.ts
@@ -152,6 +152,9 @@ export class CatalogAPI extends BaseClient {
       queryParams.append('emoteOutcomeType', filters.emoteOutcomeType)
     }
 
+    // Hide social emotes from the marketplace until the feature is released
+    queryParams.append('includeSocialEmotes', 'false')
+
     return queryParams.toString()
   }
 }

--- a/webapp/src/modules/vendor/decentraland/item/api.ts
+++ b/webapp/src/modules/vendor/decentraland/item/api.ts
@@ -6,13 +6,15 @@ export const DEFAULT_TRENDING_PAGE_SIZE = 20
 
 export class ItemAPI extends BaseClient {
   async get(filters: ItemFilters = {}): Promise<ItemResponse> {
-    const queryParams = this.buildItemsQueryString(filters)
+    const queryParams = new URLSearchParams(this.buildItemsQueryString(filters))
     // Hide social emotes from the marketplace until the feature is released
-    return this.fetch(`/v1/items?${queryParams}&includeSocialEmotes=false`)
+    queryParams.append('includeSocialEmotes', 'false')
+    return this.fetch(`/v1/items?${queryParams.toString()}`)
   }
 
   async getTrendings(size = DEFAULT_TRENDING_PAGE_SIZE): Promise<ItemResponse> {
-    return this.fetch(`/v1/trendings?size=${size}`)
+    // Hide social emotes from the marketplace until the feature is released
+    return this.fetch(`/v1/trendings?size=${size}&includeSocialEmotes=false`)
   }
 
   async getOne(contractAddress: string, itemId: string): Promise<Item> {

--- a/webapp/src/modules/vendor/decentraland/item/api.ts
+++ b/webapp/src/modules/vendor/decentraland/item/api.ts
@@ -7,7 +7,8 @@ export const DEFAULT_TRENDING_PAGE_SIZE = 20
 export class ItemAPI extends BaseClient {
   async get(filters: ItemFilters = {}): Promise<ItemResponse> {
     const queryParams = this.buildItemsQueryString(filters)
-    return this.fetch(`/v1/items?${queryParams}`)
+    // Hide social emotes from the marketplace until the feature is released
+    return this.fetch(`/v1/items?${queryParams}&includeSocialEmotes=false`)
   }
 
   async getTrendings(size = DEFAULT_TRENDING_PAGE_SIZE): Promise<ItemResponse> {

--- a/webapp/src/modules/vendor/decentraland/nft/api.ts
+++ b/webapp/src/modules/vendor/decentraland/nft/api.ts
@@ -223,6 +223,9 @@ class NFTAPI extends BaseAPI {
       this.appendNFTFiltersToQueryParams(queryParams, filters)
     }
 
+    // Hide social emotes from the marketplace until the feature is released
+    queryParams.append('includeSocialEmotes', 'false')
+
     return queryParams.toString()
   }
 


### PR DESCRIPTION
## What

Sends `includeSocialEmotes=false` on the marketplace browse requests so social emotes are excluded from the marketplace until the feature is released.

## Why

`marketplace-server` now includes social emotes by default and only excludes them when `includeSocialEmotes=false` is explicitly passed (see decentraland/marketplace-server#346). This PR opts the marketplace webapp out so social emotes don't surface in browsing yet.

## Changes

`includeSocialEmotes=false` is appended on the three browse entrypoints:

| Client | Method | Endpoint |
|--------|--------|----------|
| `CatalogAPI` | `get` | `/v1/catalog`, `/v2/catalog` |
| `ItemAPI` | `get` | `/v1/items` |
| `NFTAPI` | `fetch` | `/v1/nfts` |

Single-item lookups (`ItemAPI.getOne`, `NFTAPI.fetchOne`) are intentionally left untouched, so direct asset detail pages still resolve.

## Notes

- This is **not** tied to the `SOCIAL_EMOTES` feature flag — the webapp always sends `false`. When the feature is released, this is the place to revisit (and the flag's social-emote filter UI would otherwise return nothing while this is in place).
- This also hides owned social emotes from a user's marketplace profile/store view (it uses `NFTAPI.fetch`). The explorer/backpack is unaffected — it reads the user-assets endpoints, which were not changed.

## Depends on

- decentraland/marketplace-server#346 (adds the `includeSocialEmotes` param)