### PR TITLE
feat: load segment's analytics.js from the first party proxy in stg and prod

### DIFF
--- a/webapp/src/config/env/prod.json
+++ b/webapp/src/config/env/prod.json
@@ -31,6 +31,7 @@
   "CONVERTER_EXCHANGE": "uniswap_v2",
   "INTERCOM_APP_ID": "z0h94kay",
   "SEGMENT_API_KEY": "WijgHCmOGJjV04XBGghZGEadMD4454R3",
+  "SEGMENT_ANALYTICS_URL": "https://evs.e.decentraland.org/z8jpJNrQbg/YUxRAEHA4U.min.js",
   "DISCORD_URL": "https://dcl.gg/discord",
   "ENVIRONMENT": "production",
   "MIN_SALE_VALUE_IN_WEI": "1000000000000000000",

--- a/webapp/src/config/env/stg.json
+++ b/webapp/src/config/env/stg.json
@@ -31,6 +31,7 @@
   "CONVERTER_EXCHANGE": "uniswap_v2",
   "INTERCOM_APP_ID": "z0h94kay",
   "SEGMENT_API_KEY": "WijgHCmOGJjV04XBGghZGEadMD4454R3",
+  "SEGMENT_ANALYTICS_URL": "https://evs.e.decentraland.org/z8jpJNrQbg/YUxRAEHA4U.min.js",
   "DISCORD_URL": "https://dcl.gg/discord",
   "ENVIRONMENT": "staging",
   "MIN_SALE_VALUE_IN_WEI": "1000000000000000000",


### PR DESCRIPTION
Ad blockers drop the requests to `cdn.segment.com`, so those sessions load no analytics.js and send no events. #2679 pointed dev at our first party proxy and left stg and prod on Segment's CDN until they had their own proxy path, this sets it for both.

stg and prod share the same Segment source, so they take the same bundle url: `https://evs.e.decentraland.org/z8jpJNrQbg/YUxRAEHA4U.min.js`. No code changes needed, `initStore` already passes `SEGMENT_ANALYTICS_URL` to the analytics middleware.

Verified against the proxy:

* The bundle responds 200 and is the one built for the stg/prod source (the write key it embeds in `window.analyticsWriteKey` matches `SEGMENT_API_KEY` in `prod.json` and `stg.json`, not dev's).
* `analytics.load()` still wins over that embedded key, the bundle resolves `_writeKey` first.
* The proxy serves the settings endpoint for that source (`/v1/projects/<write key>/settings` responds 200 with the source's integrations), which matters because the snippet resolves `analytics._cdn` from the bundle's origin.

Events themselves still post to `api.segment.io`, which is not proxied, so the most aggressive blockers can keep dropping them. The proxy covers the bundle and the settings.
