### PR TITLE
fix: convert a usd-pegged mint price on the catalog card

### DIFF
--- a/webapp/src/components/AssetCard/AssetCard.spec.tsx
+++ b/webapp/src/components/AssetCard/AssetCard.spec.tsx
@@ -4,11 +4,19 @@ import { BodyShape, ChainId, Network, NFTCategory, Rarity, WearableCategory } fr
 import { Asset } from '../../modules/asset/types'
 import { INITIAL_STATE } from '../../modules/favorites/reducer'
 import { PageName, SortBy } from '../../modules/routing/types'
+import { useTradePriceDenomination } from '../../modules/trade/hooks'
 import { renderWithProviders } from '../../utils/test'
 import AssetCard from './AssetCard'
 import { Props as AssetCardProps } from './AssetCard.types'
 
 const FAVORITES_COUNTER_TEST_ID = 'favorites-counter'
+
+// The two reads the pegged path depends on: which unit the listing is in, and the rate to convert it.
+// Both are network calls in production; here they are dials so a test can state the situation it means.
+jest.mock('../../modules/trade/hooks', () => ({
+  useTradePriceDenomination: jest.fn(() => 'mana'),
+  useManaUsdRate: jest.fn(() => ({ answer: 100000000n, decimals: 8 }))
+}))
 
 function renderAssetCard(props: Partial<AssetCardProps> = {}) {
   return renderWithProviders(
@@ -123,6 +131,46 @@ describe('AssetCard', () => {
         asset
       })
       expect(queryByTestId(FAVORITES_COUNTER_TEST_ID)).toBeNull()
+    })
+  })
+
+  /**
+   * A USD-pegged listing carries USD wei in `price`, so drawing it with the MANA glyph tells the shopper
+   * the item costs a fraction of what it does. The catalog card renders through its own path, which is why
+   * the item page being right did not make the grid right.
+   */
+  describe('when the catalog card shows a USD-pegged mint price', () => {
+    let catalogAsset: Asset
+
+    beforeEach(() => {
+      // $1 per MANA, so the converted figure is a round number the assertion can name.
+      ;(useTradePriceDenomination as jest.Mock).mockReturnValue('usd-pegged')
+      catalogAsset = {
+        ...asset,
+        itemId: '0',
+        price: '20100000000000000000',
+        isOnSale: true,
+        available: 43,
+        listings: 0,
+        minPrice: '20100000000000000000'
+      } as unknown as Asset
+    })
+
+    it('should convert it through the rate instead of labelling the dollars as MANA', () => {
+      renderAssetCard({ asset: catalogAsset, priceTradeId: 'trade-1', sortBy: SortBy.NEWEST })
+      mockAllIsIntersecting(true)
+
+      expect(screen.getByTestId('pegged-mana-price')).toBeInTheDocument()
+    })
+
+    // The same card must NOT convert a resale figure: those are already MANA, and running them through
+    // the rate would be this bug pointing the other way.
+    it('should leave the price alone when it is not the mint price', () => {
+      const withResale = { ...catalogAsset, price: '20100000000000000000', minPrice: '5000000000000000000' } as unknown as Asset
+      renderAssetCard({ asset: withResale, priceTradeId: 'trade-1', sortBy: SortBy.CHEAPEST })
+      mockAllIsIntersecting(true)
+
+      expect(screen.queryByTestId('pegged-mana-price')).toBeNull()
     })
   })
 })

--- a/webapp/src/components/AssetCard/AssetCard.tsx
+++ b/webapp/src/components/AssetCard/AssetCard.tsx
@@ -149,6 +149,17 @@ const AssetCard = (props: Props) => {
     return null
   }, [appliedFilters, asset, sortBy])
 
+  /**
+   * Whether the figure this card is about to show is the USD-pegged MINT price.
+   *
+   * The pegged unit belongs to `asset.price` alone: every other figure a catalog card can show — the
+   * cheapest listing, a min/max range — comes from resales, which are priced in MANA. So the card can
+   * only convert when the value it landed on is the mint price itself; converting a resale figure would
+   * be the same mistake in the other direction.
+   */
+  const showsPeggedMintPrice =
+    isUSDPegged && !isNFT(asset) && !!catalogItemInformation?.price && catalogItemInformation.price === asset.price
+
   const renderCatalogItemInformation = useCallback(() => {
     const isAvailableForMint = !isNFT(asset) && asset.isOnSale && asset.available > 0
     const notForSale = !isAvailableForMint && !isNFT(asset) && !asset.minListingPrice
@@ -161,7 +172,11 @@ const AssetCard = (props: Props) => {
         </span>
 
         {catalogItemInformation.price ? (
-          isIAP ? (
+          showsPeggedMintPrice ? (
+            <div className="PriceInMana">
+              <PeggedManaPrice usdWei={catalogItemInformation.price} network={asset.network} size="large" />
+            </div>
+          ) : isIAP ? (
             <span className="CreditsPrice">
               <img src={CreditsIcon} alt="Credits" className="creditsIcon" />
               {catalogItemInformation.price?.includes('-')
@@ -189,7 +204,7 @@ const AssetCard = (props: Props) => {
         {catalogItemInformation.extraInformation && <span className="extraInformation">{catalogItemInformation.extraInformation}</span>}
       </div>
     ) : null
-  }, [asset, catalogItemInformation])
+  }, [asset, catalogItemInformation, showsPeggedMintPrice, isIAP])
 
   const setWrapperRef = useCallback(
     (node: HTMLDivElement | null) => {


### PR DESCRIPTION
The browse grid draws a USD-pegged listing's price with the MANA glyph, one to one. At today's rate that reads roughly 15x cheaper than the item costs.

Pairs with marketplace-server #387, which sends the `tradeId` this needs. Neither half changes anything on its own.

## Why the item page was already right and the grid was not

`PriceComponent` and the non-catalog branch of `AssetCard` both resolve the unit through `useTradePriceDenomination(tradeId)` and hand a pegged listing to `PeggedManaPrice`, which divides by the oracle rate and marks the result approximate.

The catalog card never reaches that code. Its price renders through `renderCatalogItemInformation`, and the branch that converts is gated on `!isCatalogItem(asset)` — so for a grid card it is not evaluated at all. The value goes straight into `<Mana>`.

## Change

The catalog branch now converts too, under a condition narrower than "the listing is pegged".

**Only when the figure on the card IS the mint price.** A catalog card can also show the cheapest listing or a min/max range, and those come from resales, which are priced in MANA. Converting one of those would be this same bug pointing the other way — a correct MANA figure relabelled as dollars and divided by the rate. So the card converts only when `catalogItemInformation.price === asset.price`.

## End to end

Traced against the deployed code and live data rather than assumed:

- the grid requests `/v2/catalog` (`modules/vendor/decentraland/catalog/api.ts`), which returns `isOnSale: true` and `price: 20.1e18` for a real pegged item — the server was never wrong about the number, only silent about its unit
- `AssetCard.container` reads `asset.tradeId` into `priceTradeId`, which is the field #387 adds
- `useTradePriceDenomination` resolves it to `USD_PEGGED`, and this change routes it to `PeggedManaPrice`

## Test plan

- [x] two new cases in `AssetCard.spec.tsx`: a pegged mint price renders through the converter, and a non-mint figure on the same card does not
- [x] both mutations checked — never converting fails the first, converting on `isUSDPegged` alone fails the second
- [x] `AssetCard.spec.tsx` 7 pass; `npm run check:code` (the command CI runs) reports 0 errors
- [x] typecheck clean
- [ ] full suite and build not run locally (machine thermals); CI is the first full run

## Known adjacent, not fixed here

`min_price` on the server is `LEAST(items.price, nfts_with_orders.min_price)` — a comparison between USD wei and MANA wei when the item is pegged. It predates this change and affects sorting and the cheapest-option label rather than the figure this PR renders, but it is the same unit confusion one layer down and worth its own look.