### PR TITLE
fix: drop the local navbar height compensation

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -27,7 +27,7 @@
         "dcl-catalyst-commons": "^9.0.1",
         "decentraland-connect": "^12.0.0",
         "decentraland-crypto-fetch": "^2.0.1",
-        "decentraland-dapps": "^29.6.1",
+        "decentraland-dapps": "^29.6.2",
         "decentraland-transactions": "^3.0.3",
         "decentraland-ui": "^7.1.0",
         "decentraland-ui2": "^3.20.0",
@@ -15072,9 +15072,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-29.6.1.tgz",
-      "integrity": "sha512-dXVRKE6OnyOfCcK3Fq8CdDrfYHjDEBec1pW6XGkCuautPhYl0HeKttrwG+DZArQAAN1S4RO5FhXeJI8wweG0Og==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-29.6.2.tgz",
+      "integrity": "sha512-QaXplhNIegQvyHDDU3SaHFPGcJ/dCbezpx0ypgFKYiiXi3DRBTkqvuujd9/hbJpSOZkfHvF5LPtXRRd8C6KlhQ==",
       "dependencies": {
         "@0xsequence/multicall": "0.25.1",
         "@0xsequence/relayer": "0.25.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,7 +22,7 @@
     "dcl-catalyst-commons": "^9.0.1",
     "decentraland-connect": "^12.0.0",
     "decentraland-crypto-fetch": "^2.0.1",
-    "decentraland-dapps": "^29.6.1",
+    "decentraland-dapps": "^29.6.2",
     "decentraland-transactions": "^3.0.3",
     "decentraland-ui": "^7.1.0",
     "decentraland-ui2": "^3.20.0",

--- a/webapp/src/components/AnnouncementBar/AnnouncementBar.module.css
+++ b/webapp/src/components/AnnouncementBar/AnnouncementBar.module.css
@@ -8,11 +8,6 @@
   justify-content: center;
   gap: 8px;
   min-height: 46px;
-  /* The ui2 navbar is fixed and 92px tall on desktop, but the container that
-     wraps it only reserves 66px, so the first 26px of the flow sit behind it.
-     Compensating here keeps the bar flush under the navbar instead of below it.
-     Under 992px the navbar is 64px tall and already fits in those 66px. */
-  margin-top: 26px;
   /* Keeps the centered content from sliding under the absolutely positioned close button */
   padding: 0 56px;
   background-color: var(--announcement-bar-background);
@@ -103,7 +98,6 @@
 @media (max-width: 991px) {
   .bar {
     justify-content: flex-start;
-    margin-top: 0;
     padding: 8px 0 8px 16px;
   }
 

--- a/webapp/src/components/PageLayout/PageLayout.module.css
+++ b/webapp/src/components/PageLayout/PageLayout.module.css
@@ -11,15 +11,6 @@
 
 .navbar {
   flex-shrink: 0;
-  /* The fixed navbar is taller than the space its own container reserves, so
-     this gap is what keeps page content from sliding underneath it. */
-  margin-bottom: 36px;
-}
-
-/* The announcement bar already separates the navbar from the page, so the gap
-   would only read as dead space while it is showing. */
-.navbarWithAnnouncement {
-  margin-bottom: 0;
 }
 
 @media (max-width: 767px) {

--- a/webapp/src/components/PageLayout/PageLayout.tsx
+++ b/webapp/src/components/PageLayout/PageLayout.tsx
@@ -41,7 +41,7 @@ const PageLayout = ({ children, activeTab, className, hideNavigation }: Props) =
 
   return (
     <div className={classNames(styles.page, className)}>
-      <div className={classNames(styles.navbar, { [styles.navbarWithAnnouncement]: showAnnouncementBar })}>
+      <div className={styles.navbar}>
         <Navbar />
         {showAnnouncementBar && <AnnouncementBar onDismiss={handleAnnouncementBarDismiss} />}
       </div>


### PR DESCRIPTION
Takes `decentraland-dapps` to `^29.6.2` and removes the local gap this repo was carrying to work around a library bug that is now fixed.

### What this removes

This repo carried the workaround twice, in two different files.

`PageLayout.module.css` had:

```css
.navbar {
  /* The fixed navbar is taller than the space its own container reserves, so
     this gap is what keeps page content from sliding underneath it. */
  margin-bottom: 36px;
}

.navbarWithAnnouncement {
  margin-bottom: 0;
}
```

The cause is gone: `Navbar2`'s container reserved 66px for a bar that is 92px on desktop, and decentraland/decentraland-dapps#822 (shipped in 29.6.2) makes it track the bar's real heights, 64px below 992px and 92px above. With that, the compensation is dead weight, and leaving it in would push content 26px further down than the design calls for. The `.navbarWithAnnouncement` rule existed only to cancel the gap while the announcement bar shows, so it goes with it, along with the `classNames` call that toggled it.

And `AnnouncementBar.module.css` had a second one, the same 26px margin builder carried, plus a `margin-top: 0` inside the `max-width: 991px` block that existed only to cancel it:

```css
/* The ui2 navbar is fixed and 92px tall on desktop, but the container that
   wraps it only reserves 66px, so the first 26px of the flow sit behind it. */
margin-top: 26px;
```

Both are gone. Leaving the second one in is what produced the visible 26px band between the navbar and the purple bar on this branch before the last commit.

builder carried the announcement-bar half of the same patch and it is removed in decentraland/builder#3479.

### Measured, at 1200px wide

| | Before | After |
| --- | --- | --- |
| Container reserves | 66px | 92px |
| Gap between navbar and announcement bar | 26px | 0 |
| Announcement bar top edge | 118px | 92px |
| Sub-nav top, announcement bar showing | 164px | 138px |
| Sub-nav top, announcement bar dismissed | 102px | 92px |
| Content behind the bar | none | none |

Below 992px the container reserves the bar's 64px and the announcement bar's own mobile override is no longer needed either.

One judgement call worth a second opinion: with the announcement bar dismissed the sub-nav now sits flush against the navbar instead of 10px below it. The old 36px was 26px of deficit plus 10px of slack, and the comment framed the whole thing as overlap prevention rather than as a designed gap, so the slack goes too. Flush is also what governance-ui does with the same bar. If those 10px were deliberate, they should come back as an explicit rule rather than as a side effect of a workaround.

### How to test

`cd webapp && npm ci && npm run build && npm test`, then in the running app at a desktop width:

```js
const nav = document.querySelector('nav')
nav.closest('div').getBoundingClientRect().height // 92, was 66
```

Check the page with the announcement bar visible and dismissed (`localStorage.setItem('shop-announcement-bar', '1')` and reload); neither should put content under the bar.

`src/components/AssetPage/OwnersTable` and `src/components/Modals/FavoritesModal` can time out on a loaded machine during a full run and pass in 2.5s on their own; that flake is unrelated to this change.
