### PR TITLE
chore: bump decentraland-ui2 to 3.18.0

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -29,7 +29,7 @@
         "decentraland-dapps": "^29.3.1-20260805170817.commit-f4ffa6a",
         "decentraland-transactions": "^3.0.3",
         "decentraland-ui": "^7.1.0",
-        "decentraland-ui2": "^3.8.0",
+        "decentraland-ui2": "^3.18.0",
         "ethers": "^5.6.8",
         "graphql": "^14.7.0",
         "history": "^4.10.1",
@@ -2138,9 +2138,9 @@
       }
     },
     "node_modules/@dcl/schemas": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-26.0.0.tgz",
-      "integrity": "sha512-M6R36CAMQFVp6cjXWh16JHunzb4ICjFXhkKnDu2SOc8qjnV6oepL1XfzoVooqrPUVw5bQaO/o9VrIOdXcePkhg==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-26.5.0.tgz",
+      "integrity": "sha512-R7/IXI3g4SFGsVKtsLzwUk7romfV9vxWtI0A7pbwlNEyfPtIVgdIqpgHAXD06vDTAyrEZAWMyzhHxcBEoIXniQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0",
@@ -15234,9 +15234,9 @@
       "license": "ISC"
     },
     "node_modules/decentraland-ui2": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-3.8.0.tgz",
-      "integrity": "sha512-G1x22JxrSB9qI/upQw+gsqvxXQbgTpJBEgyvQgUOh0AEnN3E8gMDYC6r6ZK7E43pVFjp4WGQnAl8GaTJZkXBCA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-3.18.0.tgz",
+      "integrity": "sha512-NG+lyvB3BDYveEJ8ynwpMPWGX+C7prhv8utYA5bOpErxZayoFxaROhzDSm7cs8YuY+2sEcSgHU2WMaISD1bCPg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "11.14.0",
@@ -15255,7 +15255,7 @@
       "peerDependencies": {
         "@contentful/rich-text-react-renderer": "^16.0.0",
         "@dcl/hooks": "^1.2.1",
-        "@dcl/schemas": "^26.0.0",
+        "@dcl/schemas": "^26.5.0",
         "@dcl/ui-env": "^2.0.0",
         "lottie-react": "^2.4.0",
         "react": "^18.2.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -24,7 +24,7 @@
     "decentraland-dapps": "^29.3.1-20260805170817.commit-f4ffa6a",
     "decentraland-transactions": "^3.0.3",
     "decentraland-ui": "^7.1.0",
-    "decentraland-ui2": "^3.8.0",
+    "decentraland-ui2": "^3.18.0",
     "ethers": "^5.6.8",
     "graphql": "^14.7.0",
     "history": "^4.10.1",


### PR DESCRIPTION
Brings the navbar in line with the new shop. Part of the set that lets marketplace, builder and sites all point at it on release.

## Changes

- `decentraland-ui2` `^3.8.0` → `^3.18.0`
- pulls `@dcl/schemas` `26.0.0` → `26.5.0` with it (3.18.0 requires it)

What the navbar inherits: the **Explore** label (was "What's On"), the Shop menu pointing at `decentraland.org/shop` instead of the legacy marketplace, and the hexagonal **C** as the credits mark. LAND and Merch are unchanged.

## Notes

**Verified the bump actually reaches the navbar.** This app renders it through `decentraland-dapps`' `Navbar2` container, not a direct ui2 import, so dapps shipping its own nested copy of ui2 would have made this a PR that changes nothing visible. There is exactly **one** copy of ui2 in the tree (3.18.0) and dapps declares it as `peerDependency ^3.0.0`, so it resolves to this one.

**Ten minors of jump, and `@dcl/schemas` moved five.** That is the real risk here, not ui2 itself — `schemas` is shared type surface (Wearable, ChainId, Trade). `tsc` compiles clean and the suite is green, so nothing broke structurally. What tests cannot answer is visual drift: a ui2 component whose spacing or default changed somewhere across those ten minors. **Worth a look at the preview before merge**, particularly the navbar and anything using ui2 primitives.

## Test plan

- [x] `npm run build` (tsc + vite) — no type errors despite the `@dcl/schemas` bump
- [x] `npm test` — 159 suites / 1815 tests passing (21 skipped, pre-existing)
- [ ] Visual check on the preview: navbar reads "Explore", the Shop menu goes to `/shop`, credits mark is the C
- [ ] **Release timing:** merging is safe, but releasing points users at `/shop` — worth holding the release until the shop is live