### PR TITLE
fix: say the trending row covers the last week, not 24 hours

### DIFF
--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -307,7 +307,7 @@
     "subtitle": "Welcome to the virtual world's one-stop-shop for the very best digital assets.",
     "get_started": "Start Browsing",
     "home_trending_items": "Trending items",
-    "home_trending_items_subtitle": "Bestselling Items over the last 24hs 🔥",
+    "home_trending_items_subtitle": "Bestselling Items over the last week 🔥",
     "home_trending_items_explore_all": "Explore all",
     "home_trending_items_empty_message": "We are having troubles fetching the latest trending wearables.{br}{try_again_link} or {explore_all_link}",
     "home_trending_items_try_again": "Try again",

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -300,7 +300,7 @@
     "subtitle": "Bienvenido al mercado virtual de Decentraland, donde encontrarás los mejores ítems virtuales.",
     "get_started": "Comienza a navegar",
     "home_trending_items": "Items de tendencia",
-    "home_trending_items_subtitle": "Items más vendidos en las últimas 24hs 🔥",
+    "home_trending_items_subtitle": "Items más vendidos de la última semana 🔥",
     "home_trending_items_explore_all": "Explorar todos",
     "home_trending_items_empty_message": "Tenemos problemas para obtener los últimos items.{br}{try_again_link} o {explore_all_link}",
     "home_trending_items_try_again": "Intentar de nuevo",

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -303,7 +303,7 @@
     "subtitle": "欢迎来到虚拟世界的一站式商店, 获取最好的数字资产。",
     "get_started": "开始浏览",
     "home_trending_items": "热门商品",
-    "home_trending_items_subtitle": "过去 24 小时内的畅销商品 🔥",
+    "home_trending_items_subtitle": "过去一周内的畅销商品 🔥",
     "home_trending_items_explore_all": "探索所有",
     "home_trending_items_empty_message": "我们无法获取最新流行的可穿戴设备。{br}{try_again_link} 或 {explore_all_link}",
     "home_trending_items_try_again": "再试一次",


### PR DESCRIPTION
Pairs with **marketplace-server#399**, which widens the trending window from one day to a week. Without this the subtitle becomes false.

## Why the window moved

The row was rendering its empty state — the one that reads *"We are having troubles fetching the latest trending wearables."* Nothing was failing: a one-day window over a marketplace that sells **four items a day** produced two candidates on a good day and none on a quiet one.

## Changes

Subtitle only, three locales:

| | before | after |
|---|---|---|
| en | Bestselling Items over the last **24hs** 🔥 | Bestselling Items over the last **week** 🔥 |
| es | Items más vendidos en las últimas **24hs** 🔥 | Items más vendidos de la **última semana** 🔥 |
| zh | 过去 **24 小时**内的畅销商品 🔥 | 过去**一周**内的畅销商品 🔥 |

The zh edit swaps the time unit inside the existing sentence (24 小时 → 一周) and leaves the structure untouched — worth a native glance, but it is not a new translation.

## Test plan

- [x] All three files parse as JSON
- [x] Diff is three values; no keys added, removed or reordered
- [x] Merge alongside marketplace-server#399 — the copy is only true once that lands

Not touched, and worth its own decision: the empty-state copy still says "we are having troubles fetching" for a row that is merely quiet. The wider window makes that state rare rather than impossible, so it will still be wrong the day it appears.