### PR TITLE
fix: stop a pending rate read from claiming the price is unavailable

### DIFF
--- a/webapp/src/components/AssetCard/AssetCard.spec.tsx
+++ b/webapp/src/components/AssetCard/AssetCard.spec.tsx
@@ -15,7 +15,7 @@ const FAVORITES_COUNTER_TEST_ID = 'favorites-counter'
 // Both are network calls in production; here they are dials so a test can state the situation it means.
 jest.mock('../../modules/trade/hooks', () => ({
   useTradePriceDenomination: jest.fn(() => 'mana'),
-  useManaUsdRate: jest.fn(() => ({ answer: 100000000n, decimals: 8 }))
+  useManaUsdRate: jest.fn(() => ({ status: 'ready', rate: { answer: 100000000n, decimals: 8 } }))
 }))
 
 function renderAssetCard(props: Partial<AssetCardProps> = {}) {

--- a/webapp/src/components/PeggedManaPrice/PeggedManaPrice.module.css
+++ b/webapp/src/components/PeggedManaPrice/PeggedManaPrice.module.css
@@ -8,3 +8,11 @@
 .unavailable {
   opacity: 0.6;
 }
+
+/* Holds the line's height while the rate is being read, so the price does not pop the layout when it
+   lands. Deliberately empty of text: a spinner or a placeholder number next to a Buy button would each
+   say something — that something is wrong, or that this is the price — and neither is true yet. */
+.loading {
+  min-height: 1em;
+  min-width: 4ch;
+}

--- a/webapp/src/components/PeggedManaPrice/PeggedManaPrice.spec.tsx
+++ b/webapp/src/components/PeggedManaPrice/PeggedManaPrice.spec.tsx
@@ -1,0 +1,67 @@
+import { screen } from '@testing-library/react'
+import { Network } from '@dcl/schemas'
+import { useManaUsdRate } from '../../modules/trade/hooks'
+import { renderWithProviders } from '../../utils/test'
+import PeggedManaPrice from './PeggedManaPrice'
+
+jest.mock('../../modules/trade/hooks', () => ({ useManaUsdRate: jest.fn() }))
+
+const asMock = useManaUsdRate as jest.Mock
+
+// $1 per MANA, so a USD figure converts to the same number and the assertion can name it.
+const READY = { status: 'ready', rate: { answer: 100000000n, decimals: 8 } }
+
+function render(usdWei = '20100000000000000000') {
+  return renderWithProviders(<PeggedManaPrice usdWei={usdWei} network={Network.MATIC} />)
+}
+
+/**
+ * "Still reading" and "cannot be read" are different facts about the oracle, and this component is where
+ * the difference is visible. Collapsing them made every price accuse the oracle of being down for the
+ * frame before its first read landed — on a grid, once per card.
+ */
+describe('when the rate is still being read', () => {
+  beforeEach(() => asMock.mockReturnValue({ status: 'pending', rate: null }))
+
+  it('should say nothing rather than claim the price is unavailable', () => {
+    render()
+
+    expect(screen.getByTestId('pegged-mana-price-loading')).toBeInTheDocument()
+    expect(screen.queryByTestId('pegged-mana-price-unavailable')).toBeNull()
+    expect(screen.queryByTestId('pegged-mana-price')).toBeNull()
+  })
+})
+
+describe('when the rate cannot be read', () => {
+  beforeEach(() => asMock.mockReturnValue({ status: 'unavailable', rate: null }))
+
+  // The claim is only honest once a read has actually failed, and then it does need saying: a placeholder
+  // number next to a Buy button would be worse than admitting there is no figure.
+  it('should say the price is unavailable', () => {
+    render()
+
+    expect(screen.getByTestId('pegged-mana-price-unavailable')).toBeInTheDocument()
+    expect(screen.queryByTestId('pegged-mana-price-loading')).toBeNull()
+  })
+})
+
+describe('when the rate is in', () => {
+  beforeEach(() => asMock.mockReturnValue(READY))
+
+  it('should render the converted figure, marked approximate', () => {
+    render()
+
+    expect(screen.getByTestId('pegged-mana-price')).toBeInTheDocument()
+    expect(screen.queryByTestId('pegged-mana-price-loading')).toBeNull()
+    expect(screen.queryByTestId('pegged-mana-price-unavailable')).toBeNull()
+  })
+
+  // A rate that is present but unusable is not a rate: the conversion returns null and the honest answer
+  // is the same one a failed read gets.
+  it('should fall back to unavailable when the rate cannot produce a figure', () => {
+    asMock.mockReturnValue({ status: 'ready', rate: { answer: 0n, decimals: 8 } })
+    render()
+
+    expect(screen.getByTestId('pegged-mana-price-unavailable')).toBeInTheDocument()
+  })
+})

--- a/webapp/src/components/PeggedManaPrice/PeggedManaPrice.tsx
+++ b/webapp/src/components/PeggedManaPrice/PeggedManaPrice.tsx
@@ -38,11 +38,24 @@ function chainIdOf(network: Props['network']): ChainId | undefined {
  * rounds up so the shown figure never sits above the charge.
  */
 const PeggedManaPrice = ({ usdWei, network, size = 'medium', className, manaClassName, inline }: Props) => {
-  const rate = useManaUsdRate(chainIdOf(network))
+  const { status, rate } = useManaUsdRate(chainIdOf(network))
   const manaWei = rate ? usdWeiToManaWei(usdWei, rate) : null
 
-  // No rate (still reading, or the oracle is unreachable) means there is no honest MANA figure to show. Saying
-  // so beats rendering a placeholder number next to a Buy button.
+  // The read has not come back yet. There is no figure to show, but there is nothing wrong either — so hold
+  // the space and say nothing. Announcing "price unavailable" here is a claim about the oracle that the first
+  // frame of every render was making on its behalf, and on a grid that is one false alarm per card.
+  if (status === 'pending') {
+    return (
+      <span
+        className={classNames(styles.PeggedManaPrice, styles.loading, className)}
+        data-testid="pegged-mana-price-loading"
+        aria-busy="true"
+      />
+    )
+  }
+
+  // Now it is a real answer: the oracle could not be reached, or answered something a price cannot be built
+  // from. Saying so beats rendering a placeholder number next to a Buy button.
   if (manaWei === null) {
     return (
       <span className={classNames(styles.PeggedManaPrice, styles.unavailable, className)} data-testid="pegged-mana-price-unavailable">

--- a/webapp/src/modules/trade/hooks.ts
+++ b/webapp/src/modules/trade/hooks.ts
@@ -36,34 +36,47 @@ export function useTradePriceDenomination(tradeId?: string): PriceDenomination {
   return denomination
 }
 
+/** Where a rate read has got to. `pending` is the answer not being in yet; `unavailable` is not getting one. */
+export type ManaUsdRateState =
+  | { status: 'pending'; rate: null }
+  | { status: 'ready'; rate: ManaUsdRate }
+  | { status: 'unavailable'; rate: null }
+
+const PENDING = { status: 'pending', rate: null } as const
+const UNAVAILABLE = { status: 'unavailable', rate: null } as const
+
 /**
- * The MANA/USD rate for a chain, or `null` while it is being read (or if the oracle cannot be reached).
+ * The MANA/USD rate for a chain, as a state rather than a nullable value.
  *
- * A null result is a real state, not a loading detail to paper over: without the rate there is no honest MANA
- * figure to show for a USD-pegged listing, so the caller renders "price unavailable" instead of guessing.
+ * "Still reading" and "cannot be read" are different facts, and collapsing them into `null` made every
+ * caller state the wrong one: a price would announce itself unavailable for the frame before its first
+ * read landed, which on a grid is one such flash per card. Without the rate there is still no honest MANA
+ * figure to show — that part was right — but a pending read is not a failure, and only the second deserves
+ * to be said out loud.
  */
-export function useManaUsdRate(chainId?: ChainId): ManaUsdRate | null {
-  const [rate, setRate] = useState<ManaUsdRate | null>(null)
+export function useManaUsdRate(chainId?: ChainId): ManaUsdRateState {
+  const [state, setState] = useState<ManaUsdRateState>(PENDING)
 
   useEffect(() => {
     if (!chainId) {
-      setRate(null)
+      // No chain to read against is a dead end, not a wait: nothing is coming.
+      setState(UNAVAILABLE)
       return
     }
 
     let cancelled = false
-    // Clear first: on a chain switch the previous chain's rate would otherwise linger until the new read
-    // resolves, briefly pricing a listing at another network's rate.
-    setRate(null)
+    // Back to pending first: on a chain switch the previous chain's rate would otherwise linger until the
+    // new read resolves, briefly pricing a listing at another network's rate.
+    setState(PENDING)
     void fetchManaUsdRate(chainId)
       .then(resolved => {
         if (!cancelled) {
-          setRate(resolved)
+          setState({ status: 'ready', rate: resolved })
         }
       })
       .catch(() => {
         if (!cancelled) {
-          setRate(null)
+          setState(UNAVAILABLE)
         }
       })
 
@@ -72,5 +85,5 @@ export function useManaUsdRate(chainId?: ChainId): ManaUsdRate | null {
     }
   }, [chainId])
 
-  return rate
+  return state
 }


### PR DESCRIPTION
A USD-pegged listing flashes "price unavailable" before settling on its real figure. Now that the browse grid converts too, that flash is one per card instead of one per page.

## Cause

`useManaUsdRate` returned `ManaUsdRate | null` and used `null` for two different facts: the read has not come back yet, and the read cannot be made. `PeggedManaPrice` could only see the `null`, so it announced the oracle was unreachable on the first frame of every render — before anything had been asked of it.

The old comment argued the case honestly and got the conclusion wrong: *"a null result is a real state, not a loading detail to paper over"*. True of a failed read. Not true of one that has not resolved.

## Change

The hook returns a state instead of a nullable value — `pending`, `ready`, or `unavailable`. No chain to read against resolves to `unavailable` rather than `pending`, because nothing is coming.

`PeggedManaPrice` now holds the line's space while pending and says nothing. Deliberately no spinner and no placeholder number: next to a Buy button each would assert something — that something is wrong, or that this is the price — and neither is true yet. Once a read actually fails, "price unavailable" is said exactly as before; that part was right and is unchanged.

## Test plan

- [x] new `PeggedManaPrice.spec.tsx` — pending says nothing, a failed read says unavailable, a good read renders the approximate figure, and a present-but-unusable rate falls back to unavailable
- [x] mutation checked: removing the pending branch fails the first case
- [x] `AssetCard.spec.tsx` still passes with the hook's new shape — 11 tests green across both specs
- [x] `npm run check:code` (the command CI runs) reports 0 errors; typecheck clean
- [ ] full suite and build not run locally (machine thermals); CI is the first full run

## Note

`useManaUsdRate` had one production caller, so the shape change is contained to this component and the card spec that mocks it.