### PR TITLE
chore: bump decentraland-dapps so pegged trades can be bought and cancelled

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -26,7 +26,7 @@
         "dcl-catalyst-commons": "^9.0.1",
         "decentraland-connect": "^12.0.0",
         "decentraland-crypto-fetch": "^2.0.1",
-        "decentraland-dapps": "^28.9.0",
+        "decentraland-dapps": "^29.3.1-20260805170817.commit-f4ffa6a",
         "decentraland-transactions": "^3.0.3",
         "decentraland-ui": "^7.1.0",
         "decentraland-ui2": "^3.8.0",
@@ -1670,6 +1670,14 @@
       "resolved": "https://registry.npmjs.org/@dcl/catalyst-contracts/-/catalyst-contracts-4.4.1.tgz",
       "integrity": "sha512-auKNcpZUQV4u7BiL65TXGB0j+eLRVzvpE7oDd7ML0wyB4A8op9B1Ca+7JKZQLClrhj6nbyXoDT7JzFeSpkipoA=="
     },
+    "node_modules/@dcl/core-commons": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@dcl/core-commons/-/core-commons-0.10.1.tgz",
+      "integrity": "sha512-iLBpIg15czlzV7No5Wzb3FyreXpqYx8YnVJ8xYKczXpl6C3eqBQoqEA02hRkd/UASbzqcPJeG1wH1wHSxYTmQw==",
+      "dependencies": {
+        "@well-known-components/interfaces": "^1.5.2"
+      }
+    },
     "node_modules/@dcl/crypto": {
       "version": "3.4.5",
       "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.4.5.tgz",
@@ -1933,6 +1941,14 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/@dcl/fetch-component": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@dcl/fetch-component/-/fetch-component-1.1.1.tgz",
+      "integrity": "sha512-Q1d/By58NRFIF7h5oMSSFNFGtcJmoKKY6V3kOo314soCgSH0IETydwaD8Hu2zPWK9TZQVx+eDJppViyKVpt91Q==",
+      "dependencies": {
+        "@dcl/core-commons": "0.10.1"
+      }
+    },
     "node_modules/@dcl/hashing": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@dcl/hashing/-/hashing-2.0.0.tgz",
@@ -2104,6 +2120,21 @@
         "@formatjs/fast-memoize": "2.2.7",
         "@formatjs/icu-messageformat-parser": "2.11.4",
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@dcl/hooks/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@dcl/schemas": {
@@ -12094,9 +12125,10 @@
       }
     },
     "node_modules/@well-known-components/interfaces": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@well-known-components/interfaces/-/interfaces-1.4.2.tgz",
-      "integrity": "sha512-1tkr/OhZ4UmnQiST2svKznEiJ86crV2S+AIhokhowR4MexAKWgYlmZpoP6VIcgDVPf7nu8hOtIPMQaCZ+COC0A==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@well-known-components/interfaces/-/interfaces-1.5.2.tgz",
+      "integrity": "sha512-TzKQblOci2Azczk1DZ4JL5aJW7hwq7kHrFMO4lCRMmW51bA71BtiZlq0WP72Dln067xTSoHQAU4WHCFJlGYvEQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^20.3.1",
         "@types/node-fetch": "^2.5.12",
@@ -15029,18 +15061,17 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "28.9.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-28.9.0.tgz",
-      "integrity": "sha512-4hg3tVTJpnYGeN4REMuOVc/h9QuNddO6WRJ9B/VpWlduXg5QbjTSLObeFpDd94zueXO4FPj2DbRlM8uoeNxnpQ==",
+      "version": "29.3.1-20260805170817.commit-f4ffa6a",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-29.3.1-20260805170817.commit-f4ffa6a.tgz",
+      "integrity": "sha512-tXPxJJ8X5TRo3x/nftIrBx88msQEsr84hMA6peJs2JdJug1GCvmRna72MgNmvuZeboM0+laxMkTAedcVHltY6w==",
       "dependencies": {
         "@0xsequence/multicall": "0.25.1",
         "@0xsequence/relayer": "0.25.1",
         "@dcl/single-sign-on-client": "^0.1.0",
         "@transak/transak-sdk": "4.0.0",
         "@wert-io/widget-initializer": "6.8.0",
-        "axios": "0.21.4",
         "date-fns": "1.30.1",
-        "dcl-catalyst-client": "^21.1.0",
+        "dcl-catalyst-client": "^22.0.0",
         "decentraland-crypto-fetch": "^2.0.1",
         "decentraland-transactions": "^3.0.2",
         "events": "3.3.0",
@@ -15075,18 +15106,45 @@
         "redux-saga": "^1.1.3"
       }
     },
-    "node_modules/decentraland-dapps/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
+    "node_modules/decentraland-dapps/node_modules/@dcl/hashing": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@dcl/hashing/-/hashing-3.0.4.tgz",
+      "integrity": "sha512-Cg+MoIOn+BYmQV2q8zSFnNYY+GldlnUazwBnfgrq3i66ZxOaZ65h01btd8OUtSAlfWG4VTNIOHDjtKqmuwJNBg==",
+      "license": "Apache-2.0"
     },
     "node_modules/decentraland-dapps/node_modules/date-fns": {
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+    },
+    "node_modules/decentraland-dapps/node_modules/dcl-catalyst-client": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-22.0.0.tgz",
+      "integrity": "sha512-K2cjYR5RZcdH6YNC7YjQMmZd4fhlE7zGyc79sYWvJGgofjO8TxAJ7CCNahqqllzMrdnxidFFGOWXTYJMJmOdqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@dcl/catalyst-contracts": "^4.4.0",
+        "@dcl/crypto": "^3.4.0",
+        "@dcl/fetch-component": "^1.0.1",
+        "@dcl/hashing": "^3.0.0",
+        "@dcl/schemas": "^23.0.0",
+        "cookie": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/decentraland-dapps/node_modules/dcl-catalyst-client/node_modules/@dcl/schemas": {
+      "version": "23.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-23.1.0.tgz",
+      "integrity": "sha512-2+Sp4OrUKyGxEe1nLMuLtEmNwLThGUDei0QqXzurkQMkhQdJvB1viS4UW86Wia7AelmCzBewSLU6to8CgQ8UEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-keywords": "^5.1.0",
+        "mitt": "^3.0.1"
+      }
     },
     "node_modules/decentraland-dapps/node_modules/typesafe-actions": {
       "version": "2.2.0",
@@ -17938,7 +17996,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -23697,7 +23755,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/saxes": {
       "version": "6.0.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -21,7 +21,7 @@
     "dcl-catalyst-commons": "^9.0.1",
     "decentraland-connect": "^12.0.0",
     "decentraland-crypto-fetch": "^2.0.1",
-    "decentraland-dapps": "^28.9.0",
+    "decentraland-dapps": "^29.3.1-20260805170817.commit-f4ffa6a",
     "decentraland-transactions": "^3.0.3",
     "decentraland-ui": "^7.1.0",
     "decentraland-ui2": "^3.8.0",

--- a/webapp/src/components/Navbar/Navbar.tsx
+++ b/webapp/src/components/Navbar/Navbar.tsx
@@ -39,7 +39,6 @@ const Navbar = (props: Props) => {
       {...props}
       withChainSelector
       withNotifications
-      // @ts-expect-error forwarded to ui2 Navbar at runtime; dapps connect() types haven't picked up this ui2 prop yet
       showManaBalancesInNavbar
       activePage="shop"
       identity={props.identity}


### PR DESCRIPTION
A USD-pegged listing can be neither **bought** nor **cancelled** from this app. Both go through
`TradeService` in decentraland-dapps, whose `getValueForTradeAsset` had no case for `USD_PEGGED_MANA` and
returned `''` — so the rebuilt trade struct hashed differently than the seller signed and the on-chain
signature check rejected it.

```
modules/order/sagas.ts:164 → [tradeService, 'accept']
modules/order/sagas.ts:268 → [tradeService, 'cancel']
modules/item/sagas.ts:231  → [tradeService, 'accept']
```

Fixed in decentraland/decentraland-dapps#813. **This bump is what delivers it.** Worth being explicit: #2670
fixed this repo's *own* copy of those helpers, which feeds `estimateTradeGas` and trade creation — the accept
path never touched that copy, so buying a pegged listing stayed broken until now.

## What the 28 → 29 major actually contains

Checked commit by commit rather than assumed:

| commit | impact here |
|---|---|
| `chore: update Node.js to 24 (#799)` | toolchain |
| `chore: update to OIDC npm Trusted Publishing (#800)` | release infra |
| `chore: fix semantic-release permissions in CI (#801)` | CI |
| `chore: migrate to oddish-action for OIDC publishing (#803)` | release infra |
| `fix: sign the sign-external-call credits request (#804)` | **reverted by #806** |
| `Revert "fix: sign the sign-external-call…" (#806)` | — |
| **`refactor: drop node-fetch and axios in favor of native fetch (#807)`** | **the real breaking change** |

So the one that could bite a consumer is #807: response shapes from the package's API clients are no longer
axios-shaped (`.data`).

**This app turns out to have been waiting for it.** The only type error the bump produced was an
`Unused '@ts-expect-error' directive` in `Navbar.tsx`, and the suppression's own comment says why:

```ts
// @ts-expect-error forwarded to ui2 Navbar at runtime; dapps connect() types haven't picked up this ui2 prop yet
showManaBalancesInNavbar
```

In 29 they have. The directive is removed; nothing else needed adapting. (The Builder showed the mirror image of
this — three type errors on `master` that the same bump *resolved*, including one that literally mentioned
`AxiosRequestConfig`.)

## Version pin, and the trap in it

Pinned to `^29.3.1-20260805170817.commit-f4ffa6a`, not `^29.3.1` and not `latest`:

- the fix shipped as a **prerelease**, and npm's caret ranges exclude prereleases unless the range carries one;
- npm's `latest` tag is **still `29.3.0`**, which does not contain the fix.

So `npm i decentraland-dapps@latest` would have looked like an upgrade and changed nothing. `f4ffa6a` is the
merge commit of #813, and I verified the **published artifact** rather than the version string — `dist/lib/trades.js`
in that tarball contains `case TradeAssetType.USD_PEGGED_MANA: return asset.amount`.

## Test plan

- [x] `tsc --noEmit` — 0 errors
- [x] `npm test` — 160 suites / 1827 passing
- [x] `npm run build` — clean
- [x] Diff is the dependency, the lockfile, and the one stale suppression
- [ ] **On `.zone`: buy a pegged listing, and cancel one.** Neither has ever worked, so there is no "still
      works" to regress — this is the first time either is possible.
- [ ] **Also worth a look because of #807:** any screen that fetches through a dapps API client — favorites,
      notifications, credits, rentals. `tsc` covers the shapes it can see, but a runtime `.data` read would slip
      past it. A list that comes back empty or a counter stuck at zero would be native fetch, not the trade fix.