### PR TITLE
fix: stop offering credits the marketplace cannot spend [ON HOLD]

### DIFF
--- a/webapp/src/components/Navbar/Navbar.spec.tsx
+++ b/webapp/src/components/Navbar/Navbar.spec.tsx
@@ -1,0 +1,48 @@
+import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Navbar from './Navbar'
+
+const baseNavbar = jest.fn((_props: Record<string, unknown>) => null)
+jest.mock('decentraland-dapps/dist/containers/Navbar', () => ({
+  Navbar2: (props: Record<string, unknown>) => baseNavbar(props)
+}))
+
+const useIsIAP = jest.fn(() => false)
+jest.mock('../../modules/iap/useIAP', () => ({ useIsIAP: () => useIsIAP() }))
+
+function renderNavbar() {
+  return render(
+    <MemoryRouter>
+      <Navbar />
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  baseNavbar.mockClear()
+  useIsIAP.mockReturnValue(false)
+})
+
+/**
+ * The credits chip is the Shop's, not this app's.
+ *
+ * Left on, the navbar rendered the LEGACY MANA-denominated credits — "Expiring in 0 days (1 Credit = 1 MANA
+ * in value)" — for a programme the marketplace no longer issues or spends. `withCredits` defaults to TRUE in
+ * dapps, so this is a prop that has to be passed rather than a default that has to be kept: a future edit
+ * that drops it silently brings the chip back.
+ */
+describe('when rendering the navbar', () => {
+  it('should not offer credits the marketplace cannot spend', () => {
+    renderNavbar()
+
+    expect(baseNavbar).toHaveBeenCalledWith(expect.objectContaining({ withCredits: false }))
+  })
+
+  // The iOS web view renders its own cut-down navbar, and it took the same default.
+  it('and it is the in-app view it should not offer them either', () => {
+    useIsIAP.mockReturnValue(true)
+    renderNavbar()
+
+    expect(baseNavbar).toHaveBeenCalledWith(expect.objectContaining({ withCredits: false }))
+  })
+})

--- a/webapp/src/components/Navbar/Navbar.tsx
+++ b/webapp/src/components/Navbar/Navbar.tsx
@@ -6,6 +6,15 @@ import { useIsIAP } from '../../modules/iap/useIAP'
 import { getBasename } from '../../modules/routing/basename'
 import { Props } from './Navbar.types'
 
+/**
+ * `withCredits={false}` on both variants: the credits chip belongs to the Shop, not here.
+ *
+ * Left on — and it defaults to ON in dapps — this navbar rendered the LEGACY MANA-denominated credits
+ * ("Expiring in 0 days (1 Credit = 1 MANA in value)"), a programme the marketplace no longer issues or
+ * spends, so the figure is at best zero and at worst an offer this surface cannot honour. The flag also
+ * covers the Shop's USD credits, which is the right outcome for the same reason: they are not spendable
+ * here either.
+ */
 const Navbar = (props: Props) => {
   const { pathname, search } = useLocation()
   const isIAP = useIsIAP()
@@ -26,6 +35,7 @@ const Navbar = (props: Props) => {
           {...props}
           withChainSelector={false}
           withNotifications={false}
+          withCredits={false}
           activePage={undefined}
           identity={props.identity}
           onSignIn={handleOnSignIn}
@@ -39,6 +49,7 @@ const Navbar = (props: Props) => {
       {...props}
       withChainSelector
       withNotifications
+      withCredits={false}
       showManaBalancesInNavbar
       activePage="shop"
       identity={props.identity}


### PR DESCRIPTION
The navbar still shows a credits chip, and hovering it reads:

> Expiring in 0 days
> (1 Credit = 1 MANA in value)

Those are the **legacy MANA-denominated credits** — a programme this app no longer issues or spends. The figure is at best zero, and at worst an offer this surface cannot honour.

## Changes

`withCredits={false}` on both navbar variants (the standard one and the iOS in-app view, which took the same default).

The marketplace never set this prop, and `decentraland-dapps` defaults it to **true** — so the chip was not a decision anyone made here, it was a default nobody turned off.

## One thing to be aware of before merging

`withCredits` is the only switch dapps exposes, and it gates both balances:

```ts
creditsBalance:     withCredits ? creditsBalance : undefined,
shopCreditsBalance: withCredits ? shopCreditsBalance : undefined,
```

So this also hides the **Shop's USD credits** from this navbar. I believe that is right for the same reason — they are not spendable here either, and a balance shown where it cannot be used is the same false offer in a newer denomination.

If the intent is to keep Shop credits visible in the marketplace while dropping only the legacy ones, this flag cannot express that and the change belongs in `decentraland-dapps` as a separate prop instead. Say the word and I will take it there.

## Test plan

- [x] New `Navbar.spec.tsx` — the component had none — asserting `withCredits: false` reaches `Navbar2` in both the standard and in-app variants
- [x] **Mutation-checked**: dropping the prop from either variant fails its case. This matters more than usual here, because the dapps default is `true` — a future edit that removes the prop silently brings the chip back rather than erroring
- [x] typecheck clean; 2 tests pass
- [ ] full suite and build not run locally (machine thermals); CI is the first full run