### PR TITLE
fix: skip collections-v1 items in rankings to avoid invalid item request

### DIFF
--- a/webapp/src/components/RankingsTable/RankingItemRow/RankingItemRow.tsx
+++ b/webapp/src/components/RankingsTable/RankingItemRow/RankingItemRow.tsx
@@ -162,13 +162,17 @@ const RankingItemRow = ({ entity }: Props) => {
     </Table.Row>
   )
 
+  const { contractAddress, tokenId } = parseItemId(entity.id)
+
+  // Collections-v2 items have a numeric itemId. Legacy Ethereum collections-v1 items use a
+  // non-numeric representation id (e.g. "cw_city_sneakers_feet") that the items endpoint can't
+  // resolve, so skip them instead of firing a request the server rejects with a 400.
+  if (!tokenId || !/^\d+$/.test(tokenId)) {
+    return null
+  }
+
   return (
-    <AssetProvider
-      key={entity.id}
-      type={AssetType.ITEM}
-      contractAddress={parseItemId(entity.id).contractAddress}
-      tokenId={parseItemId(entity.id).tokenId}
-    >
+    <AssetProvider key={entity.id} type={AssetType.ITEM} contractAddress={contractAddress} tokenId={tokenId}>
       {(item, _order, _rental, isLoading) => {
         if (!isLoading && !item) {
           return null


### PR DESCRIPTION
## Problem

On the homepage Rankings table (Wearables/Emotes), each legacy Ethereum collections-v1 item triggers a failing `GET /v1/items?...&itemId=<name>` request that returns **HTTP 400**.

## Root cause

Rows resolve via `<AssetProvider type={AssetType.ITEM} tokenId={parseItemId(entity.id).tokenId}>`. The ranking entity id is `${contractAddress}-${itemId}`. Collections-v2 items have a numeric itemId (`0x..-0`), but legacy collections-v1 items use a non-numeric representation id, e.g. `0x32b7...-cw_city_sneakers_feet`. The items endpoint casts `itemId` to numeric, so `numeric("cw_city_sneakers_feet")` fails with 400. These rows already render nothing (the item never resolves), so the only effect today is a wasted 400 request per such item.

Reproduced against prod: numeric `itemId` → 200, non-numeric representation id → 400.

## Changes

- Parse `entity.id` once and early-return `null` when the itemId is missing or non-numeric, so collections-v1 items are skipped instead of firing a request the server rejects. The numeric (collections-v2) path is unchanged. Also removes a brief loader flicker those rows showed before collapsing.

## Test plan

- [ ] Homepage → Rankings → Wearables: no `items?...&itemId=<non-numeric>` 400 requests in the Network tab.
- [ ] Collections-v2 wearable/emote rankings still render normally.
- [ ] Emotes tab behaves the same.