### PR TITLE
fix: show make offer on estates with listings affected by the registry upgrade

### DIFF
--- a/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
+++ b/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
@@ -235,7 +235,15 @@ const SaleRentActionBox = ({
                 ) : null}
                 <div className={styles.saleButtons}>
                   {order && !isEstateListingBroken ? <BuyWithCryptoButton asset={nft} onClick={onBuyWithCrypto} /> : null}
-                  {canBid && !isEstateListingBroken ? (
+                  {/*
+                   * Making a new offer is independent of the seller's listing being
+                   * broken by the EstateRegistry upgrade. A fresh bid is signed with the
+                   * on-chain getFingerprintV2 value, so it is executable regardless of
+                   * whether an existing pre-upgrade order/listing on the same Estate is
+                   * no longer honored. Only the BUY action (which executes the seller's
+                   * existing order) is gated by `isEstateListingBroken`.
+                   */}
+                  {canBid ? (
                     <Popup
                       content={t('asset_page.sales_rent_action_box.parcel_belongs_to_estate_bid')}
                       position="top center"


### PR DESCRIPTION
## Context

On Estate detail pages for Estates with >18 LANDs (e.g. [token 6466](https://decentraland.org/marketplace/contracts/0x959e104e1a4db6317fa58f8295f586e1a978c297/tokens/6466)), the `EstateUpgradeWarning` shows ("this listing is no longer available, the seller needs to recreate it") but the **MAKE OFFER** button is missing.

## Root cause

In `SaleRentActionBox`, the bid button was gated by `canBid && !isEstateListingBroken`, where `isEstateListingBroken = isEstateListingAffectedByUpgrade(nft)` is `true` for any Estate >18 LANDs. So the registry-upgrade flag was suppressing **both** the BUY button and the MAKE OFFER button.

Suppressing BUY is correct — it executes the seller's existing (now non-executable) order. But suppressing MAKE OFFER is wrong: a new bid is signed with the on-chain `getFingerprintV2` value (since #2639), so it is executable regardless of whether a pre-upgrade listing on the same Estate is broken. Making an offer is exactly what a visitor should still be able to do when the seller's listing is dead.

## Changes

- Decouple the MAKE OFFER (bid) button from `isEstateListingBroken` in `SaleRentActionBox`. The BUY button stays gated.

## Test plan

- [ ] On an Estate >18 LANDs with a broken listing: the upgrade warning shows, BUY is hidden, **MAKE OFFER is visible** (for non-owners).
- [ ] On an Estate >18 LANDs: a bid placed from MAKE OFFER is accepted by the server and is acceptable on-chain by the owner.
- [ ] On a normal Estate (≤18 LANDs) / Parcel: no behavior change.
- [ ] Owner view: still sees MANAGE, not MAKE OFFER.