### PR TITLE
fix(mobile-iap): checkout below total + 225-credit price cap

### DIFF
--- a/webapp/src/components/AssetTopbar/AssetTopbar.tsx
+++ b/webapp/src/components/AssetTopbar/AssetTopbar.tsx
@@ -4,6 +4,7 @@ import { NFTCategory } from '@dcl/schemas'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Close, Dropdown, DropdownProps, Field, Icon, useTabletAndBelowMediaQuery } from 'decentraland-ui'
 import trash from '../../images/trash.png'
+import { useIsIAP } from '../../modules/iap/useIAP'
 import { getCategoryFromSection, getSectionFromCategory } from '../../modules/routing/search'
 import { SortBy } from '../../modules/routing/types'
 import { isCatalogView } from '../../modules/routing/utils'
@@ -34,6 +35,10 @@ export const AssetTopbar = ({
   sortByOptions
 }: Props): JSX.Element => {
   const isMobile = useTabletAndBelowMediaQuery()
+  // In mobile-IAP mode the price/status/credits filters are force-injected (see store.ts),
+  // so the removable filter chips + "clear all" must stay hidden — otherwise the user could
+  // strip the maxPrice ceiling and see unaffordable items (#2298).
+  const isIAP = useIsIAP()
   const searchBarFieldRef = useRef<HTMLDivElement>(null)
   const category = section ? getCategoryFromSection(section) : undefined
   const [searchValueForDropdown, setSearchValueForDropdown] = useState(search)
@@ -232,7 +237,7 @@ export const AssetTopbar = ({
           ) : null}
         </div>
       )}
-      {!isMap && hasFiltersEnabled ? (
+      {!isMap && hasFiltersEnabled && !isIAP ? (
         <div className={styles.selectedFiltersContainer}>
           <SelectedFilters />
           <button className={styles.clearFilters} onClick={onClearFilters}>

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.module.css
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.module.css
@@ -462,6 +462,14 @@
   line-height: 26px;
 }
 
+/* Checkout button anchored directly below the Total in the IAP flow (#2306). The button
+   is `fluid`, so it fills this full-width block; the margin separates it from the Total. */
+.iapCheckoutButton {
+  display: flex;
+  width: 100%;
+  margin-top: 40px;
+}
+
 @media (max-width: 767px) {
   .buyWithCryptoModal {
     height: 100%;

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.tsx
@@ -835,13 +835,19 @@ export const BuyWithCryptoModal = (props: Props) => {
               )}
 
               {isIAP ? (
-                <div className={styles.iapTotalContainer}>
-                  <span>{t('buy_with_crypto_modal.total')}</span>
-                  <span className={styles.creditsPrice}>
-                    <img src={CreditsIcon} alt="Credits" className={styles.creditsIcon} />
-                    {formatWeiMANA(displayPrice)}
-                  </span>
-                </div>
+                <>
+                  <div className={styles.iapTotalContainer}>
+                    <span>{t('buy_with_crypto_modal.total')}</span>
+                    <span className={styles.creditsPrice}>
+                      <img src={CreditsIcon} alt="Credits" className={styles.creditsIcon} />
+                      {formatWeiMANA(displayPrice)}
+                    </span>
+                  </div>
+                  {/* Anchor the Checkout button directly below the Total so the flow reads
+                      items → total → checkout (#2306). For non-IAP the button stays pinned to
+                      the modal footer via Modal.Actions below. */}
+                  <div className={styles.iapCheckoutButton}>{renderMainActionButton()}</div>
+                </>
               ) : (
                 <PurchaseTotal
                   selectedToken={selectedToken}
@@ -943,7 +949,7 @@ export const BuyWithCryptoModal = (props: Props) => {
           )}
         </>
       </Modal.Content>
-      {showChainSelector || showTokenSelector || isPollingCrossChain || isCrossChainFailed || isCrossChainSucceeded ? null : (
+      {showChainSelector || showTokenSelector || isPollingCrossChain || isCrossChainFailed || isCrossChainSucceeded || isIAP ? null : (
         <Modal.Actions>
           <div className={classNames(styles.buttons, isWearableOrEmote(asset) && 'with-mana')}>{renderMainActionButton()}</div>
           {isWearableOrEmote(asset) && isBuyWithCardPage ? (

--- a/webapp/src/modules/store.ts
+++ b/webapp/src/modules/store.ts
@@ -43,6 +43,10 @@ export const createHistory = () => {
   }
 
   // Persist `view` query param (e.g. mobile-iap) and forced filters across all navigations
+  // Largest credits tier (tier3 = 225 credits) as a price ceiling: items priced above it
+  // can't be bought with a single In-App Purchase, so they're filtered out (#2298). The
+  // browse `maxPrice` is in whole MANA/credits (parsed via parseUnits downstream), not wei.
+  const MOBILE_IAP_MAX_PRICE = '225'
   const initialParams = new URLSearchParams(window.location.search)
   const viewParam = initialParams.get('view')
   const isIAP = viewParam === 'mobile-iap'
@@ -55,12 +59,14 @@ export const createHistory = () => {
         params.set('view', 'mobile-iap')
         params.set('withCredits', 'true')
         params.set('status', 'on_sale')
+        params.set('maxPrice', MOBILE_IAP_MAX_PRICE)
         return `${pathname}?${params.toString()}`
       }
       const params = new URLSearchParams(path.search || '')
       params.set('view', 'mobile-iap')
       params.set('withCredits', 'true')
       params.set('status', 'on_sale')
+      params.set('maxPrice', MOBILE_IAP_MAX_PRICE)
       return { ...path, search: `?${params.toString()}` }
     }
 


### PR DESCRIPTION
Polish for the mobile-IAP webview (`view=mobile-iap`):

- Anchor the **Checkout** button directly below the **Total** in the buy modal.
- Cap browse to **225 credits (MANA)** and hide the active-filter chips so the ceiling can't be removed — items priced above the top credits tier aren't purchasable.

Related issues:
- decentraland/godot-explorer#2306
- decentraland/godot-explorer#2298
