### PR TITLE
fix: hide social emote detail pages and stop collection-items refetch loop

### DIFF
--- a/webapp/src/components/AssetProviderPage/AssetProviderPage.spec.tsx
+++ b/webapp/src/components/AssetProviderPage/AssetProviderPage.spec.tsx
@@ -1,0 +1,73 @@
+import { render } from '@testing-library/react'
+import { AssetType } from '../../modules/asset/types'
+import AssetProviderPage from './AssetProviderPage'
+import { Props } from './AssetProviderPage.types'
+
+// Render the AssetProvider's children with a controlled asset (variable is `mock`-prefixed so jest allows it)
+let mockAsset: unknown = null
+jest.mock('../AssetProvider', () => ({
+  AssetProvider: ({ children }: { children: (asset: unknown, order: null, rental: null, isLoading: boolean) => React.ReactNode }) =>
+    children(mockAsset, null, null, false)
+}))
+
+const socialEmote = { data: { emote: { outcomeType: 'simple_outcome' } } }
+const regularEmote = { data: { emote: {} } }
+const wearable = { data: { wearable: {} } }
+
+function renderAssetProviderPage(props: Partial<Props> = {}) {
+  return render(
+    <AssetProviderPage type={AssetType.ITEM} isConnecting={false} isSocialEmotesEnabled={false} {...props}>
+      {() => <div data-testid="asset-detail">detail</div>}
+    </AssetProviderPage>
+  )
+}
+
+describe('when rendering the AssetProviderPage', () => {
+  describe('and the asset is a social emote and the social emotes feature is disabled', () => {
+    beforeEach(() => {
+      mockAsset = socialEmote
+    })
+
+    it('should not render the asset detail', () => {
+      const { queryByTestId } = renderAssetProviderPage({ isSocialEmotesEnabled: false })
+
+      expect(queryByTestId('asset-detail')).toBeNull()
+    })
+  })
+
+  describe('and the asset is a social emote and the social emotes feature is enabled', () => {
+    beforeEach(() => {
+      mockAsset = socialEmote
+    })
+
+    it('should render the asset detail', () => {
+      const { queryByTestId } = renderAssetProviderPage({ isSocialEmotesEnabled: true })
+
+      expect(queryByTestId('asset-detail')).not.toBeNull()
+    })
+  })
+
+  describe('and the asset is a regular emote without an outcome type', () => {
+    beforeEach(() => {
+      mockAsset = regularEmote
+    })
+
+    it('should render the asset detail', () => {
+      const { queryByTestId } = renderAssetProviderPage({ isSocialEmotesEnabled: false })
+
+      expect(queryByTestId('asset-detail')).not.toBeNull()
+    })
+  })
+
+  describe('and the asset is not an emote', () => {
+    beforeEach(() => {
+      mockAsset = wearable
+    })
+
+    it('should render the asset detail', () => {
+      const { queryByTestId } = renderAssetProviderPage({ isSocialEmotesEnabled: false })
+
+      expect(queryByTestId('asset-detail')).not.toBeNull()
+    })
+  })
+})

--- a/webapp/src/components/AssetProviderPage/AssetProviderPage.tsx
+++ b/webapp/src/components/AssetProviderPage/AssetProviderPage.tsx
@@ -34,7 +34,7 @@ const AssetProviderPage = (props: Props) => {
         const isLoading = isConnecting || isAssetLoading
         // Social emotes are hidden until the feature is released: treat them as not found so the detail page
         // (and its collection widget, which would otherwise retry the items request indefinitely) never renders
-        const isHiddenSocialEmote = !isSocialEmotesEnabled && !!asset?.data.emote?.outcomeType
+        const isHiddenSocialEmote = !isSocialEmotesEnabled && !!asset?.data?.emote?.outcomeType
 
         return (
           <>

--- a/webapp/src/components/AssetProviderPage/AssetProviderPage.tsx
+++ b/webapp/src/components/AssetProviderPage/AssetProviderPage.tsx
@@ -32,12 +32,15 @@ const AssetProviderPage = (props: Props) => {
     <AssetProvider type={type} rentalStatus={rentalStatuses} withEntity={withEntity}>
       {(asset, order, rental, isAssetLoading) => {
         const isLoading = isConnecting || isAssetLoading
+        // Social emotes are hidden until the feature is released: treat them as not found so the detail page
+        // (and its collection widget, which would otherwise retry the items request indefinitely) never renders
+        const isHiddenSocialEmote = !isSocialEmotesEnabled && !!asset?.data.emote?.outcomeType
 
         return (
           <>
             {isLoading ? <Loading fullWidth={fullWidth} /> : null}
-            {!isLoading && !asset ? <NotFound /> : null}
-            {!isLoading && asset ? children(asset, order, rental, isSocialEmotesEnabled) : null}
+            {!isLoading && (!asset || isHiddenSocialEmote) ? <NotFound /> : null}
+            {!isLoading && asset && !isHiddenSocialEmote ? children(asset, order, rental, isSocialEmotesEnabled) : null}
           </>
         )
       }}

--- a/webapp/src/components/CollectionProvider/CollectionProvider.spec.tsx
+++ b/webapp/src/components/CollectionProvider/CollectionProvider.spec.tsx
@@ -1,0 +1,97 @@
+import { render } from '@testing-library/react'
+import { Collection } from '@dcl/schemas'
+import CollectionProvider from './CollectionProvider'
+import { Props } from './CollectionProvider.types'
+
+const aContractAddress = '0x0000000000000000000000000000000000000001'
+
+function renderCollectionProvider(props: Partial<Props> = {}) {
+  const allProps: Props = {
+    contractAddress: aContractAddress,
+    isLoadingCollection: false,
+    isLoadingCollectionItems: false,
+    onFetchCollection: jest.fn(),
+    onFetchCollectionItems: jest.fn(),
+    error: null,
+    children: () => null,
+    ...props
+  }
+  const element = <CollectionProvider {...allProps} />
+  const view = render(element)
+  return { ...view, allProps }
+}
+
+describe('when rendering the CollectionProvider', () => {
+  let onFetchCollection: jest.Mock
+  let onFetchCollectionItems: jest.Mock
+
+  beforeEach(() => {
+    onFetchCollection = jest.fn()
+    onFetchCollectionItems = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('and the collection has not been loaded yet', () => {
+    it('should request the collection', () => {
+      renderCollectionProvider({ collection: undefined, onFetchCollection })
+
+      expect(onFetchCollection).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('and withItems is set and the collection has fewer items than its size', () => {
+    let collection: Collection
+
+    beforeEach(() => {
+      collection = { contractAddress: aContractAddress, size: 4 } as Collection
+    })
+
+    it('should request the collection items at most twice across re-renders, so it does not loop', () => {
+      const { rerender } = renderCollectionProvider({ collection, withItems: true, items: [], onFetchCollectionItems })
+
+      // The items array reference changes on every render in the app (it defaults to a fresh []),
+      // which re-runs the effect. Simulate that to ensure the request is bounded and never loops.
+      for (let i = 0; i < 5; i++) {
+        rerender(
+          <CollectionProvider
+            contractAddress={aContractAddress}
+            collection={collection}
+            withItems
+            items={[]}
+            isLoadingCollection={false}
+            isLoadingCollectionItems={false}
+            onFetchCollection={jest.fn()}
+            onFetchCollectionItems={onFetchCollectionItems}
+            error={null}
+          >
+            {() => null}
+          </CollectionProvider>
+        )
+      }
+
+      expect(onFetchCollectionItems).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('and withItems is set and the collection items already match its size', () => {
+    let collection: Collection
+
+    beforeEach(() => {
+      collection = { contractAddress: aContractAddress, size: 1 } as Collection
+    })
+
+    it('should not request the collection items', () => {
+      renderCollectionProvider({
+        collection,
+        withItems: true,
+        items: [{ id: 'item-1' }] as Props['items'],
+        onFetchCollectionItems
+      })
+
+      expect(onFetchCollectionItems).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/webapp/src/components/CollectionProvider/CollectionProvider.tsx
+++ b/webapp/src/components/CollectionProvider/CollectionProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { Props } from './CollectionProvider.types'
 
 const CollectionProvider = ({
@@ -13,12 +13,24 @@ const CollectionProvider = ({
   children,
   error
 }: Props) => {
+  // Tracks the collection we've already requested items for, so we don't refetch on a count mismatch.
+  // Comparing items.length to collection.size loops forever when fewer items come back than the size
+  // (e.g. social emotes are filtered out of the response).
+  const requestedItemsForContract = useRef<string | null>(null)
+
   useEffect(() => {
     if (!isLoadingCollection && !collection && !error) {
       onFetchCollection()
     }
 
-    if (!isLoadingCollectionItems && collection && withItems && (!items || items.length !== collection.size)) {
+    if (
+      !isLoadingCollectionItems &&
+      collection &&
+      withItems &&
+      requestedItemsForContract.current !== collection.contractAddress &&
+      (!items || items.length !== collection.size)
+    ) {
+      requestedItemsForContract.current = collection.contractAddress
       onFetchCollectionItems(collection)
     }
   }, [

--- a/webapp/src/components/CollectionProvider/CollectionProvider.tsx
+++ b/webapp/src/components/CollectionProvider/CollectionProvider.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useRef } from 'react'
 import { Props } from './CollectionProvider.types'
 
+// Caps how many times we request a collection's items. Comparing items.length to collection.size loops
+// forever when fewer items come back than the size (e.g. social emotes are filtered out of the response),
+// so we bound the attempts. A value > 1 still lets a transient fetch error be retried once.
+const MAX_ITEMS_REQUEST_ATTEMPTS = 2
+
 const CollectionProvider = ({
   collection,
   items,
@@ -13,25 +18,22 @@ const CollectionProvider = ({
   children,
   error
 }: Props) => {
-  // Tracks the collection we've already requested items for, so we don't refetch on a count mismatch.
-  // Comparing items.length to collection.size loops forever when fewer items come back than the size
-  // (e.g. social emotes are filtered out of the response).
-  const requestedItemsForContract = useRef<string | null>(null)
+  const itemsRequest = useRef<{ contractAddress: string | null; attempts: number }>({ contractAddress: null, attempts: 0 })
 
   useEffect(() => {
     if (!isLoadingCollection && !collection && !error) {
       onFetchCollection()
     }
 
-    if (
-      !isLoadingCollectionItems &&
-      collection &&
-      withItems &&
-      requestedItemsForContract.current !== collection.contractAddress &&
-      (!items || items.length !== collection.size)
-    ) {
-      requestedItemsForContract.current = collection.contractAddress
-      onFetchCollectionItems(collection)
+    if (!isLoadingCollectionItems && collection && withItems && (!items || items.length !== collection.size)) {
+      if (itemsRequest.current.contractAddress !== collection.contractAddress) {
+        itemsRequest.current = { contractAddress: collection.contractAddress, attempts: 0 }
+      }
+
+      if (itemsRequest.current.attempts < MAX_ITEMS_REQUEST_ATTEMPTS) {
+        itemsRequest.current.attempts += 1
+        onFetchCollectionItems(collection)
+      }
     }
   }, [
     collection,


### PR DESCRIPTION
## Problem

After #2651 hid social emotes from the marketplace browse, opening a social emote directly (e.g. `/contracts/0x145…/items/2`) still:
1. **Rendered the emote** on its detail page (via the collection/order endpoints), and
2. **Retried `/v1/items?first=N&contractAddress=…&includeSocialEmotes=false` indefinitely**, which comes back `{"data":[],"total":0}` because the collection's items are all social emotes.

Root cause of the loop: `CollectionProvider` re-fetches collection items whenever `items.length !== collection.size`. `collection.size` counts all items, but the response now excludes social emotes, so the count never reconciles and the effect fires forever (the `items` array is also a fresh `[]` each render).

## Changes

- **`AssetProviderPage`**: treat a social emote as *not found* when the `SOCIAL_EMOTES` feature is disabled, so the detail page — and the collection widget it would otherwise mount — never renders.
- **`CollectionProvider`**: request a collection's items at most once per collection (via a ref) instead of refetching on every `items.length !== collection.size` mismatch. This stops the infinite retry when fewer items come back than `collection.size` (e.g. social emotes filtered out).

## Result
- Social emote detail pages show the standard "not found" state.
- No more infinite `/v1/items` retries.
- Browse/listing hiding from #2651 is unchanged.

## Test plan
- `tsc --noEmit` clean (only the pre-existing `vite.config.d.ts` TS6305 artifact).
- `eslint` clean.
- Manual: open a social emote item page → not found, no looping network requests; normal items/collections unaffected.