### PR TITLE
feat: load segment's analytics.js from a first party proxy in dev

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -26,7 +26,7 @@
         "dcl-catalyst-commons": "^9.0.1",
         "decentraland-connect": "^12.0.0",
         "decentraland-crypto-fetch": "^2.0.1",
-        "decentraland-dapps": "^29.3.1-20260805170817.commit-f4ffa6a",
+        "decentraland-dapps": "^29.4.0",
         "decentraland-transactions": "^3.0.3",
         "decentraland-ui": "^7.1.0",
         "decentraland-ui2": "^3.8.0",
@@ -15061,9 +15061,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "29.3.1-20260805170817.commit-f4ffa6a",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-29.3.1-20260805170817.commit-f4ffa6a.tgz",
-      "integrity": "sha512-tXPxJJ8X5TRo3x/nftIrBx88msQEsr84hMA6peJs2JdJug1GCvmRna72MgNmvuZeboM0+laxMkTAedcVHltY6w==",
+      "version": "29.4.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-29.4.0.tgz",
+      "integrity": "sha512-AwWUEOkrhq0WufoDacSSY1iLBmY+5Ddli4+H5Vc9iEV3v3o3XcC8ots1tdqKEj75PSKkOKFZkmXnVwYhW/bPJA==",
       "dependencies": {
         "@0xsequence/multicall": "0.25.1",
         "@0xsequence/relayer": "0.25.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -21,7 +21,7 @@
     "dcl-catalyst-commons": "^9.0.1",
     "decentraland-connect": "^12.0.0",
     "decentraland-crypto-fetch": "^2.0.1",
-    "decentraland-dapps": "^29.3.1-20260805170817.commit-f4ffa6a",
+    "decentraland-dapps": "^29.4.0",
     "decentraland-transactions": "^3.0.3",
     "decentraland-ui": "^7.1.0",
     "decentraland-ui2": "^3.8.0",

--- a/webapp/src/config/env/dev.json
+++ b/webapp/src/config/env/dev.json
@@ -31,6 +31,7 @@
   "CONVERTER_EXCHANGE": "uniswap_v2",
   "INTERCOM_APP_ID": "z0h94kay",
   "SEGMENT_API_KEY": "gMnkewUBzA6J879kAtMvp2WhohEk36uy",
+  "SEGMENT_ANALYTICS_URL": "https://evs.e.decentraland.org/z8jpJNrQbg/rqp8VgURTs.min.js",
   "DISCORD_URL": "https://dcl.gg/discord",
   "ENVIRONMENT": "development",
   "MIN_SALE_VALUE_IN_WEI": "1000000000000000000",

--- a/webapp/src/modules/store.ts
+++ b/webapp/src/modules/store.ts
@@ -132,7 +132,10 @@ export function initStore(history: History) {
     actions: [CLEAR_TRANSACTIONS, ARCHIVE_BID, UNARCHIVE_BID, SET_IS_TRYING_ON], // array of actions types that will trigger a SAVE (optional)
     migrations: {} // migration object that will migrate your localstorage (optional)
   }) as { storageMiddleware: Middleware; loadStorageMiddleware: Middleware }
-  const analyticsMiddleware = createAnalyticsMiddleware(config.get('SEGMENT_API_KEY'))
+  // analytics.js is served from a first party proxy where configured, ad blockers drop the requests to Segment's CDN
+  const analyticsMiddleware = createAnalyticsMiddleware(config.get('SEGMENT_API_KEY'), {
+    analyticsUrl: config.get('SEGMENT_ANALYTICS_URL', '') || undefined
+  })
 
   const middleware = applyMiddleware(sagasMiddleware, loggerMiddleware, transactionMiddleware, storageMiddleware, analyticsMiddleware)
   const enhancer = composeEnhancers(middleware)


### PR DESCRIPTION
## What

Loads Segment's `analytics.js` from our first party proxy instead of `cdn.segment.com`, **in dev only**.

- Bumps `decentraland-dapps` to `29.4.0`, which is where the `analyticsUrl` option comes from (decentraland/decentraland-dapps#814).
- Adds `SEGMENT_ANALYTICS_URL` to `webapp/src/config/env/dev.json` and passes it to `createAnalyticsMiddleware`.
- `stg` and `prod` have no URL configured, so they keep loading the bundle from Segment's CDN until they get their own proxy path.

## Why

Ad blockers drop the requests to `cdn.segment.com`, so those sessions send no events at all. The proxy serves the same bundle from a first party host with an obfuscated path.

## Notes

- The write key is untouched: each environment keeps writing to its own source through `SEGMENT_API_KEY`.
- `analytics.js` fetches its settings from the origin of the URL (`https://evs.e.decentraland.org`), which the dapps side derives on its own. No extra config needed here.
- Upstream ignores any value that is not a valid URL, or that is not HTTPS unless it belongs to the dapp's own origin, falling back to Segment's CDN. So a misconfigured environment degrades to today's behavior instead of loading a script from an untrusted origin.
- Worth tracking separately: whoever controls the proxy host controls script execution on the dapp, and the webapp has no CSP `script-src` allowlist today to constrain it.

## Test

`tsc`, eslint and the test suite pass against the bumped dependency. Once deployed to dev, the check is that the bundle request goes to `evs.e.decentraland.org` and the events land in the dev source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)