### PR TITLE
fix: accept usd-pegged trades instead of signing an empty value

### DIFF
--- a/webapp/src/utils/trades.spec.ts
+++ b/webapp/src/utils/trades.spec.ts
@@ -7,7 +7,8 @@ import {
   Trade,
   TradeAsset,
   TradeCreation,
-  TradeType
+  TradeType,
+  USDPeggedManaTradeAsset
 } from '@dcl/schemas/dist/dapps/trade'
 import * as ethUtils from 'decentraland-dapps/dist/lib/eth'
 import { TradeService } from 'decentraland-dapps/dist/modules/trades/TradeService'
@@ -67,11 +68,16 @@ describe('when getting the value for a trade asset', () => {
    */
   describe('and the asset is USD-PEGGED MANA', () => {
     beforeEach(() => {
-      asset = { assetType: TradeAssetType.USD_PEGGED_MANA, amount: '600000000000000000' } as ERC20TradeAsset
+      asset = {
+        assetType: TradeAssetType.USD_PEGGED_MANA,
+        contractAddress: '0xmana',
+        amount: '600000000000000000',
+        extra: '0x'
+      } as USDPeggedManaTradeAsset
     })
 
     it('should return the amount, not an empty value', () => {
-      expect(getValueForTradeAsset(asset)).toBe('600000000000000000')
+      expect(getValueForTradeAsset(asset)).toBe((asset as USDPeggedManaTradeAsset).amount)
     })
   })
 })
@@ -294,7 +300,6 @@ describe('when getting the trade to accept', () => {
     const onChainTrade = getOnChainTrade(peggedTrade, beneficiaryAddress)
 
     expect(onChainTrade.received[0].value).toBe('600000000000000000')
-    expect(onChainTrade.received[0].value).not.toBe('')
   })
 })
 

--- a/webapp/src/utils/trades.spec.ts
+++ b/webapp/src/utils/trades.spec.ts
@@ -59,6 +59,21 @@ describe('when getting the value for a trade asset', () => {
       expect(getValueForTradeAsset(asset)).toBe((asset as CollectionItemTradeAsset).itemId)
     })
   })
+
+  /**
+   * A USD-pegged price is an amount like any other as far as this function is concerned. It is denominated
+   * in USD wei rather than MANA wei, but the conversion is the contract's business at settlement — here the
+   * only requirement is reproducing the value the seller signed.
+   */
+  describe('and the asset is USD-PEGGED MANA', () => {
+    beforeEach(() => {
+      asset = { assetType: TradeAssetType.USD_PEGGED_MANA, amount: '600000000000000000' } as ERC20TradeAsset
+    })
+
+    it('should return the amount, not an empty value', () => {
+      expect(getValueForTradeAsset(asset)).toBe('600000000000000000')
+    })
+  })
 })
 
 describe('when getting the trade signature', () => {
@@ -248,6 +263,38 @@ describe('when getting the trade to accept', () => {
         beneficiary: asset.beneficiary
       }))
     })
+  })
+
+  /**
+   * THE REGRESSION THAT MATTERED.
+   *
+   * `getOnChainTrade` rebuilds the trade struct client-side to hand to `accept()`. A USD-pegged received
+   * asset used to come back with `value: ''`, which produces a different trade hash than the one the seller
+   * signed — so the on-chain signature check rejected it, and every credits-priced listing was unbuyable
+   * from this app.
+   *
+   * Asserted against the LITERAL amount rather than through `getValueForTradeAsset`: routing the expectation
+   * through the same function under test (as the structural test above does, correctly, since it is checking
+   * shape) would pass no matter what that function returned.
+   */
+  it('should preserve a USD-pegged price so the rebuilt trade still matches the seller signature', () => {
+    const peggedTrade = {
+      ...trade,
+      received: [
+        {
+          assetType: TradeAssetType.USD_PEGGED_MANA,
+          contractAddress: '0xmana',
+          amount: '600000000000000000',
+          extra: '0x',
+          beneficiary: '0x123123'
+        }
+      ]
+    } as unknown as Trade
+
+    const onChainTrade = getOnChainTrade(peggedTrade, beneficiaryAddress)
+
+    expect(onChainTrade.received[0].value).toBe('600000000000000000')
+    expect(onChainTrade.received[0].value).not.toBe('')
   })
 })
 

--- a/webapp/src/utils/trades.ts
+++ b/webapp/src/utils/trades.ts
@@ -74,19 +74,19 @@ export function getValueForTradeAsset(asset: TradeAsset): string {
     case TradeAssetType.ERC20:
       return asset.amount
     case TradeAssetType.USD_PEGGED_MANA:
-      // The amount VERBATIM, exactly as for ERC20. It is denominated in USD wei rather than MANA wei, but
-      // that is the contract's business — it converts through the oracle at settlement — not this
-      // function's. All that matters here is reproducing the value the SELLER signed.
-      //
-      // Falling through to `default` returned '' for these, and the consequence was not cosmetic:
-      // `generateTradeValues` feeds this into the EIP-712 struct, and `getOnChainTrade` rebuilds that
-      // struct client-side to hand to `accept()`. An empty value yields a different trade hash than the
-      // one the seller signed, so the signature check rejects it on chain — every USD-pegged listing was
-      // unbuyable from this app. The shop carries its own extractor for exactly this reason.
+      // The amount VERBATIM. It is denominated in USD wei rather than MANA wei, but converting it is the
+      // contract's job at settlement, not this function's: what goes in here has to reproduce the value the
+      // SELLER signed, or the rebuilt trade hashes differently and `accept()` is rejected on chain.
       return asset.amount
-    default:
-      console.error('Invalid asset type:', asset)
+    default: {
+      // Compile-time exhaustiveness: a new member of the `TradeAsset` union without a case above becomes a
+      // type error here, instead of a silent '' that only surfaces as a rejected signature on chain (which
+      // is how the USD_PEGGED_MANA case came to be missing). Runtime behaviour is unchanged on purpose —
+      // this also receives API data, so a value outside the union must degrade rather than throw.
+      const unhandled: never = asset
+      console.error('Invalid asset type:', unhandled)
       return ''
+    }
   }
 }
 

--- a/webapp/src/utils/trades.ts
+++ b/webapp/src/utils/trades.ts
@@ -73,6 +73,17 @@ export function getValueForTradeAsset(asset: TradeAsset): string {
       return asset.itemId
     case TradeAssetType.ERC20:
       return asset.amount
+    case TradeAssetType.USD_PEGGED_MANA:
+      // The amount VERBATIM, exactly as for ERC20. It is denominated in USD wei rather than MANA wei, but
+      // that is the contract's business — it converts through the oracle at settlement — not this
+      // function's. All that matters here is reproducing the value the SELLER signed.
+      //
+      // Falling through to `default` returned '' for these, and the consequence was not cosmetic:
+      // `generateTradeValues` feeds this into the EIP-712 struct, and `getOnChainTrade` rebuilds that
+      // struct client-side to hand to `accept()`. An empty value yields a different trade hash than the
+      // one the seller signed, so the signature check rejects it on chain — every USD-pegged listing was
+      // unbuyable from this app. The shop carries its own extractor for exactly this reason.
+      return asset.amount
     default:
       console.error('Invalid asset type:', asset)
       return ''


### PR DESCRIPTION
Every USD-pegged listing is unbuyable from this app. Not mispriced — **unbuyable**.

`getValueForTradeAsset` had no case for `TradeAssetType.USD_PEGGED_MANA`, so it fell through to `default`,
logged "Invalid asset type" and returned `''`.

That value is not cosmetic. `generateTradeValues` feeds it into the EIP-712 struct, and `getOnChainTrade`
rebuilds that struct **client-side** to hand to the contract's `accept()`:

```
getOnChainTrade(trade, buyer) → generateTradeValues(trade) → getValueForTradeAsset(asset)   // utils/trades.ts:103,110
```

So the seller signs a trade whose received value is `600000000000000000`, and the buyer submits one whose
received value is `''`. Different struct, different trade hash, and the on-chain signature check rejects it.
`estimateTradeGas` runs through the same helper, so it fails first and surfaces as a generic error with nothing
pointing at the cause.

This is live right now and getting worse on its own: as creators migrate listings from MANA to credits, each
migrated listing becomes unbuyable here. The shop is unaffected — it carries its own extractor precisely
because of this gap, with a comment saying so.

## The fix

```ts
case TradeAssetType.USD_PEGGED_MANA:
  return asset.amount
```

The amount **verbatim**, exactly as for `ERC20`. It is denominated in USD wei rather than MANA wei, but the
conversion is the contract's business at settlement, not this function's — all that matters here is
reproducing the value the seller signed.

## Tests

Two, and **both fail without the fix** (verified by removing the case and re-running):

1. The unit case: a pegged asset returns its amount, not an empty value.
2. The one that matters: `getOnChainTrade` **preserves** the pegged amount when it rebuilds the struct.
   Asserted against the literal `600000000000000000` rather than through `getValueForTradeAsset` — the
   existing structural test builds its expectation by calling that same function, which is right for checking
   shape but means it would have passed no matter what the function returned. That is why this bug reached
   production with a green suite.

```
src/utils/trades.spec.ts — 8 passed, 2 skipped (pre-existing skips)
```

## Test plan

- [x] `tsc --noEmit`, prettier
- [x] `src/utils/trades.spec.ts`
- [ ] Full suite in CI
- [ ] **Buy a USD-pegged listing on `.zone` from this app** — the point of the change, and it has never
      succeeded, so there is no "still works" to regress
- [ ] Confirm a plain MANA (ERC20) listing still buys, since it shares the code path