### PR TITLE
fix: show ethereum wearables in recently sold table

### DIFF
--- a/webapp/src/components/RecentlySoldTable/RecentlySoldTable.tsx
+++ b/webapp/src/components/RecentlySoldTable/RecentlySoldTable.tsx
@@ -148,7 +148,7 @@ const RecentlySoldTable = (props: Props) => {
     )
   }
 
-  const soldItemRow = (sale: Sale, item: Item | null, isLoading: boolean) => {
+  const soldItemRow = (sale: Sale, item: Item | NFT<VendorName.DECENTRALAND> | null, isLoading: boolean) => {
     return (
       <>
         <Mobile>
@@ -227,18 +227,20 @@ const RecentlySoldTable = (props: Props) => {
                       {item.name}
                     </Link>
 
-                    <span>
-                      <T
-                        id="home_page.analytics.rankings.by_creator"
-                        values={{
-                          creator: (
-                            <span className="rankings-item-data-creator">
-                              <LinkedProfile address={item.creator} textOnly inline={false} />
-                            </span>
-                          )
-                        }}
-                      />
-                    </span>
+                    {'creator' in item ? (
+                      <span>
+                        <T
+                          id="home_page.analytics.rankings.by_creator"
+                          values={{
+                            creator: (
+                              <span className="rankings-item-data-creator">
+                                <LinkedProfile address={item.creator} textOnly inline={false} />
+                              </span>
+                            )
+                          }}
+                        />
+                      </span>
+                    ) : null}
                   </div>
                 </div>
               ) : isLoading ? (
@@ -388,11 +390,19 @@ const RecentlySoldTable = (props: Props) => {
     switch (currentCategory) {
       case NFTCategory.WEARABLE:
       case NFTCategory.EMOTE:
-        content = data.map(sale => (
-          <AssetProvider key={sale.id} type={AssetType.ITEM} contractAddress={sale.contractAddress} tokenId={sale.itemId}>
-            {(item, _order, _rental, isLoading) => soldItemRow(sale, item, isLoading)}
-          </AssetProvider>
-        ))
+        content = data.map(sale =>
+          // Ethereum collections-v1 wearables have no itemId (only secondary-market NFT sales),
+          // so they can only be resolved as NFTs by their tokenId instead of as catalog items.
+          sale.itemId !== null ? (
+            <AssetProvider key={sale.id} type={AssetType.ITEM} contractAddress={sale.contractAddress} tokenId={sale.itemId}>
+              {(item, _order, _rental, isLoading) => soldItemRow(sale, item, isLoading)}
+            </AssetProvider>
+          ) : (
+            <AssetProvider key={sale.id} type={AssetType.NFT} contractAddress={sale.contractAddress} tokenId={sale.tokenId}>
+              {(nft, _order, _rental, isLoading) => soldItemRow(sale, nft, isLoading)}
+            </AssetProvider>
+          )
+        )
         break
       case NFTCategory.ENS:
       case NFTCategory.PARCEL:


### PR DESCRIPTION
## Problem

Ethereum collections-v1 wearables never rendered in the homepage **Recently Sold** table (Wearables/Emotes tabs): their thumbnail, name and "by creator" were blank while seller/buyer/type/time/price still showed.

## Root cause

The table resolved every wearable/emote sale via `<AssetProvider type={AssetType.ITEM} tokenId={sale.itemId}>`. Ethereum collections-v1 wearables are only ever sold on the secondary market (`order`/`bid`), and those sales carry `itemId: null` (only a `tokenId`) — they have no catalog "item" entity. With a null `tokenId`, `AssetProvider`'s fetch is gated off, the item never resolves, and the Item cell renders empty.

Confirmed against prod: of the 500 most recent wearable sales, the 23 Ethereum ones all had `itemId: null` and were all `order`/`bid`; every Polygon sale had an `itemId`.

## Changes

- Route sales with `itemId === null` through `AssetType.NFT` using `sale.tokenId`, so Ethereum wearables resolve as NFTs; the Polygon (`itemId` present) path is unchanged.
- `soldItemRow` now accepts `Item | NFT`; the "by creator" line is guarded with `'creator' in item` since the NFT type has no `creator` field. NFT-resolved rows show image + name + sale info (no creator attribution, as that data isn't available for v1 wearable NFTs).

## Test plan

- [ ] Homepage → Recently Sold → Wearables: rows with the Ethereum MANA icon now show thumbnail + name (previously blank).
- [ ] Polygon wearable/emote rows still render with "by creator" as before.
- [ ] Emotes tab behaves the same.