### PR TITLE
fix: bound the rental listing status polling

### DIFF
--- a/webapp/src/config/env/dev.json
+++ b/webapp/src/config/env/dev.json
@@ -9,6 +9,7 @@
   "DEFAULT_FAVORITES_LIST_ID": "70ab6873-4a03-4eb2-b331-4b8be0e0b8af",
   "DECENTRALAND_BLOG": "https://decentraland.org/blog",
   "REFRESH_SIGNATURES_DELAY": "10000",
+  "MAX_REFRESH_SIGNATURES_RETRIES": "60",
   "TRANSACTIONS_API_URL": "https://transactions-api.decentraland.zone/v1",
   "TRANSAK_POLLING_DELAY": "6000",
   "TRANSAK_PUSHER_APP_KEY": "1d9ffac87de599c61283",

--- a/webapp/src/config/env/prod.json
+++ b/webapp/src/config/env/prod.json
@@ -9,6 +9,7 @@
   "DEFAULT_FAVORITES_LIST_ID": "70ab6873-4a03-4eb2-b331-4b8be0e0b8af",
   "DECENTRALAND_BLOG": "https://decentraland.org/blog",
   "REFRESH_SIGNATURES_DELAY": "10000",
+  "MAX_REFRESH_SIGNATURES_RETRIES": "60",
   "TRANSACTIONS_API_URL": "https://transactions-api.decentraland.org/v1",
   "TRANSAK_POLLING_DELAY": "6000",
   "TRANSAK_PUSHER_APP_KEY": "1d9ffac87de599c61283",

--- a/webapp/src/config/env/stg.json
+++ b/webapp/src/config/env/stg.json
@@ -9,6 +9,7 @@
   "DEFAULT_FAVORITES_LIST_ID": "70ab6873-4a03-4eb2-b331-4b8be0e0b8af",
   "DECENTRALAND_BLOG": "https://decentraland.org/blog",
   "REFRESH_SIGNATURES_DELAY": "10000",
+  "MAX_REFRESH_SIGNATURES_RETRIES": "60",
   "TRANSACTIONS_API_URL": "https://transactions-api.decentraland.today/v1",
   "TRANSAK_POLLING_DELAY": "6000",
   "TRANSAK_PUSHER_APP_KEY": "1d9ffac87de599c61283",

--- a/webapp/src/modules/rental/utils.ts
+++ b/webapp/src/modules/rental/utils.ts
@@ -223,14 +223,22 @@ async function delay(milliseconds: number) {
 }
 
 export async function waitUntilRentalChangesStatus(nft: NFT<VendorName>, status: RentalStatus) {
-  let hasChanged = false
-  let listing: RentalListing
-  while (!hasChanged) {
-    await delay(Number(config.get('REFRESH_SIGNATURES_DELAY', '5000')))
-    listing = await rentalsAPI.refreshRentalListing(nft.openRentalId!)
-    hasChanged = listing.status === status
+  if (!nft.openRentalId) {
+    throw new Error('The provided NFT does not have an open rental')
   }
-  return listing!
+
+  // Bounded so a listing that never reaches the expected status stops polling the signatures server
+  const maxRetries = Number(config.get('MAX_REFRESH_SIGNATURES_RETRIES', '60'))
+
+  for (let retry = 0; retry < maxRetries; retry++) {
+    await delay(Number(config.get('REFRESH_SIGNATURES_DELAY', '5000')))
+    const listing: RentalListing = await rentalsAPI.refreshRentalListing(nft.openRentalId)
+    if (listing.status === status) {
+      return listing
+    }
+  }
+
+  throw new Error(`The rental listing did not change to the ${status} status in time`)
 }
 
 /**


### PR DESCRIPTION
## what

`waitUntilRentalChangesStatus` polls the signatures server every `REFRESH_SIGNATURES_DELAY`
milliseconds waiting for a listing to reach a given status, and had no exit condition:

```ts
let hasChanged = false
while (!hasChanged) {
  await delay(...)
  listing = await rentalsAPI.refreshRentalListing(nft.openRentalId!)
  hasChanged = listing.status === status
}
```

if the listing never reaches that status the loop never ends, and the tab keeps requesting
the signatures server for as long as it stays open. it is reachable from five places: the
rental sagas (claim, remove, accept) and the order, nft and bid sagas.

this is not hypothetical. a listing can settle on a status other than the expected one, for
example a listing that gets cancelled while the caller is waiting for `EXECUTED`, and a
signatures-server bug that cancelled listings on refresh made exactly that happen.

## changes

- the loop is bounded by a new `MAX_REFRESH_SIGNATURES_RETRIES` config value, defaulting to
  `60`, and throws when it runs out. every call site already wraps it in a try/catch that
  dispatches a failure action, so the error surfaces as a normal failure instead of a
  silent infinite loop.
- `nft.openRentalId!` was a non null assertion feeding a request that would otherwise ask
  for `undefined`. it is now an explicit guard that throws a readable error.
- `MAX_REFRESH_SIGNATURES_RETRIES` added to the dev, stg and prod configs next to
  `REFRESH_SIGNATURES_DELAY`.

with the default delay of 10s and 60 retries, callers wait up to 10 minutes before giving
up, which is well past the time any of these transactions take to be mined and indexed.

## testing

`eslint` passes on the changed file. the jest suite could not be run locally: it fails to
transform `react-intl` on this machine, on `master` as well as on this branch, so the
failure is unrelated to these changes. the sagas that call this function should be
exercised in CI.