### PR TITLE
feat: default my assets to show all with on sale as an opt-in filter

### DIFF
--- a/webapp/src/components/AssetFilters/MoreFilters/MoreFilters.tsx
+++ b/webapp/src/components/AssetFilters/MoreFilters/MoreFilters.tsx
@@ -20,8 +20,9 @@ export const MoreFilters = ({ onlyOnSale, onSaleChange, defaultCollapsed = false
     [onSaleChange]
   )
 
+  // The box holds the opt-in "On Sale" toggle, so the collapsed header reflects its state: the filter name when on, nothing when off.
   const filterText = useMemo(() => {
-    return onlyOnSale ? t('nft_filters.for_sale') : t('nft_filters.not_on_sale')
+    return onlyOnSale ? t('nft_filters.on_sale') : ''
   }, [onlyOnSale])
 
   const header = useMemo(

--- a/webapp/src/components/AssetTopbar/SelectedFilters/SelectedFilters.tsx
+++ b/webapp/src/components/AssetTopbar/SelectedFilters/SelectedFilters.tsx
@@ -4,6 +4,8 @@ import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import ProfilesCache from '../../../lib/profiles'
 import { CreatorAccount } from '../../../modules/account/types'
 import { AssetType } from '../../../modules/asset/types'
+import { SortBy } from '../../../modules/routing/types'
+import { View } from '../../../modules/ui/types'
 import {
   getEstateSizeLabel,
   getGenderFilterLabel,
@@ -41,8 +43,10 @@ export const SelectedFilters = ({ browseOptions, isLandSection, category, onBrow
     status,
     emoteHasSound,
     emoteHasGeometry,
-    emoteOutcomeType
+    emoteOutcomeType,
+    view
   } = browseOptions
+  const isCurrentAccount = view === View.CURRENT_ACCOUNT
   const [collections, setCollections] = useState<Record<string, string>[] | []>([])
 
   const [selectedCreators, setSelectedCreators] = useState<Pick<CreatorAccount, 'address' | 'name'>[]>()
@@ -124,8 +128,11 @@ export const SelectedFilters = ({ browseOptions, isLandSection, category, onBrow
   }, [onBrowse])
 
   const handleDeleteOnlySale = useCallback(() => {
-    onBrowse({ onlyOnSale: true })
-  }, [onBrowse])
+    // In My Assets the pill is the opt-in "On Sale" filter, so deleting it turns the filter off (shows all assets).
+    // The sort is reset to avoid invalid combinations with the on sale sort options.
+    // Elsewhere the pill is "Includes not on sale", so deleting it goes back to showing only on sale assets.
+    onBrowse(isCurrentAccount ? { onlyOnSale: false, sortBy: SortBy.NEWEST } : { onlyOnSale: true })
+  }, [onBrowse, isCurrentAccount])
 
   const handleDeleteGender = useCallback(() => {
     onBrowse({ wearableGenders: [] })
@@ -185,6 +192,13 @@ export const SelectedFilters = ({ browseOptions, isLandSection, category, onBrow
     onBrowse({ emoteOutcomeType: undefined })
   }, [onBrowse])
 
+  // In My Assets "On Sale" is an opt-in filter: show the pill only when it's enabled (onlyOnSale === true).
+  // Elsewhere the on sale filter is on by default, so the pill represents "Includes not on sale" (onlyOnSale === false).
+  const showOnSaleFilterPill = isCurrentAccount
+    ? !!onlyOnSale && !isLandSection
+    : !onlyOnSale && !isLandSection && assetType !== AssetType.ITEM
+  const onSaleFilterPillLabel = isCurrentAccount ? t('nft_filters.on_sale') : t('nft_filters.not_on_sale')
+
   return (
     <div className={styles.pillContainer}>
       {emoteHasSound ? (
@@ -217,9 +231,7 @@ export const SelectedFilters = ({ browseOptions, isLandSection, category, onBrow
       {wearableGenders?.length ? (
         <Pill label={t(getGenderFilterLabel(wearableGenders))} id="wearable_genders" onDelete={handleDeleteGender} />
       ) : null}
-      {!onlyOnSale && !isLandSection && assetType !== AssetType.ITEM ? ( // TODO UNIFIED: CHECK THIS
-        <Pill label={t('nft_filters.not_on_sale')} id="onlyOnSale" onDelete={handleDeleteOnlySale} />
-      ) : null}
+      {showOnSaleFilterPill ? <Pill label={onSaleFilterPillLabel} id="onlyOnSale" onDelete={handleDeleteOnlySale} /> : null}
       {emotePlayMode?.map(playMode => (
         <Pill key={playMode} label={t(`emote.play_mode.${playMode}`)} onDelete={handleDeleteEmotePlayMode} id={playMode} />
       ))}

--- a/webapp/src/modules/routing/sagas.spec.ts
+++ b/webapp/src/modules/routing/sagas.spec.ts
@@ -175,38 +175,40 @@ describe('when handling the clear filters request action', () => {
         })
       })
       describe('and the asset type is NFT', () => {
-        it("should fetch assets and change the URL by clearing the filter's browse options and restarting the page counter and remove the onlyOnSale filter", () => {
-          return expectSaga(routingSaga)
-            .provide([
-              [
-                call(getCurrentBrowseOptions, search, pathname, View.MARKET),
-                {
-                  ...browseOptions,
-                  onlyOnSale: true,
-                  section: Section.WEARABLES,
-                  assetType: AssetType.NFT,
-                  view: View.CURRENT_ACCOUNT
-                }
-              ],
-              [select(getPage), 1],
-              [select(getView), View.MARKET],
-              [select(getCurrentLocationAddress, pathname), currentLocationAddress],
-              [getContext('history'), { location: { pathname, search }, push: pushMock }],
-              [select(getEventData), {}],
-              [call(fetchAssetsFromRoute, browseOptionsWithoutFilters), Promise.resolve()]
-            ])
-            .dispatch(clearFilters())
-            .run({ silenceTimeout: true })
-            .then(() => {
-              expect(pushMock).toHaveBeenCalledWith(
-                buildBrowseURL(pathname, {
-                  ...browseOptionsWithoutFilters,
-                  section: Section.WEARABLES,
-                  onlyOnSale: true,
-                  assetType: AssetType.NFT
-                })
-              )
-            })
+        describe('and it is the My Assets view (current account)', () => {
+          it("should fetch assets and change the URL by clearing the filter's browse options and keeping the On Sale filter off so all assets are shown", () => {
+            return expectSaga(routingSaga)
+              .provide([
+                [
+                  call(getCurrentBrowseOptions, search, pathname, View.MARKET),
+                  {
+                    ...browseOptions,
+                    onlyOnSale: true,
+                    section: Section.WEARABLES,
+                    assetType: AssetType.NFT,
+                    view: View.CURRENT_ACCOUNT
+                  }
+                ],
+                [select(getPage), 1],
+                [select(getView), View.MARKET],
+                [select(getCurrentLocationAddress, pathname), currentLocationAddress],
+                [getContext('history'), { location: { pathname, search }, push: pushMock }],
+                [select(getEventData), {}],
+                [call(fetchAssetsFromRoute, browseOptionsWithoutFilters), Promise.resolve()]
+              ])
+              .dispatch(clearFilters())
+              .run({ silenceTimeout: true })
+              .then(() => {
+                expect(pushMock).toHaveBeenCalledWith(
+                  buildBrowseURL(pathname, {
+                    ...browseOptionsWithoutFilters,
+                    section: Section.WEARABLES,
+                    onlyOnSale: false,
+                    assetType: AssetType.NFT
+                  })
+                )
+              })
+          })
         })
       })
     })

--- a/webapp/src/modules/routing/search.ts
+++ b/webapp/src/modules/routing/search.ts
@@ -32,7 +32,8 @@ export function getDefaultOptionsByView(view?: View, section?: Section): BrowseO
       defaultOptions = {
         ...defaultOptions,
         status: undefined, // status doesn't apply to ENS
-        onlyOnSale: true // show ENS names on sale by default
+        // My Assets (current account) shows all names by default with "On Sale" as an opt-in filter. Elsewhere names are shown on sale by default.
+        onlyOnSale: view === View.CURRENT_ACCOUNT ? false : true
       }
     }
   }

--- a/webapp/src/modules/routing/url-parser.spec.ts
+++ b/webapp/src/modules/routing/url-parser.spec.ts
@@ -1410,6 +1410,38 @@ describe('when checking if filters are enabled', () => {
       })
     })
 
+    describe('and is the My Assets view (current account)', () => {
+      describe('and the On Sale filter is enabled', () => {
+        beforeEach(() => {
+          browseOptions = {
+            section: Section.WEARABLES,
+            view: View.CURRENT_ACCOUNT,
+            onlyOnSale: true
+          }
+        })
+
+        it('should return true', () => {
+          const result = urlParser.hasFiltersEnabled(browseOptions)
+          expect(result).toBe(true)
+        })
+      })
+
+      describe('and the On Sale filter is off so all assets are shown', () => {
+        beforeEach(() => {
+          browseOptions = {
+            section: Section.WEARABLES,
+            view: View.CURRENT_ACCOUNT,
+            onlyOnSale: false
+          }
+        })
+
+        it('should return false', () => {
+          const result = urlParser.hasFiltersEnabled(browseOptions)
+          expect(result).toBe(false)
+        })
+      })
+    })
+
     describe('and has emote filters', () => {
       beforeEach(() => {
         browseOptions = {

--- a/webapp/src/modules/routing/url-parser.ts
+++ b/webapp/src/modules/routing/url-parser.ts
@@ -255,7 +255,8 @@ export const hasFiltersEnabled = (browseOptions: BrowseOptions) => {
     onlySmart,
     emoteHasGeometry,
     emoteHasSound,
-    emoteOutcomeType
+    emoteOutcomeType,
+    view
   } = browseOptions
 
   const isLand = isLandSection(section as Section)
@@ -285,7 +286,9 @@ export const hasFiltersEnabled = (browseOptions: BrowseOptions) => {
   const hasContractsFilter = contracts && contracts.length > 0
   const hasCreatorFilter = creators && creators.length > 0
   const hasEmotePlayModeFilter = emotePlayMode && emotePlayMode.length > 0
-  const hasNotOnSaleFilter = onlyOnSale === false
+  // In My Assets the "On Sale" filter is opt-in, so it only counts as an active filter when explicitly enabled (true).
+  // Elsewhere the on sale filter is on by default, so including not-on-sale assets (false) is the active filter.
+  const hasOnSaleFilter = view === View.CURRENT_ACCOUNT ? onlyOnSale === true : onlyOnSale === false
 
   return (
     hasNetworkFilter ||
@@ -297,7 +300,7 @@ export const hasFiltersEnabled = (browseOptions: BrowseOptions) => {
     hasEmotePlayModeFilter ||
     !!minPrice ||
     !!maxPrice ||
-    hasNotOnSaleFilter ||
+    hasOnSaleFilter ||
     emoteHasSound ||
     emoteHasGeometry ||
     !!emoteOutcomeType ||

--- a/webapp/src/modules/routing/utils.spec.ts
+++ b/webapp/src/modules/routing/utils.spec.ts
@@ -126,7 +126,7 @@ describe('when clearing browser options', () => {
     })
   })
 
-  describe('and its not a catalog view', () => {
+  describe('and it is the My Assets view (current account)', () => {
     beforeEach(() => {
       baseBrowseOptions = {
         onlyOnSale: false,
@@ -135,7 +135,24 @@ describe('when clearing browser options', () => {
         section: Section.WEARABLES
       }
     })
-    it('should not set the status filter option', () => {
+    it('should keep the On Sale filter off so all assets are shown', () => {
+      expect(getClearedBrowseOptions(baseBrowseOptions)).toStrictEqual({
+        ...baseBrowseOptions,
+        onlyOnSale: false
+      })
+    })
+  })
+
+  describe('and it is another account view', () => {
+    beforeEach(() => {
+      baseBrowseOptions = {
+        onlyOnSale: false,
+        page: 1,
+        view: View.ACCOUNT,
+        section: Section.WEARABLES
+      }
+    })
+    it('should turn the On Sale filter back on by default', () => {
       expect(getClearedBrowseOptions(baseBrowseOptions)).toStrictEqual({
         ...baseBrowseOptions,
         onlyOnSale: true

--- a/webapp/src/modules/routing/utils.ts
+++ b/webapp/src/modules/routing/utils.ts
@@ -118,13 +118,15 @@ export function getClearedBrowseOptions(browseOptions: BrowseOptions, fillWithUn
     clearedBrowseOptions.status = AssetStatusFilter.ON_SALE
   }
 
-  // The onlyOnSale filter is ON by default for some sections. The clear should remove it if it's off so it's back on (default state)
+  // The onlyOnSale filter is ON by default for some sections. The clear should remove it if it's off so it's back on (default state).
+  // My Assets (current account) is the exception: it shows all assets by default with "On Sale" as an opt-in filter,
+  // so clearing keeps it off (false) and the toggle stays visible.
   if (
     !clearedBrowseOptions.onlyOnSale &&
     !isLandSection(browseOptions.section as Section) &&
     !isCatalogViewWithStatusFilter(browseOptions.view)
   ) {
-    clearedBrowseOptions.onlyOnSale = true
+    clearedBrowseOptions.onlyOnSale = browseOptions.view === View.CURRENT_ACCOUNT ? false : true
   }
   // reset the pages to the first one
   clearedBrowseOptions.page = 1


### PR DESCRIPTION
## Context

Per product feedback, the My Assets filter should be **"On Sale"** rather than "Includes not on sale". By default users should see **all** of their assets, and only the ones on sale when they explicitly turn the "On Sale" filter on.

## Changes

- My Assets now shows **all** of a user's assets by default across every asset section (wearables, emotes, names, LAND). "On Sale" becomes an opt-in filter that narrows the view to assets currently on sale when enabled.
- Names (ENS) in My Assets now default to showing all names instead of only the ones on sale.
- `onlyOnSale === false` (showing all) is no longer treated as an active filter in My Assets, so the "Includes not on sale" pill and the empty "Clear filters" bar no longer appear by default.
- Clearing filters in My Assets keeps the On Sale filter off (shows all) instead of reverting to on-sale only.
- The selected-filter pill now reads "On Sale" and removing it turns the filter off; the collapsed "More filters" header no longer shows "Includes not on sale".
- Marketplace, LAND browsing and other accounts' stores keep their existing behavior — all changes are gated to the current account (My Assets) view.

## Test plan

- [ ] Open My Assets → all owned wearables / emotes / names / LAND are shown by default, with no active "Clear filters" bar.
- [ ] Turn the "On Sale" filter on → only assets on sale are shown and an "On Sale" pill appears.
- [ ] Remove the "On Sale" pill (or clear filters) → returns to showing all assets.
- [ ] Marketplace and other users' stores still default to showing items on sale.