### PR TITLE
fix: only flag estate listings broken by the upgrade per-listing, not by size alone

### DIFF
--- a/webapp/src/components/AssetPage/BuyNFTBox/BuyNFTBox.tsx
+++ b/webapp/src/components/AssetPage/BuyNFTBox/BuyNFTBox.tsx
@@ -35,7 +35,7 @@ const BuyNFTBox = ({ nft, bids, address, wallet, onFetchBids }: Props) => {
         : order.expiresAt * 1000 // in s
     )
     const isOrderExpired = getIsOrderExpired(order.expiresAt)
-    const isEstateListingBroken = isEstateListingAffectedByUpgrade(nft)
+    const isEstateListingBroken = isEstateListingAffectedByUpgrade(nft, order?.createdAt)
 
     const handleUseCredits = (value: boolean) => {
       setUseCredits(value)
@@ -43,7 +43,7 @@ const BuyNFTBox = ({ nft, bids, address, wallet, onFetchBids }: Props) => {
 
     return (
       <div className={`${styles.containerColumn} ${styles.fullWidth}`}>
-        <EstateUpgradeWarning nft={nft} isOwnListing={!!isOwner} />
+        <EstateUpgradeWarning nft={nft} isOwnListing={!!isOwner} listingCreatedAt={order?.createdAt} />
         <div className={styles.informationContainer}>
           <div className={styles.columnListing}>
             <span className={styles.informationTitle}>{t('best_buying_option.minting.price').toUpperCase()}</span>

--- a/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
+++ b/webapp/src/components/AssetPage/SaleRentActionBox/SaleRentActionBox.tsx
@@ -53,7 +53,7 @@ const SaleRentActionBox = ({
   const isRentalOpen = isRentalListingOpen(rental)
   const isOwner = isOwnedBy(nft, wallet, rental ? rental : undefined)
   const isTenant = rental && wallet && addressEquals(rental.tenant ?? undefined, wallet.address)
-  const isEstateListingBroken = isEstateListingAffectedByUpgrade(nft)
+  const isEstateListingBroken = isEstateListingAffectedByUpgrade(nft, order?.createdAt)
 
   const [selectedRentalPeriodIndex, setSelectedRentalPeriodIndex] = useState<number | undefined>(undefined)
   const [view, setView] = useState(!!order || !isRentalOpen ? View.SALE : View.RENT)
@@ -98,7 +98,7 @@ const SaleRentActionBox = ({
 
   return (
     <div className={styles.main}>
-      <EstateUpgradeWarning nft={nft} isOwnListing={isOwner} />
+      <EstateUpgradeWarning nft={nft} isOwnListing={isOwner} listingCreatedAt={order?.createdAt} />
       {isRentalOpen && maxPriceOfPeriods ? (
         <div className={styles.viewSelector}>
           <button

--- a/webapp/src/components/Bid/Bid.tsx
+++ b/webapp/src/components/Bid/Bid.tsx
@@ -144,7 +144,7 @@ const Bid = (props: Props) => {
           {asset => (
             <>
               {isBidder ? <WarningMessage asset={asset} bid={bid} /> : null}
-              {asset && isNFT(asset) ? <EstateUpgradeWarning nft={asset} isOwnListing={isBidder} /> : null}
+              {asset && isNFT(asset) ? <EstateUpgradeWarning nft={asset} isOwnListing={isBidder} listingCreatedAt={bid.createdAt} /> : null}
             </>
           )}
         </AssetProvider>

--- a/webapp/src/components/EstateUpgradeWarning/EstateUpgradeWarning.tsx
+++ b/webapp/src/components/EstateUpgradeWarning/EstateUpgradeWarning.tsx
@@ -12,10 +12,15 @@ type Props = {
   // When true, callers are showing this on the lister's own listing — the wording
   // uses "you" instead of "the seller".
   isOwnListing?: boolean
+  // Creation timestamp (seconds or ms) of the listing being shown (order / bid).
+  // The warning only renders for a listing created before the v2-fingerprint
+  // cutoff — i.e. one actually broken by the upgrade. Omit it when there is no
+  // listing in context.
+  listingCreatedAt?: number
 }
 
-const EstateUpgradeWarning = ({ nft, className, isOwnListing = false }: Props) => {
-  if (!isEstateListingAffectedByUpgrade(nft)) return null
+const EstateUpgradeWarning = ({ nft, className, isOwnListing = false, listingCreatedAt }: Props) => {
+  if (!isEstateListingAffectedByUpgrade(nft, listingCreatedAt)) return null
 
   const messageKey = isOwnListing ? 'estate_upgrade_warning.owner' : 'estate_upgrade_warning.visitor'
 

--- a/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
+++ b/webapp/src/components/ManageAssetPage/ManageAssetPage.tsx
@@ -90,7 +90,7 @@ export const ManageAssetPage = (props: Props) => {
                           <Column className={styles.content}>
                             {asset && !isLoading ? (
                               <>
-                                <EstateUpgradeWarning nft={asset} isOwnListing />
+                                <EstateUpgradeWarning nft={asset} isOwnListing listingCreatedAt={order?.createdAt} />
                                 <section className={styles.assetDescription}>
                                   <div className={styles.assetDescriptionHeader}>
                                     <h1 className={styles.assetDescriptionTitle}>{asset?.name}</h1>
@@ -139,7 +139,7 @@ export const ManageAssetPage = (props: Props) => {
                             ) : null}
                             {asset && !isLoading ? (
                               <>
-                                <EstateUpgradeWarning nft={asset} isOwnListing />
+                                <EstateUpgradeWarning nft={asset} isOwnListing listingCreatedAt={order?.createdAt} />
                                 <section className={styles.assetDescription}>
                                   <div className={styles.assetDescriptionHeader}>
                                     <h1 className={styles.assetDescriptionTitle}>{asset?.name}</h1>

--- a/webapp/src/components/OnSaleOrRentList/OnSaleListElement/OnSaleListElement.tsx
+++ b/webapp/src/components/OnSaleOrRentList/OnSaleListElement/OnSaleListElement.tsx
@@ -16,7 +16,7 @@ import './OnSaleListElement.css'
 
 const OnSaleListElement = ({ nft, item, order, isAuthorized, authorization, onRevoke, wallet }: Props) => {
   const category = item?.category || nft!.category
-  const isAffectedByEstateUpgrade = !!nft && isNFT(nft) && isEstateListingAffectedByUpgrade(nft)
+  const isAffectedByEstateUpgrade = !!nft && isNFT(nft) && isEstateListingAffectedByUpgrade(nft, order?.createdAt)
 
   const cancelOrSellOptions = {
     redirectTo: locations.currentAccount({
@@ -33,7 +33,7 @@ const OnSaleListElement = ({ nft, item, order, isAuthorized, authorization, onRe
             {formatWeiMANA(item?.price || order!.price)}
           </Mana>
         </div>
-        {isAffectedByEstateUpgrade ? <EstateUpgradeWarning nft={nft} isOwnListing /> : null}
+        {isAffectedByEstateUpgrade ? <EstateUpgradeWarning nft={nft} isOwnListing listingCreatedAt={order?.createdAt} /> : null}
       </Mobile>
       <NotMobile>
         <Table.Row>

--- a/webapp/src/lib/estateUpgrade.spec.ts
+++ b/webapp/src/lib/estateUpgrade.spec.ts
@@ -1,6 +1,6 @@
 import { NFTCategory } from '@dcl/schemas'
 import { NFT } from '../modules/nft/types'
-import { ESTATE_LR_XOR_SAFE_MAX_SIZE, isEstateListingAffectedByUpgrade } from './estateUpgrade'
+import { ESTATE_LR_XOR_SAFE_MAX_SIZE, ESTATE_V2_FINGERPRINT_LISTING_CUTOFF, isEstateListingAffectedByUpgrade } from './estateUpgrade'
 
 function makeEstateNFT(size: number | undefined): NFT {
   return {
@@ -16,36 +16,68 @@ function makeParcelNFT(): NFT {
   } as unknown as NFT
 }
 
+const beforeCutoffInSeconds = ESTATE_V2_FINGERPRINT_LISTING_CUTOFF - 1
+const afterCutoffInSeconds = ESTATE_V2_FINGERPRINT_LISTING_CUTOFF + 1
+const aboveThreshold = ESTATE_LR_XOR_SAFE_MAX_SIZE + 1
+
 describe('isEstateListingAffectedByUpgrade', () => {
   describe('when the NFT is not an Estate', () => {
-    it('should return false', () => {
-      expect(isEstateListingAffectedByUpgrade(makeParcelNFT())).toBe(false)
+    it('should return false even with a pre-cutoff listing', () => {
+      expect(isEstateListingAffectedByUpgrade(makeParcelNFT(), beforeCutoffInSeconds)).toBe(false)
     })
   })
 
-  describe('when the NFT is an Estate', () => {
-    describe('and the Estate size exceeds the safe threshold', () => {
+  describe('when the NFT is an Estate larger than the safe threshold', () => {
+    describe('and there is no listing', () => {
+      it('should return false', () => {
+        expect(isEstateListingAffectedByUpgrade(makeEstateNFT(aboveThreshold))).toBe(false)
+      })
+    })
+
+    describe('and the listing was created before the v2-fingerprint cutoff', () => {
       it('should return true', () => {
-        expect(isEstateListingAffectedByUpgrade(makeEstateNFT(ESTATE_LR_XOR_SAFE_MAX_SIZE + 1))).toBe(true)
+        expect(isEstateListingAffectedByUpgrade(makeEstateNFT(aboveThreshold), beforeCutoffInSeconds)).toBe(true)
       })
     })
 
-    describe('and the Estate size is at the safe threshold', () => {
+    describe('and the listing was created after the v2-fingerprint cutoff', () => {
       it('should return false', () => {
-        expect(isEstateListingAffectedByUpgrade(makeEstateNFT(ESTATE_LR_XOR_SAFE_MAX_SIZE))).toBe(false)
+        expect(isEstateListingAffectedByUpgrade(makeEstateNFT(aboveThreshold), afterCutoffInSeconds)).toBe(false)
       })
     })
 
-    describe('and the Estate size is below the safe threshold', () => {
-      it('should return false', () => {
-        expect(isEstateListingAffectedByUpgrade(makeEstateNFT(5))).toBe(false)
+    describe('and the listing timestamp is in milliseconds', () => {
+      describe('and it is before the cutoff', () => {
+        it('should return true', () => {
+          expect(isEstateListingAffectedByUpgrade(makeEstateNFT(aboveThreshold), beforeCutoffInSeconds * 1000)).toBe(true)
+        })
+      })
+
+      describe('and it is after the cutoff', () => {
+        it('should return false', () => {
+          expect(isEstateListingAffectedByUpgrade(makeEstateNFT(aboveThreshold), afterCutoffInSeconds * 1000)).toBe(false)
+        })
+      })
+    })
+  })
+
+  describe('when the NFT is an Estate at or below the safe threshold', () => {
+    describe('and the size is at the threshold', () => {
+      it('should return false even with a pre-cutoff listing', () => {
+        expect(isEstateListingAffectedByUpgrade(makeEstateNFT(ESTATE_LR_XOR_SAFE_MAX_SIZE), beforeCutoffInSeconds)).toBe(false)
       })
     })
 
-    describe('and the Estate has no size data', () => {
-      it('should return false', () => {
-        expect(isEstateListingAffectedByUpgrade(makeEstateNFT(undefined))).toBe(false)
+    describe('and the size is below the threshold', () => {
+      it('should return false even with a pre-cutoff listing', () => {
+        expect(isEstateListingAffectedByUpgrade(makeEstateNFT(5), beforeCutoffInSeconds)).toBe(false)
       })
+    })
+  })
+
+  describe('when the Estate has no size data', () => {
+    it('should return false', () => {
+      expect(isEstateListingAffectedByUpgrade(makeEstateNFT(undefined), beforeCutoffInSeconds)).toBe(false)
     })
   })
 })

--- a/webapp/src/lib/estateUpgrade.ts
+++ b/webapp/src/lib/estateUpgrade.ts
@@ -7,6 +7,13 @@ import { NFT } from '../modules/nft/types'
 // trades) become non-executable on-chain and must be re-created by the seller.
 export const ESTATE_LR_XOR_SAFE_MAX_SIZE = 18
 
+// Unix seconds of when the marketplace started signing/validating Estate listings
+// against getFingerprintV2 (server commit `9877d90`, 2026-05-20 13:37:12 UTC).
+// Listings created before this carry a legacy v1 fingerprint; listings created
+// after are v2 and remain executable. Used to tell a broken pre-upgrade listing
+// apart from a valid new one on a large Estate.
+export const ESTATE_V2_FINGERPRINT_LISTING_CUTOFF = 1779284232
+
 function isEstateNFT(nft: NFT | null | undefined): boolean {
   return !!nft && nft.category === NFTCategory.ESTATE
 }
@@ -16,10 +23,23 @@ function getEstateSize(nft: NFT | null | undefined): number | undefined {
   return nft?.data.estate?.size
 }
 
-// True when an Estate listing (order / bid / rental) is non-executable on-chain
-// because the underlying Estate exceeds the size that the post-upgrade
-// EstateRegistry can still verify with the legacy v1 fingerprint.
-export function isEstateListingAffectedByUpgrade(nft: NFT | null | undefined): boolean {
+// Normalizes a timestamp that may arrive in seconds or milliseconds to seconds.
+function toSeconds(timestamp: number): number {
+  return timestamp > 1e12 ? Math.floor(timestamp / 1000) : timestamp
+}
+
+// True when a specific Estate listing (order / bid) is non-executable on-chain
+// after the upgrade: the Estate is larger than the LR-XOR safe size AND the
+// listing was created before the v2-fingerprint cutoff (so it carries a stale v1
+// fingerprint the contract no longer honors).
+//
+// `listingCreatedAt` is the order/bid creation timestamp (seconds or ms). When it
+// is undefined there is no listing to be broken, so this returns false — that is
+// what keeps the upgrade warning off Estates that simply have no active listing
+// and off valid listings created after the cutoff.
+export function isEstateListingAffectedByUpgrade(nft: NFT | null | undefined, listingCreatedAt?: number): boolean {
   const size = getEstateSize(nft)
-  return size !== undefined && size > ESTATE_LR_XOR_SAFE_MAX_SIZE
+  if (size === undefined || size <= ESTATE_LR_XOR_SAFE_MAX_SIZE) return false
+  if (listingCreatedAt === undefined) return false
+  return toSeconds(listingCreatedAt) < ESTATE_V2_FINGERPRINT_LISTING_CUTOFF
 }


### PR DESCRIPTION
## Context

The EstateRegistry upgrade (`getFingerprint` LR-XOR → `getFingerprintV2`) made pre-upgrade listings on Estates > 18 LANDs non-executable. We flag those with `EstateUpgradeWarning` + suppressed BUY. But the flag, `isEstateListingAffectedByUpgrade(nft)`, was **size-only** — it returned `true` for *every* Estate > 18 LANDs, regardless of whether there was a listing or when it was created.

That produced false positives:
- A **valid new** listing on a > 18 LAND Estate (created after the fix, with a v2 fingerprint) showed the "no longer available, recreate it" warning and had BUY hidden — even though it is perfectly executable.
- Estates > 18 LANDs with **no listing at all** showed the warning for no reason.

## Change

Makes the determination **per-listing**: `isEstateListingAffectedByUpgrade(nft, listingCreatedAt?)` now returns `true` only when

- the Estate is larger than `ESTATE_LR_XOR_SAFE_MAX_SIZE` (18), **and**
- a listing is present (`listingCreatedAt` is defined), **and**
- the listing was created before `ESTATE_V2_FINGERPRINT_LISTING_CUTOFF` (`2026-05-20 13:37:12 UTC`, when the marketplace started signing/validating against `getFingerprintV2`) — i.e. it carries a stale v1 fingerprint.

The timestamp is normalized (`toSeconds`) so it works whether the listing's `createdAt` arrives in seconds or milliseconds.

`EstateUpgradeWarning` gains a `listingCreatedAt` prop, threaded from the order/bid in each call site:

- `SaleRentActionBox`, `BuyNFTBox` → `order?.createdAt`
- `ManageAssetPage`, `OnSaleListElement` → `order?.createdAt` (owner surfaces)
- `Bid` → `bid.createdAt`

## Effect

| Case | Before (size-only) | After (per-listing) |
|------|--------------------|---------------------|
| Owner's pre-upgrade broken listing (>18) | warning + no BUY | warning + no BUY + still visible → re-list ✅ |
| Valid new listing (>18) | warning + no BUY ❌ | BUY normal, no warning ✅ |
| Estate >18 with no listing | warning ❌ | no warning ✅ |
| Pre-upgrade broken listing buyer view | no BUY + MAKE OFFER | no BUY + MAKE OFFER ✅ |

Companion to decentraland/marketplace-server#358, which hides broken Estate orders from the public browse feed (but keeps them on owner surfaces / the detail page so the owner sees they must re-list).

## Test plan

- [x] `estateUpgrade.spec.ts` updated for the per-listing behavior (seconds + ms inputs, before/after cutoff, ≤18 guard, no-listing guard)
- [ ] >18 Estate, pre-cutoff listing: warning shows, BUY hidden, MAKE OFFER visible; owner can still see & re-list
- [ ] >18 Estate, post-cutoff (valid) listing: BUY shows, no warning
- [ ] >18 Estate, no listing: no warning
- [ ] ≤18 Estate: unaffected regardless of listing age