### PR TITLE
feat: track announcement bar clicks and reclaim the navbar gap

### DIFF
--- a/webapp/src/components/AnnouncementBar/AnnouncementBar.spec.tsx
+++ b/webapp/src/components/AnnouncementBar/AnnouncementBar.spec.tsx
@@ -1,21 +1,32 @@
+import { MemoryRouter } from 'react-router-dom'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { config } from '../../config'
 import * as events from '../../utils/events'
-import AnnouncementBar from './AnnouncementBar'
+import AnnouncementBar, { isAnnouncementBarDismissed } from './AnnouncementBar'
 
 jest.mock('decentraland-dapps/dist/modules/analytics/utils', () => ({
   getAnalytics: jest.fn()
 }))
 
 const ANNOUNCEMENT_BAR_KEY = 'shop-announcement-bar'
+const PATH = '/browse'
+
+const renderComponent = (onDismiss: () => void) =>
+  render(
+    <MemoryRouter initialEntries={[PATH]}>
+      <AnnouncementBar onDismiss={onDismiss} />
+    </MemoryRouter>
+  )
 
 describe('AnnouncementBar', () => {
   let track: jest.Mock
+  let onDismiss: jest.Mock
 
   beforeEach(() => {
     track = jest.fn()
+    onDismiss = jest.fn()
     ;(getAnalytics as jest.Mock).mockReturnValue({ track })
   })
 
@@ -24,56 +35,70 @@ describe('AnnouncementBar', () => {
     jest.clearAllMocks()
   })
 
-  describe('when it has not been dismissed yet', () => {
+  describe('when rendering the call to action', () => {
+    let link: HTMLElement
+
     beforeEach(() => {
-      render(<AnnouncementBar />)
+      renderComponent(onDismiss)
+      link = screen.getByRole('link', { name: t('announcement_bar.cta') })
     })
 
-    it('should point the call to action to the shop', () => {
-      expect(screen.getByRole('link', { name: t('announcement_bar.cta') })).toHaveAttribute('href', config.get('SHOP_URL'))
+    it('should point to the shop', () => {
+      expect(link).toHaveAttribute('href', expect.stringContaining(config.get('SHOP_URL')))
+    })
+
+    it('should tag the link so the shop can attribute the visit to this bar', () => {
+      expect(link.getAttribute('href')).toContain('utm_source=marketplace&utm_medium=announcement_bar&utm_campaign=shop_launch')
     })
 
     it('should open the shop in a new tab so the marketplace context is not lost', () => {
-      expect(screen.getByRole('link', { name: t('announcement_bar.cta') })).toHaveAttribute('target', '_blank')
-    })
-
-    describe('and the user clicks the call to action', () => {
-      beforeEach(() => {
-        fireEvent.click(screen.getByRole('link', { name: t('announcement_bar.cta') }))
-      })
-
-      it('should track the click', () => {
-        expect(track).toHaveBeenCalledWith(events.CLICK_SHOP_ANNOUNCEMENT_BAR)
-      })
-    })
-
-    describe('and the user dismisses it', () => {
-      beforeEach(() => {
-        fireEvent.click(screen.getByRole('button', { name: t('announcement_bar.dismiss') }))
-      })
-
-      it('should remove the bar from the document', () => {
-        expect(screen.queryByRole('link', { name: t('announcement_bar.cta') })).not.toBeInTheDocument()
-      })
-
-      it('should remember the dismissal so it stays hidden on the next visit', () => {
-        expect(localStorage.getItem(ANNOUNCEMENT_BAR_KEY)).not.toBeNull()
-      })
-
-      it('should track the dismissal', () => {
-        expect(track).toHaveBeenCalledWith(events.DISMISS_SHOP_ANNOUNCEMENT_BAR)
-      })
+      expect(link).toHaveAttribute('target', '_blank')
     })
   })
 
-  describe('when it was already dismissed in a previous visit', () => {
+  describe('when the user clicks the call to action', () => {
     beforeEach(() => {
-      localStorage.setItem(ANNOUNCEMENT_BAR_KEY, '1')
-      render(<AnnouncementBar />)
+      renderComponent(onDismiss)
+      fireEvent.click(screen.getByRole('link', { name: t('announcement_bar.cta') }))
     })
 
-    it('should not render the bar', () => {
-      expect(screen.queryByRole('link', { name: t('announcement_bar.cta') })).not.toBeInTheDocument()
+    it('should track the click with the app and the page it happened on', () => {
+      expect(track).toHaveBeenCalledWith(events.CLICK_SHOP_ANNOUNCEMENT_BAR, { source: 'marketplace', path: PATH })
+    })
+  })
+
+  describe('when the user dismisses the bar', () => {
+    beforeEach(() => {
+      renderComponent(onDismiss)
+      fireEvent.click(screen.getByRole('button', { name: t('announcement_bar.dismiss') }))
+    })
+
+    it('should notify the parent so it can reclaim the space', () => {
+      expect(onDismiss).toHaveBeenCalled()
+    })
+
+    it('should remember the dismissal so it stays hidden on the next visit', () => {
+      expect(isAnnouncementBarDismissed()).toBe(true)
+    })
+
+    it('should track the dismissal with the app and the page it happened on', () => {
+      expect(track).toHaveBeenCalledWith(events.DISMISS_SHOP_ANNOUNCEMENT_BAR, { source: 'marketplace', path: PATH })
+    })
+  })
+
+  describe('when it has not been dismissed', () => {
+    it('should report the bar as not dismissed', () => {
+      expect(isAnnouncementBarDismissed()).toBe(false)
+    })
+  })
+
+  describe('when it was dismissed in a previous visit', () => {
+    beforeEach(() => {
+      localStorage.setItem(ANNOUNCEMENT_BAR_KEY, '1')
+    })
+
+    it('should report the bar as dismissed', () => {
+      expect(isAnnouncementBarDismissed()).toBe(true)
     })
   })
 })

--- a/webapp/src/components/AnnouncementBar/AnnouncementBar.tsx
+++ b/webapp/src/components/AnnouncementBar/AnnouncementBar.tsx
@@ -1,30 +1,41 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useMemo } from 'react'
+import { useLocation } from 'react-router-dom'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
 import { t, T } from 'decentraland-dapps/dist/modules/translation/utils'
 import { config } from '../../config'
 import ArrowIcon from '../../images/announcement-bar-arrow.svg'
 import CloseIcon from '../../images/announcement-bar-close.svg'
 import * as events from '../../utils/events'
+import { Props } from './AnnouncementBar.types'
 import styles from './AnnouncementBar.module.css'
 
 const ANNOUNCEMENT_BAR_KEY = 'shop-announcement-bar'
+const ANNOUNCEMENT_BAR_SOURCE = 'marketplace'
 
-const AnnouncementBar = () => {
-  const [isDismissed, setIsDismissed] = useState(() => localStorage.getItem(ANNOUNCEMENT_BAR_KEY) !== null)
+export const isAnnouncementBarDismissed = () => localStorage.getItem(ANNOUNCEMENT_BAR_KEY) !== null
+
+const AnnouncementBar = ({ onDismiss }: Props) => {
+  const { pathname } = useLocation()
+
+  // The campaign params let the shop attribute what these visitors do after they
+  // land, which the click event alone cannot tell us.
+  const shopUrl = useMemo(() => {
+    const url = new URL(config.get('SHOP_URL'))
+    url.searchParams.set('utm_source', ANNOUNCEMENT_BAR_SOURCE)
+    url.searchParams.set('utm_medium', 'announcement_bar')
+    url.searchParams.set('utm_campaign', 'shop_launch')
+    return url.toString()
+  }, [])
 
   const handleDismiss = useCallback(() => {
     localStorage.setItem(ANNOUNCEMENT_BAR_KEY, '1')
-    setIsDismissed(true)
-    getAnalytics()?.track(events.DISMISS_SHOP_ANNOUNCEMENT_BAR)
-  }, [])
+    getAnalytics()?.track(events.DISMISS_SHOP_ANNOUNCEMENT_BAR, { source: ANNOUNCEMENT_BAR_SOURCE, path: pathname })
+    onDismiss()
+  }, [onDismiss, pathname])
 
   const handleClick = useCallback(() => {
-    getAnalytics()?.track(events.CLICK_SHOP_ANNOUNCEMENT_BAR)
-  }, [])
-
-  if (isDismissed) {
-    return null
-  }
+    getAnalytics()?.track(events.CLICK_SHOP_ANNOUNCEMENT_BAR, { source: ANNOUNCEMENT_BAR_SOURCE, path: pathname })
+  }, [pathname])
 
   return (
     <aside className={styles.bar}>
@@ -34,7 +45,7 @@ const AnnouncementBar = () => {
           values={{ highlight: <span className={styles.highlight}>{t('announcement_bar.highlight')}</span> }}
         />
       </p>
-      <a className={styles.cta} href={config.get('SHOP_URL')} target="_blank" rel="noopener noreferrer" onClick={handleClick}>
+      <a className={styles.cta} href={shopUrl} target="_blank" rel="noopener noreferrer" onClick={handleClick}>
         <span className={styles.ctaLabel}>{t('announcement_bar.cta')}</span>
         <span className={styles.ctaIcon}>
           <img src={ArrowIcon} alt="" />

--- a/webapp/src/components/AnnouncementBar/AnnouncementBar.types.ts
+++ b/webapp/src/components/AnnouncementBar/AnnouncementBar.types.ts
@@ -1,0 +1,3 @@
+export type Props = {
+  onDismiss: () => void
+}

--- a/webapp/src/components/AnnouncementBar/index.ts
+++ b/webapp/src/components/AnnouncementBar/index.ts
@@ -1,2 +1,3 @@
 import AnnouncementBar from './AnnouncementBar'
+export { isAnnouncementBarDismissed } from './AnnouncementBar'
 export { AnnouncementBar }

--- a/webapp/src/components/PageLayout/PageLayout.module.css
+++ b/webapp/src/components/PageLayout/PageLayout.module.css
@@ -11,7 +11,15 @@
 
 .navbar {
   flex-shrink: 0;
+  /* The fixed navbar is taller than the space its own container reserves, so
+     this gap is what keeps page content from sliding underneath it. */
   margin-bottom: 36px;
+}
+
+/* The announcement bar already separates the navbar from the page, so the gap
+   would only read as dead space while it is showing. */
+.navbarWithAnnouncement {
+  margin-bottom: 0;
 }
 
 @media (max-width: 767px) {

--- a/webapp/src/components/PageLayout/PageLayout.tsx
+++ b/webapp/src/components/PageLayout/PageLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import classNames from 'classnames'
 import { ChainId } from '@dcl/schemas'
@@ -7,7 +7,7 @@ import { getChainId, isConnected } from 'decentraland-dapps/dist/modules/wallet/
 import { config } from '../../config'
 import { useIsIAP } from '../../modules/iap/useIAP'
 import { RootState } from '../../modules/reducer'
-import { AnnouncementBar } from '../AnnouncementBar'
+import { AnnouncementBar, isAnnouncementBarDismissed } from '../AnnouncementBar'
 import { Footer } from '../Footer'
 import { Navbar } from '../Navbar'
 import { Navigation } from '../Navigation'
@@ -33,11 +33,17 @@ const PageLayout = ({ children, activeTab, className, hideNavigation }: Props) =
   const isIAP = useIsIAP()
   useIAPAutoSwitchNetwork()
 
+  const [isAnnouncementBarVisible, setIsAnnouncementBarVisible] = useState(() => !isAnnouncementBarDismissed())
+
+  const handleAnnouncementBarDismiss = useCallback(() => setIsAnnouncementBarVisible(false), [])
+
+  const showAnnouncementBar = !isIAP && isAnnouncementBarVisible
+
   return (
     <div className={classNames(styles.page, className)}>
-      <div className={styles.navbar}>
+      <div className={classNames(styles.navbar, { [styles.navbarWithAnnouncement]: showAnnouncementBar })}>
         <Navbar />
-        {!isIAP && <AnnouncementBar />}
+        {showAnnouncementBar && <AnnouncementBar onDismiss={handleAnnouncementBarDismiss} />}
       </div>
       {!hideNavigation && <Navigation activeTab={activeTab} />}
       <div className={styles.content}>{children}</div>


### PR DESCRIPTION
Follow-up to #2683.

## Changes

**Reclaims the gap under the navbar.** The bar sat on top of the 36px margin the navbar wrapper carries, which read as dead space between the bar and the page. That margin exists because the fixed navbar is taller than the space its own container reserves, so it can't just be removed: without it, page content slides behind the navbar once the bar is dismissed. It is now dropped only while the bar is showing, and comes back in the same render when the user dismisses it.

**Makes the click measurable.** The events fired with no properties, and both this app and the Builder fire the same event name, so the two were indistinguishable. Both events now carry `source` and the `path` they happened on.

**Tags the call to action with campaign params.** `utm_source` / `utm_medium` / `utm_campaign` are appended to the shop URL. The click event alone stops at the click — the params are what let the shop attribute what these visitors do after they land, which is the actual question behind "is the bar working". They are also needed because the link carries `rel="noreferrer"`, so no referrer reaches the shop.

## Test plan

- [x] Unit tests for the campaign params, the tracking payloads, and the dismissal contract
- [ ] Check on the preview that the bar sits flush against the page, and that dismissing it restores the gap instead of letting content slide under the navbar
