### PR TITLE
feat: sign and authorize against the newest off-chain marketplace

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -28,7 +28,7 @@
         "decentraland-connect": "^12.0.0",
         "decentraland-crypto-fetch": "^2.0.1",
         "decentraland-dapps": "^29.7.0",
-        "decentraland-transactions": "^3.0.3",
+        "decentraland-transactions": "^3.1.1",
         "decentraland-ui": "^7.1.0",
         "decentraland-ui2": "^3.22.0",
         "ethers": "^5.6.8",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -23,7 +23,7 @@
     "decentraland-connect": "^12.0.0",
     "decentraland-crypto-fetch": "^2.0.1",
     "decentraland-dapps": "^29.7.0",
-    "decentraland-transactions": "^3.0.3",
+    "decentraland-transactions": "^3.1.1",
     "decentraland-ui": "^7.1.0",
     "decentraland-ui2": "^3.22.0",
     "ethers": "^5.6.8",

--- a/webapp/src/components/AssetCard/AssetCard.spec.tsx
+++ b/webapp/src/components/AssetCard/AssetCard.spec.tsx
@@ -4,7 +4,7 @@ import { BodyShape, ChainId, Network, NFTCategory, Rarity, WearableCategory } fr
 import { Asset } from '../../modules/asset/types'
 import { INITIAL_STATE } from '../../modules/favorites/reducer'
 import { PageName, SortBy } from '../../modules/routing/types'
-import { useTradePriceDenomination } from '../../modules/trade/hooks'
+import { useTradePricing } from '../../modules/trade/hooks'
 import { renderWithProviders } from '../../utils/test'
 import { HoverPreviewProvider } from '../HoverPreview'
 import AssetCard from './AssetCard'
@@ -16,7 +16,7 @@ const HOVER_INTENT_MS = 120
 // The two reads the pegged path depends on: which unit the listing is in, and the rate to convert it.
 // Both are network calls in production; here they are dials so a test can state the situation it means.
 jest.mock('../../modules/trade/hooks', () => ({
-  useTradePriceDenomination: jest.fn(() => 'mana'),
+  useTradePricing: jest.fn(() => ({ denomination: 'mana', marketplaceAddress: '0xmarketplace' })),
   useManaUsdRate: jest.fn(() => ({ answer: 100000000n, decimals: 8 }))
 }))
 
@@ -146,7 +146,7 @@ describe('AssetCard', () => {
 
     beforeEach(() => {
       // $1 per MANA, so the converted figure is a round number the assertion can name.
-      ;(useTradePriceDenomination as jest.Mock).mockReturnValue('usd-pegged')
+      ;(useTradePricing as jest.Mock).mockReturnValue({ denomination: 'usd-pegged', marketplaceAddress: '0xmarketplace' })
       catalogAsset = {
         ...asset,
         itemId: '0',

--- a/webapp/src/components/AssetCard/AssetCard.tsx
+++ b/webapp/src/components/AssetCard/AssetCard.tsx
@@ -250,7 +250,7 @@ const AssetCard = (props: Props) => {
         {catalogItemInformation.extraInformation && <span className="extraInformation">{catalogItemInformation.extraInformation}</span>}
       </div>
     ) : null
-  }, [asset, catalogItemInformation, showsPeggedMintPrice, isIAP])
+  }, [asset, catalogItemInformation, showsPeggedMintPrice, isIAP, marketplaceAddress])
 
   const setWrapperRef = useCallback(
     (node: HTMLDivElement | null) => {

--- a/webapp/src/components/AssetCard/AssetCard.tsx
+++ b/webapp/src/components/AssetCard/AssetCard.tsx
@@ -21,7 +21,7 @@ import {
 import { locations } from '../../modules/routing/locations'
 import { PageName, SortBy } from '../../modules/routing/types'
 import { PriceDenomination } from '../../modules/trade/denomination'
-import { useTradePriceDenomination } from '../../modules/trade/hooks'
+import { useTradePricing } from '../../modules/trade/hooks'
 import { AssetImage } from '../AssetImage'
 import { FavoritesCounter } from '../FavoritesCounter'
 import { useHoverPreview } from '../HoverPreview'
@@ -105,7 +105,8 @@ const AssetCard = (props: Props) => {
   const { ref, inView } = useInView()
   const isMobile = useMobileMediaQuery()
   const isIAP = useIsIAP()
-  const isUSDPegged = useTradePriceDenomination(priceTradeId) === PriceDenomination.USD_PEGGED
+  const { denomination, marketplaceAddress } = useTradePricing(priceTradeId)
+  const isUSDPegged = denomination === PriceDenomination.USD_PEGGED
   const location = useLocation()
   const showListedTag = pageName === PageName.ACCOUNT && Boolean(price) && location.pathname !== locations.root()
   const hoverPreview = useHoverPreview()
@@ -214,7 +215,12 @@ const AssetCard = (props: Props) => {
         {catalogItemInformation.price ? (
           showsPeggedMintPrice ? (
             <div className="PriceInMana">
-              <PeggedManaPrice usdWei={catalogItemInformation.price} network={asset.network} size="large" />
+              <PeggedManaPrice
+                usdWei={catalogItemInformation.price}
+                network={asset.network}
+                marketplaceAddress={marketplaceAddress}
+                size="large"
+              />
             </div>
           ) : isIAP ? (
             <span className="CreditsPrice">
@@ -296,7 +302,7 @@ const AssetCard = (props: Props) => {
                 </div>
                 {!isCatalogItem(asset) && price ? (
                   isUSDPegged ? (
-                    <PeggedManaPrice usdWei={price} network={asset.network} inline />
+                    <PeggedManaPrice usdWei={price} network={asset.network} marketplaceAddress={marketplaceAddress} inline />
                   ) : isIAP ? (
                     <span className="CreditsPrice">
                       <img src={CreditsIcon} alt="Credits" className="creditsIcon" />

--- a/webapp/src/components/AssetPage/PriceComponent/PriceComponent.spec.tsx
+++ b/webapp/src/components/AssetPage/PriceComponent/PriceComponent.spec.tsx
@@ -2,7 +2,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { render, screen, waitFor } from '@testing-library/react'
 import { Network, TradeAssetType } from '@dcl/schemas'
 import { TradeService } from 'decentraland-dapps/dist/modules/trades/TradeService'
-import { clearTradePriceDenominationCache } from '../../../modules/trade/denomination'
+import { clearTradePricingCache } from '../../../modules/trade/denomination'
 import { formatWeiToAssetCard } from '../../AssetCard/utils'
 import { ManaToFiat } from '../../ManaToFiat'
 import PriceComponent from './PriceComponent'
@@ -39,6 +39,9 @@ jest.mock('../../../modules/trade/manaRate', () => {
 
 const mockTradeWithReceivedAssetType = (assetType: TradeAssetType) => {
   const fetchTrade = jest.fn().mockResolvedValue({
+    // The settlement contract: the price surface reads the MANA/USD aggregator off THIS address, so a trade
+    // without it renders "unavailable" rather than borrowing another version's rate.
+    contract: '0xmarketplace',
     received: [{ assetType, contractAddress: '0xmana', amount: '600000000000000000', extra: '' }]
   })
   ;(TradeService as unknown as jest.Mock).mockImplementation(() => ({ fetchTrade }))
@@ -80,7 +83,7 @@ describe('PriceComponent', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    clearTradePriceDenominationCache()
+    clearTradePricingCache()
   })
 
   describe('when not using credits', () => {

--- a/webapp/src/components/AssetPage/PriceComponent/PriceComponent.tsx
+++ b/webapp/src/components/AssetPage/PriceComponent/PriceComponent.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 import CreditsIcon from '../../../images/icon-credits.svg'
 import { useIsIAP } from '../../../modules/iap/useIAP'
 import { PriceDenomination } from '../../../modules/trade/denomination'
-import { useTradePriceDenomination } from '../../../modules/trade/hooks'
+import { useTradePricing } from '../../../modules/trade/hooks'
 import { formatWeiToAssetCard } from '../../AssetCard/utils'
 import Mana from '../../Mana/Mana'
 import { ManaToFiat } from '../../ManaToFiat'
@@ -13,7 +13,8 @@ import styles from './PriceComponent.module.css'
 
 const PriceComponent = ({ price, network, useCredits, credits, tradeId, className }: Props) => {
   const isIAP = useIsIAP()
-  const isUSDPegged = useTradePriceDenomination(tradeId) === PriceDenomination.USD_PEGGED
+  const { denomination, marketplaceAddress } = useTradePricing(tradeId)
+  const isUSDPegged = denomination === PriceDenomination.USD_PEGGED
   const getAdjustedPrice = useCallback(
     (originalPrice: string) => {
       if (!useCredits || !credits) return originalPrice
@@ -31,7 +32,7 @@ const PriceComponent = ({ price, network, useCredits, credits, tradeId, classNam
   if (isUSDPegged) {
     return (
       <div className={classNames(styles.PriceContainer, className)}>
-        <PeggedManaPrice usdWei={price} network={network} size="large" />
+        <PeggedManaPrice usdWei={price} network={network} marketplaceAddress={marketplaceAddress} size="large" />
       </div>
     )
   }

--- a/webapp/src/components/BidPage/BidModal/BidModal.tsx
+++ b/webapp/src/components/BidPage/BidModal/BidModal.tsx
@@ -6,7 +6,7 @@ import { AuthorizedAction } from 'decentraland-dapps/dist/containers/withAuthori
 import { toFixedMANAValue } from 'decentraland-dapps/dist/lib/mana'
 import { AuthorizationType } from 'decentraland-dapps/dist/modules/authorization/types'
 import { t, T } from 'decentraland-dapps/dist/modules/translation/utils'
-import { ContractName, getContract as getDecentralandContract } from 'decentraland-transactions'
+import { ContractName } from 'decentraland-transactions'
 import { Header, Form, Field, Button } from 'decentraland-ui'
 import { parseMANANumber } from '../../../lib/mana'
 import { getAssetName, isNFT, isOwnedBy } from '../../../modules/asset/utils'
@@ -17,6 +17,7 @@ import { getDefaultExpirationDate } from '../../../modules/order/utils'
 import { getRentalEndDate, hasRentalEnded, isRentalListingExecuted } from '../../../modules/rental/utils'
 import { locations } from '../../../modules/routing/locations'
 import { getContractNames } from '../../../modules/vendor'
+import { getLatestOffChainMarketplaceContract } from '../../../utils/trades'
 import { AssetAction } from '../../AssetAction'
 import { isPriceTooLow } from '../../BuyPage/utils'
 import { ConfirmInputValueModal } from '../../ConfirmInputValueModal'
@@ -55,7 +56,7 @@ const BidModal = (props: Props) => {
     network: asset.network
   })
 
-  const offchainBidsContract = getDecentralandContract(ContractName.OffChainMarketplaceV2, asset.chainId)
+  const offchainBidsContract = getLatestOffChainMarketplaceContract(asset.chainId)
 
   if (!wallet || !mana || !bids) {
     return null

--- a/webapp/src/components/ListingPrice/ListingPrice.spec.tsx
+++ b/webapp/src/components/ListingPrice/ListingPrice.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { Network, TradeAssetType } from '@dcl/schemas'
 import { TradeService } from 'decentraland-dapps/dist/modules/trades/TradeService'
-import { clearTradePriceDenominationCache } from '../../modules/trade/denomination'
+import { clearTradePricingCache } from '../../modules/trade/denomination'
 import ListingPrice from './ListingPrice'
 
 jest.mock('decentraland-dapps/dist/modules/trades/TradeService')
@@ -35,6 +35,9 @@ jest.mock('../../modules/trade/manaRate', () => {
 
 const mockTradeWithReceivedAssetType = (assetType: TradeAssetType) => {
   const fetchTrade = jest.fn().mockResolvedValue({
+    // The settlement contract: the price surface reads the MANA/USD aggregator off THIS address, so a trade
+    // without it renders "unavailable" rather than borrowing another version's rate.
+    contract: '0xmarketplace',
     received: [{ assetType, contractAddress: '0xmana', amount: '500000000000000000', extra: '' }]
   })
   ;(TradeService as unknown as jest.Mock).mockImplementation(() => ({ fetchTrade }))
@@ -44,7 +47,7 @@ const mockTradeWithReceivedAssetType = (assetType: TradeAssetType) => {
 describe('ListingPrice', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    clearTradePriceDenominationCache()
+    clearTradePricingCache()
   })
 
   describe('when the backing trade is USD-pegged', () => {

--- a/webapp/src/components/ListingPrice/ListingPrice.tsx
+++ b/webapp/src/components/ListingPrice/ListingPrice.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Mana } from 'decentraland-ui'
 import { formatWeiMANA } from '../../lib/mana'
 import { PriceDenomination } from '../../modules/trade/denomination'
-import { useTradePriceDenomination } from '../../modules/trade/hooks'
+import { useTradePricing } from '../../modules/trade/hooks'
 import { ManaToFiat } from '../ManaToFiat'
 import { PeggedManaPrice } from '../PeggedManaPrice'
 import { Props } from './ListingPrice.types'
@@ -19,13 +19,22 @@ import { Props } from './ListingPrice.types'
  * be converted through the settlement oracle first, and is marked approximate because that rate moves.
  */
 const ListingPrice = ({ price, network, tradeId, showFiat = false, size, className, manaClassName, inline, showTooltip }: Props) => {
-  const isUSDPegged = useTradePriceDenomination(tradeId) === PriceDenomination.USD_PEGGED
+  const { denomination, marketplaceAddress } = useTradePricing(tradeId)
+  const isUSDPegged = denomination === PriceDenomination.USD_PEGGED
 
   if (isUSDPegged) {
     // No fiat parenthetical here even when `showFiat` is set: the USD figure is what the listing is pegged TO,
     // not what the buyer pays, and showing both invites reading the wrong one as the price.
     return (
-      <PeggedManaPrice usdWei={price} network={network} size={size} className={className} manaClassName={manaClassName} inline={inline} />
+      <PeggedManaPrice
+        usdWei={price}
+        network={network}
+        marketplaceAddress={marketplaceAddress}
+        size={size}
+        className={className}
+        manaClassName={manaClassName}
+        inline={inline}
+      />
     )
   }
 

--- a/webapp/src/components/Modals/SellModal/SellModal.tsx
+++ b/webapp/src/components/Modals/SellModal/SellModal.tsx
@@ -17,6 +17,7 @@ import { useFingerprint } from '../../../modules/nft/hooks'
 import { getSellItemStatus, getError } from '../../../modules/order/selectors'
 import { getDefaultExpirationDate, INPUT_FORMAT } from '../../../modules/order/utils'
 import { VendorFactory } from '../../../modules/vendor'
+import { getLatestOffChainMarketplaceContract } from '../../../utils/trades'
 import ErrorBanner from '../../ErrorBanner'
 import { ListingPrice } from '../../ListingPrice'
 import { ManaField } from '../../ManaField'
@@ -77,7 +78,7 @@ const SellModal = ({
   const parsedValueToConfirm = useMemo(() => parseFloat(price).toString(), [price])
   const isConfirmDisabled = parsedValueToConfirm !== confirmedInput || isCreatingOrder || isLoadingAuthorization
   const marketplaceContract = getDecentralandContract(ContractName.Marketplace, nft.chainId)
-  const offChainOrdersContract = getDecentralandContract(ContractName.OffChainMarketplaceV2, nft.chainId)
+  const offChainOrdersContract = getLatestOffChainMarketplaceContract(nft.chainId)
 
   const authorizedContract = offChainOrdersContract || marketplaceContract
   // The server validates `extra` against on-chain getFingerprintV2, so we must

--- a/webapp/src/components/PeggedManaPrice/PeggedManaPrice.tsx
+++ b/webapp/src/components/PeggedManaPrice/PeggedManaPrice.tsx
@@ -37,8 +37,8 @@ function chainIdOf(network: Props['network']): ChainId | undefined {
  * what would earn a "you charged me a different price" — and the conversion deliberately truncates rather than
  * rounds up so the shown figure never sits above the charge.
  */
-const PeggedManaPrice = ({ usdWei, network, size = 'medium', className, manaClassName, inline }: Props) => {
-  const rate = useManaUsdRate(chainIdOf(network))
+const PeggedManaPrice = ({ usdWei, network, marketplaceAddress, size = 'medium', className, manaClassName, inline }: Props) => {
+  const rate = useManaUsdRate(chainIdOf(network), marketplaceAddress)
   const manaWei = rate ? usdWeiToManaWei(usdWei, rate) : null
 
   // No rate (still reading, or the oracle is unreachable) means there is no honest MANA figure to show. Saying

--- a/webapp/src/components/PeggedManaPrice/PeggedManaPrice.types.ts
+++ b/webapp/src/components/PeggedManaPrice/PeggedManaPrice.types.ts
@@ -3,8 +3,14 @@ import { Network } from '@dcl/schemas'
 export type Props = {
   /** The listing amount in USD wei (1e18 = $1) — the `amount` of a `USD_PEGGED_MANA` trade asset. */
   usdWei: string
-  /** The network the listing settles on; picks the oracle and the MANA glyph. */
+  /** The network the listing settles on; picks the MANA glyph. */
   network: Network
+  /**
+   * The marketplace this listing settles on — the trade's own `contract`. Required, and deliberately not
+   * defaulted: each version holds its own MANA/USD aggregator, so pricing a V2 listing off another version's
+   * feed would quote a rate it will never settle at. Null renders "price unavailable" rather than guessing.
+   */
+  marketplaceAddress: string | null
   /** Matches the sizes `Mana` accepts, so this drops in where a MANA price was. */
   size?: 'small' | 'medium' | 'large'
   className?: string

--- a/webapp/src/components/SellPage/SellModal/SellModal.tsx
+++ b/webapp/src/components/SellPage/SellModal/SellModal.tsx
@@ -8,7 +8,7 @@ import { getNetworkProvider } from 'decentraland-dapps/dist/lib/eth'
 import { toFixedMANAValue } from 'decentraland-dapps/dist/lib/mana'
 import { AuthorizationType } from 'decentraland-dapps/dist/modules/authorization/types'
 import { t, T } from 'decentraland-dapps/dist/modules/translation/utils'
-import { getContract as getDecentralandContract, ContractName } from 'decentraland-transactions'
+import { ContractName } from 'decentraland-transactions'
 import { Header, Form, Field, Button } from 'decentraland-ui'
 import ERC721ABI from '../../../contracts/ERC721.json'
 import { parseMANANumber } from '../../../lib/mana'
@@ -20,6 +20,7 @@ import { INPUT_FORMAT, getDefaultExpirationDate } from '../../../modules/order/u
 import { getContractNames } from '../../../modules/vendor'
 import { Contract as DCLContract } from '../../../modules/vendor/services'
 import { VendorFactory } from '../../../modules/vendor/VendorFactory'
+import { getLatestOffChainMarketplaceContract } from '../../../utils/trades'
 import { AssetAction } from '../../AssetAction'
 import { ConfirmInputValueModal } from '../../ConfirmInputValueModal'
 import ErrorBanner from '../../ErrorBanner'
@@ -112,7 +113,7 @@ const SellModal = (props: Props) => {
     return null
   }
 
-  const offchainOrdersContract = getDecentralandContract(ContractName.OffChainMarketplaceV2, nft.chainId)
+  const offchainOrdersContract = getLatestOffChainMarketplaceContract(nft.chainId)
 
   const handleCreateOrder = () =>
     onCreateOrder(nft, parseMANANumber(price), new Date(`${expiresAt} 00:00:00`).getTime(), contractFingerprint)

--- a/webapp/src/components/SettingsPage/Authorization/Authorization.tsx
+++ b/webapp/src/components/SettingsPage/Authorization/Authorization.tsx
@@ -6,10 +6,10 @@ import { ChainCheck, TransactionLink } from 'decentraland-dapps/dist/containers'
 import { getChainConfiguration } from 'decentraland-dapps/dist/lib/chainConfiguration'
 import { AuthorizationType } from 'decentraland-dapps/dist/modules/authorization/types'
 import { t, T } from 'decentraland-dapps/dist/modules/translation/utils'
-import { ContractName, getContract as getDecentralandContract } from 'decentraland-transactions'
 import { Form, Radio, Loader, Popup, RadioProps } from 'decentraland-ui'
 import { isAuthorized } from '../../../lib/authorization'
 import { locations } from '../../../modules/routing/locations'
+import { getDeployedOffChainMarketplaceContracts } from '../../../utils/trades'
 import { Props } from './Authorization.types'
 import './Authorization.css'
 
@@ -43,21 +43,10 @@ const Authorization = (props: Props) => {
   let contract
   let name: string = ''
   // Every off-chain marketplace version, so an approval granted to any of them is named here instead of
-  // falling through to the generic lookup, which does not know these addresses. Each lookup is guarded
-  // because getContract THROWS for a version a chain does not have, and V3 is testnet-only for now.
-  const offChainMarketplaces = [
-    ContractName.OffChainMarketplace,
-    ContractName.OffChainMarketplaceV2,
-    ContractName.OffChainMarketplaceV3
-  ].flatMap(contractName => {
-    try {
-      return [{ contractName, contract: getDecentralandContract(contractName, authorization.chainId) }]
-    } catch (_error) {
-      return []
-    }
-  })
-
-  const offChainMarketplace = offChainMarketplaces.find(({ contract: { address } }) => authorizedAddress === address)
+  // falling through to the generic lookup, which does not know these addresses.
+  const offChainMarketplace = getDeployedOffChainMarketplaceContracts(authorization.chainId).find(
+    ({ contract: { address } }) => authorizedAddress === address
+  )
   if (offChainMarketplace) {
     contract = offChainMarketplace.contract
     // The VERSION, not contract.name: every version shares one on-chain name per network

--- a/webapp/src/components/SettingsPage/Authorization/Authorization.tsx
+++ b/webapp/src/components/SettingsPage/Authorization/Authorization.tsx
@@ -51,16 +51,19 @@ const Authorization = (props: Props) => {
     ContractName.OffChainMarketplaceV3
   ].flatMap(contractName => {
     try {
-      return [getDecentralandContract(contractName, authorization.chainId)]
+      return [{ contractName, contract: getDecentralandContract(contractName, authorization.chainId) }]
     } catch (_error) {
       return []
     }
   })
 
-  const offChainMarketplace = offChainMarketplaces.find(({ address }) => authorizedAddress === address)
+  const offChainMarketplace = offChainMarketplaces.find(({ contract: { address } }) => authorizedAddress === address)
   if (offChainMarketplace) {
-    contract = offChainMarketplace
-    name = contract.name
+    contract = offChainMarketplace.contract
+    // The VERSION, not contract.name: every version shares one on-chain name per network
+    // ("DecentralandMarketplaceEthereum"), so naming them that way renders a page of identical rows with no
+    // way to tell which approval is which — or which one to revoke.
+    name = offChainMarketplace.contractName
   } else {
     contract = getContract({ address: authorizedAddress })
     if (contract) {

--- a/webapp/src/components/SettingsPage/Authorization/Authorization.tsx
+++ b/webapp/src/components/SettingsPage/Authorization/Authorization.tsx
@@ -42,14 +42,24 @@ const Authorization = (props: Props) => {
 
   let contract
   let name: string = ''
-  const offchainContract = getDecentralandContract(ContractName.OffChainMarketplace, authorization.chainId)
-  const offchainContractV2 = getDecentralandContract(ContractName.OffChainMarketplaceV2, authorization.chainId)
-  // This is fix to get the correct contract name for the offchain marketplace
-  if (authorizedAddress === offchainContract.address) {
-    contract = offchainContract
-    name = contract.name
-  } else if (authorizedAddress === offchainContractV2.address) {
-    contract = offchainContractV2
+  // Every off-chain marketplace version, so an approval granted to any of them is named here instead of
+  // falling through to the generic lookup, which does not know these addresses. Each lookup is guarded
+  // because getContract THROWS for a version a chain does not have, and V3 is testnet-only for now.
+  const offChainMarketplaces = [
+    ContractName.OffChainMarketplace,
+    ContractName.OffChainMarketplaceV2,
+    ContractName.OffChainMarketplaceV3
+  ].flatMap(contractName => {
+    try {
+      return [getDecentralandContract(contractName, authorization.chainId)]
+    } catch (_error) {
+      return []
+    }
+  })
+
+  const offChainMarketplace = offChainMarketplaces.find(({ address }) => authorizedAddress === address)
+  if (offChainMarketplace) {
+    contract = offChainMarketplace
     name = contract.name
   } else {
     contract = getContract({ address: authorizedAddress })

--- a/webapp/src/components/SettingsPage/SettingsPage.tsx
+++ b/webapp/src/components/SettingsPage/SettingsPage.tsx
@@ -55,16 +55,6 @@ const SettingsPage = (props: Props) => {
     network: Network.MATIC
   })
 
-  const offChainMarketplaceEthereum = getContract({
-    name: contractNames.OFF_CHAIN_MARKETPLACE,
-    network: Network.ETHEREUM
-  })
-
-  const offChainMarketplaceMatic = getContract({
-    name: contractNames.OFF_CHAIN_MARKETPLACE,
-    network: Network.MATIC
-  })
-
   const bidsEthereum = getContract({
     name: contractNames.BIDS,
     network: Network.ETHEREUM
@@ -96,8 +86,6 @@ const SettingsPage = (props: Props) => {
     !collectionStore ||
     !marketplaceEthereum ||
     !marketplaceMatic ||
-    !offChainMarketplaceEthereum ||
-    !offChainMarketplaceMatic ||
     !bidsEthereum ||
     !bidsMatic ||
     !manaEthereum ||

--- a/webapp/src/components/SettingsPage/SettingsPage.tsx
+++ b/webapp/src/components/SettingsPage/SettingsPage.tsx
@@ -9,6 +9,7 @@ import copyText from '../../lib/copyText'
 import { useTimer } from '../../lib/timer'
 import { getContractNames } from '../../modules/vendor'
 import { shortenAddress } from '../../modules/wallet/utils'
+import { getDeployedOffChainMarketplaceContracts } from '../../utils/trades'
 import { PageLayout } from '../PageLayout'
 import { Authorization } from './Authorization'
 import { Props } from './SettingsPage.types'
@@ -202,26 +203,38 @@ const SettingsPage = (props: Props) => {
                               type: AuthorizationType.ALLOWANCE
                             }}
                           />
-                          <Authorization
-                            authorization={{
-                              address: wallet.address,
-                              authorizedAddress: offChainMarketplaceEthereum.address,
-                              contractAddress: manaEthereum.address,
-                              contractName: ContractName.MANAToken,
-                              chainId: manaEthereum.chainId,
-                              type: AuthorizationType.ALLOWANCE
-                            }}
-                          />
-                          <Authorization
-                            authorization={{
-                              address: wallet.address,
-                              authorizedAddress: offChainMarketplaceMatic.address,
-                              contractAddress: manaMatic.address,
-                              contractName: ContractName.MANAToken,
-                              chainId: manaMatic.chainId,
-                              type: AuthorizationType.ALLOWANCE
-                            }}
-                          />
+                          {/*
+                            One row per DEPLOYED off-chain marketplace version, not just the newest. A grant
+                            made against an older version stays live on chain once a newer one ships, and a
+                            row is the only way to see or revoke it. Keyed by address so each version keeps
+                            its own row identity rather than sharing one with its siblings.
+                          */}
+                          {getDeployedOffChainMarketplaceContracts(manaEthereum.chainId).map(({ contract }) => (
+                            <Authorization
+                              key={contract.address}
+                              authorization={{
+                                address: wallet.address,
+                                authorizedAddress: contract.address,
+                                contractAddress: manaEthereum.address,
+                                contractName: ContractName.MANAToken,
+                                chainId: manaEthereum.chainId,
+                                type: AuthorizationType.ALLOWANCE
+                              }}
+                            />
+                          ))}
+                          {getDeployedOffChainMarketplaceContracts(manaMatic.chainId).map(({ contract }) => (
+                            <Authorization
+                              key={contract.address}
+                              authorization={{
+                                address: wallet.address,
+                                authorizedAddress: contract.address,
+                                contractAddress: manaMatic.address,
+                                contractName: ContractName.MANAToken,
+                                chainId: manaMatic.chainId,
+                                type: AuthorizationType.ALLOWANCE
+                              }}
+                            />
+                          ))}
                           <Authorization
                             authorization={{
                               address: wallet.address,

--- a/webapp/src/modules/contract/sagas.spec.ts
+++ b/webapp/src/modules/contract/sagas.spec.ts
@@ -7,6 +7,7 @@ import { AuthorizationType } from 'decentraland-dapps/dist/modules/authorization
 import { changeAccount, connectWalletSuccess } from 'decentraland-dapps/dist/modules/wallet/actions'
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { getContract as getContractFromDecentralandTransactions, ContractName } from 'decentraland-transactions'
+import { getDeployedOffChainMarketplaceContracts } from '../../utils/trades'
 import { getContractNames, VendorName } from '../vendor'
 import { ContractService } from '../vendor/decentraland'
 import { Contract } from '../vendor/services'
@@ -252,14 +253,17 @@ describe('when handling the fetch contracts request', () => {
         .put(fetchContractsSuccess([]))
         .put(
           fetchAuthorizationsRequest([
-            {
+            // One per DEPLOYED off-chain marketplace version, so an allowance on an older one can still be
+            // seen and revoked. Built from the same enumerator the saga uses rather than a fixed address,
+            // because which versions exist is a property of the chain, not of this test.
+            ...getDeployedOffChainMarketplaceContracts(ChainId.ETHEREUM_GOERLI).map(({ contract }) => ({
               address: wallet.address,
-              authorizedAddress: offChainMarketplaceEthereum.address,
+              authorizedAddress: contract.address,
               contractAddress: manaEthereum.address,
               contractName: ContractName.MANAToken,
               chainId: ChainId.ETHEREUM_GOERLI,
               type: AuthorizationType.ALLOWANCE
-            },
+            })),
             {
               address: wallet.address,
               authorizedAddress: creditsManager.address,
@@ -268,14 +272,14 @@ describe('when handling the fetch contracts request', () => {
               chainId: ChainId.MATIC_AMOY,
               type: AuthorizationType.ALLOWANCE
             },
-            {
+            ...getDeployedOffChainMarketplaceContracts(ChainId.MATIC_AMOY).map(({ contract }) => ({
               address: wallet.address,
-              authorizedAddress: offChainMarketplaceMatic.address,
+              authorizedAddress: contract.address,
               contractAddress: manaMatic.address,
               contractName: ContractName.MANAToken,
               chainId: ChainId.MATIC_AMOY,
               type: AuthorizationType.ALLOWANCE
-            },
+            })),
             {
               address: wallet.address,
               authorizedAddress: marketplaceEthereum.address,

--- a/webapp/src/modules/contract/sagas.spec.ts
+++ b/webapp/src/modules/contract/sagas.spec.ts
@@ -64,24 +64,6 @@ describe('when handling the fetch contracts request', () => {
         vendor: VendorName.DECENTRALAND
       }
 
-      const offChainMarketplaceEthereum: Contract = {
-        address: 'offChainMarketplaceEthereumAddress',
-        category: null,
-        chainId: ChainId.ETHEREUM_MAINNET,
-        name: contractNames.OFF_CHAIN_MARKETPLACE,
-        network: Network.ETHEREUM,
-        vendor: VendorName.DECENTRALAND
-      }
-
-      const offChainMarketplaceMatic: Contract = {
-        address: 'offChainMarketplaceMaticAddress',
-        category: null,
-        chainId: ChainId.MATIC_MAINNET,
-        name: contractNames.OFF_CHAIN_MARKETPLACE,
-        network: Network.MATIC,
-        vendor: VendorName.DECENTRALAND
-      }
-
       const legacyMarketplace: Contract = {
         address: 'legacyMarketplaceAddress',
         category: null,
@@ -165,20 +147,6 @@ describe('when handling the fetch contracts request', () => {
               network: Network.MATIC
             }),
             marketplaceMatic
-          ],
-          [
-            select(getContract, {
-              name: contractNames.OFF_CHAIN_MARKETPLACE,
-              network: Network.ETHEREUM
-            }),
-            offChainMarketplaceEthereum
-          ],
-          [
-            select(getContract, {
-              name: contractNames.OFF_CHAIN_MARKETPLACE,
-              network: Network.MATIC
-            }),
-            offChainMarketplaceMatic
           ],
           [
             select(getContract, {

--- a/webapp/src/modules/contract/sagas.ts
+++ b/webapp/src/modules/contract/sagas.ts
@@ -10,6 +10,7 @@ import { CHANGE_ACCOUNT, CONNECT_WALLET_SUCCESS } from 'decentraland-dapps/dist/
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { getContract as getContractFromDecentralandTransactions, ContractName, ContractData } from 'decentraland-transactions'
 import { isErrorWithMessage } from '../../lib/error'
+import { getDeployedOffChainMarketplaceContracts } from '../../utils/trades'
 import { getContractNames, VendorFactory, VendorName } from '../vendor'
 import { Contract } from '../vendor/services'
 import { getWallet } from '../wallet/selectors'
@@ -71,16 +72,6 @@ export function* handleFetchContractsSuccess() {
     network: Network.MATIC
   })) as ReturnType<typeof getContract>
 
-  const offChainMarketplaceEthereum: Contract | null = (yield select(getContract, {
-    name: contractNames.OFF_CHAIN_MARKETPLACE,
-    network: Network.ETHEREUM
-  })) as ReturnType<typeof getContract>
-
-  const offChainMarketplaceMatic: Contract | null = (yield select(getContract, {
-    name: contractNames.OFF_CHAIN_MARKETPLACE,
-    network: Network.MATIC
-  })) as ReturnType<typeof getContract>
-
   const legacyMarketplaceMatic: Contract | null = (yield select(getContract, {
     name: contractNames.LEGACY_MARKETPLACE,
     network: Network.MATIC
@@ -137,15 +128,19 @@ export function* handleFetchContractsSuccess() {
 
   let authorizations: Authorization[] = []
 
-  if (offChainMarketplaceEthereum && manaEthereum) {
-    authorizations.push({
-      address,
-      authorizedAddress: offChainMarketplaceEthereum.address,
-      contractAddress: manaEthereum.address,
-      contractName: ContractName.MANAToken,
-      chainId: manaEthereum.chainId,
-      type: AuthorizationType.ALLOWANCE
-    })
+  // Every deployed version, not just the one the vendor registry pins: an allowance granted against an older
+  // marketplace stays live on chain, and it can only be shown or revoked if it is fetched here first.
+  if (manaEthereum) {
+    for (const { contract } of getDeployedOffChainMarketplaceContracts(manaEthereum.chainId)) {
+      authorizations.push({
+        address,
+        authorizedAddress: contract.address,
+        contractAddress: manaEthereum.address,
+        contractName: ContractName.MANAToken,
+        chainId: manaEthereum.chainId,
+        type: AuthorizationType.ALLOWANCE
+      })
+    }
   }
 
   if (creditsManager && manaMatic) {
@@ -159,15 +154,17 @@ export function* handleFetchContractsSuccess() {
     })
   }
 
-  if (offChainMarketplaceMatic && manaMatic) {
-    authorizations.push({
-      address,
-      authorizedAddress: offChainMarketplaceMatic.address,
-      contractAddress: manaMatic.address,
-      contractName: ContractName.MANAToken,
-      chainId: manaMatic.chainId,
-      type: AuthorizationType.ALLOWANCE
-    })
+  if (manaMatic) {
+    for (const { contract } of getDeployedOffChainMarketplaceContracts(manaMatic.chainId)) {
+      authorizations.push({
+        address,
+        authorizedAddress: contract.address,
+        contractAddress: manaMatic.address,
+        contractName: ContractName.MANAToken,
+        chainId: manaMatic.chainId,
+        type: AuthorizationType.ALLOWANCE
+      })
+    }
   }
 
   if (marketplaceEthereum && manaEthereum) {

--- a/webapp/src/modules/toast/toasts.tsx
+++ b/webapp/src/modules/toast/toasts.tsx
@@ -153,6 +153,25 @@ export function getClaimNameWithCreditsCostUnavailableToast(): Omit<Toast, 'id'>
   }
 }
 
+/**
+ * The card-payment flow could not be opened.
+ *
+ * Every failure in the Transak saga used to dispatch OPEN_TRANSAK_FAILURE into nothing — no reducer, no
+ * handler — so the widget simply never appeared and the buyer was told why by nobody. This PR routes the
+ * first EXPECTED failure into that path (a listing whose marketplace version Transak has no registration
+ * for), which turns a dead end into a silence someone will actually hit.
+ */
+export function getOpenTransakFailureToast(): Omit<Toast, 'id'> {
+  return {
+    type: ToastType.WARN,
+    title: t('toast.open_transak_failure.title'),
+    body: <p>{t('toast.open_transak_failure.body')}</p>,
+    icon: <Icon size="big" name="exclamation circle" />,
+    closable: true,
+    timeout: 15000
+  }
+}
+
 export function getFetchAssetsFailureToast(error: string): Omit<Toast, 'id'> {
   return {
     type: ToastType.ERROR,

--- a/webapp/src/modules/toast/toasts.tsx
+++ b/webapp/src/modules/toast/toasts.tsx
@@ -160,6 +160,10 @@ export function getClaimNameWithCreditsCostUnavailableToast(): Omit<Toast, 'id'>
  * handler — so the widget simply never appeared and the buyer was told why by nobody. This PR routes the
  * first EXPECTED failure into that path (a listing whose marketplace version Transak has no registration
  * for), which turns a dead end into a silence someone will actually hit.
+ *
+ * The copy stays generic BECAUSE the catch it hangs off is saga-wide: it also covers "Credits are not
+ * enabled" and "No credits available", so anything suggesting a specific alternative payment method would
+ * be wrong for some of the paths that reach here.
  */
 export function getOpenTransakFailureToast(): Omit<Toast, 'id'> {
   return {

--- a/webapp/src/modules/trade/denomination.spec.ts
+++ b/webapp/src/modules/trade/denomination.spec.ts
@@ -1,15 +1,19 @@
 import { TradeAssetType } from '@dcl/schemas'
 import { TradeService } from 'decentraland-dapps/dist/modules/trades/TradeService'
-import { PriceDenomination, clearTradePriceDenominationCache, denominationOfTrade, fetchTradePriceDenomination } from './denomination'
+import { PriceDenomination, clearTradePricingCache, denominationOfTrade, fetchTradePricing } from './denomination'
 
 jest.mock('decentraland-dapps/dist/modules/trades/TradeService')
 
 const MANA_ON_AMOY = '0x7ad72b9f944ea9793cf4055d88f81138cc2c63a0'
+/** The marketplace the trade settles on. Carried alongside the denomination so the price can be converted
+ *  through the aggregator of the version this listing was actually signed against. */
+const MARKETPLACE = '0x1b67d0e31eeb6b52d8eeed71d3616c2f5b33b8e7'
 
 // Shapes taken from marketplace-api.decentraland.zone/v1/trades/<id>: a native (shop) listing returns
 // assetType 2 with the amount in USD wei, a legacy one returns assetType 1 with MANA wei. Both live on
 // the same OffChainMarketplaceV2 contract, which is why the contract address cannot discriminate.
 const usdPeggedTrade = {
+  contract: MARKETPLACE,
   received: [
     {
       assetType: TradeAssetType.USD_PEGGED_MANA,
@@ -21,6 +25,7 @@ const usdPeggedTrade = {
 } as never
 
 const manaTrade = {
+  contract: MARKETPLACE,
   received: [
     {
       assetType: TradeAssetType.ERC20,
@@ -35,7 +40,7 @@ describe('modules/trade/denomination', () => {
   let fetchTrade: jest.Mock
 
   beforeEach(() => {
-    clearTradePriceDenominationCache()
+    clearTradePricingCache()
     fetchTrade = jest.fn()
     ;(TradeService as unknown as jest.Mock).mockImplementation(() => ({ fetchTrade }))
   })
@@ -61,39 +66,50 @@ describe('modules/trade/denomination', () => {
   describe('when fetching the denomination of a trade', () => {
     it('should resolve USD_PEGGED for a native listing', async () => {
       fetchTrade.mockResolvedValueOnce(usdPeggedTrade)
-      await expect(fetchTradePriceDenomination('trade-usd')).resolves.toBe(PriceDenomination.USD_PEGGED)
+      await expect(fetchTradePricing('trade-usd')).resolves.toEqual({
+        denomination: PriceDenomination.USD_PEGGED,
+        marketplaceAddress: MARKETPLACE
+      })
     })
 
     it('should resolve MANA for a legacy listing', async () => {
       fetchTrade.mockResolvedValueOnce(manaTrade)
-      await expect(fetchTradePriceDenomination('trade-mana')).resolves.toBe(PriceDenomination.MANA)
+      await expect(fetchTradePricing('trade-mana')).resolves.toEqual({
+        denomination: PriceDenomination.MANA,
+        marketplaceAddress: MARKETPLACE
+      })
     })
 
     it('should read a given trade only once', async () => {
       fetchTrade.mockResolvedValue(usdPeggedTrade)
 
-      const results = await Promise.all([
-        fetchTradePriceDenomination('trade-usd'),
-        fetchTradePriceDenomination('trade-usd'),
-        fetchTradePriceDenomination('trade-usd')
-      ])
+      const results = await Promise.all([fetchTradePricing('trade-usd'), fetchTradePricing('trade-usd'), fetchTradePricing('trade-usd')])
 
-      expect(results).toEqual([PriceDenomination.USD_PEGGED, PriceDenomination.USD_PEGGED, PriceDenomination.USD_PEGGED])
+      const usdPegged = { denomination: PriceDenomination.USD_PEGGED, marketplaceAddress: MARKETPLACE }
+      expect(results).toEqual([usdPegged, usdPegged, usdPegged])
       expect(fetchTrade).toHaveBeenCalledTimes(1)
     })
 
     describe('and the trade cannot be read', () => {
       it('should fall back to MANA', async () => {
         fetchTrade.mockRejectedValueOnce(new Error('boom'))
-        await expect(fetchTradePriceDenomination('trade-broken')).resolves.toBe(PriceDenomination.MANA)
+        // No trade means no settlement contract, so the price surface renders "unavailable" rather than
+        // converting through a version this listing may never have been signed against.
+        await expect(fetchTradePricing('trade-broken')).resolves.toEqual({
+          denomination: PriceDenomination.MANA,
+          marketplaceAddress: null
+        })
       })
 
       it('should not cache the failure', async () => {
         fetchTrade.mockRejectedValueOnce(new Error('boom'))
-        await fetchTradePriceDenomination('trade-broken')
+        await fetchTradePricing('trade-broken')
 
         fetchTrade.mockResolvedValueOnce(usdPeggedTrade)
-        await expect(fetchTradePriceDenomination('trade-broken')).resolves.toBe(PriceDenomination.USD_PEGGED)
+        await expect(fetchTradePricing('trade-broken')).resolves.toEqual({
+          denomination: PriceDenomination.USD_PEGGED,
+          marketplaceAddress: MARKETPLACE
+        })
         expect(fetchTrade).toHaveBeenCalledTimes(2)
       })
     })

--- a/webapp/src/modules/trade/denomination.ts
+++ b/webapp/src/modules/trade/denomination.ts
@@ -23,7 +23,20 @@ export enum PriceDenomination {
  * change for a given id. That makes an unbounded process-lifetime cache safe, and it keeps a list of
  * rows sharing a trade (or a revisited detail page) down to a single request.
  */
-const cache = new Map<string, Promise<PriceDenomination>>()
+const cache = new Map<string, Promise<TradePricing>>()
+
+/**
+ * How a listing is priced, and the marketplace that will settle it.
+ *
+ * Both come from one `fetchTrade`, and they belong together: a USD-pegged price can only be converted through
+ * the aggregator of the contract the trade was actually signed against, so the surface that learns "this is
+ * USD-pegged" is exactly the surface that has to say which contract to ask.
+ */
+export type TradePricing = {
+  denomination: PriceDenomination
+  /** The trade's own `contract`. Null only when the trade could not be read, where the fallback is MANA. */
+  marketplaceAddress: string | null
+}
 
 function buildService(): TradeService {
   return new TradeService(API_SIGNER, MARKETPLACE_SERVER_URL, () => undefined)
@@ -43,7 +56,7 @@ export function denominationOfTrade(trade: Pick<Trade, 'received'>): PriceDenomi
  * every listing the marketplace itself creates is MANA-denominated, so MANA is the safe default for
  * an unknown, and it keeps a failed request from blanking a price that is almost certainly correct.
  */
-export async function fetchTradePriceDenomination(tradeId: string): Promise<PriceDenomination> {
+export async function fetchTradePricing(tradeId: string): Promise<TradePricing> {
   const cached = cache.get(tradeId)
   if (cached) {
     return cached
@@ -51,11 +64,11 @@ export async function fetchTradePriceDenomination(tradeId: string): Promise<Pric
 
   const pending = buildService()
     .fetchTrade(tradeId)
-    .then(denominationOfTrade)
+    .then(trade => ({ denomination: denominationOfTrade(trade), marketplaceAddress: trade.contract }))
     .catch(() => {
       // Do not cache a failure: a transient error should not pin the wrong unit for the session.
       cache.delete(tradeId)
-      return PriceDenomination.MANA
+      return { denomination: PriceDenomination.MANA, marketplaceAddress: null }
     })
 
   cache.set(tradeId, pending)
@@ -63,6 +76,6 @@ export async function fetchTradePriceDenomination(tradeId: string): Promise<Pric
 }
 
 /** Test seam — the cache is module state, so specs have to be able to empty it. */
-export function clearTradePriceDenominationCache(): void {
+export function clearTradePricingCache(): void {
   cache.clear()
 }

--- a/webapp/src/modules/trade/hooks.ts
+++ b/webapp/src/modules/trade/hooks.ts
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react'
 import { ChainId } from '@dcl/schemas'
-import { PriceDenomination, fetchTradePriceDenomination } from './denomination'
+import { PriceDenomination, TradePricing, fetchTradePricing } from './denomination'
 import { ManaUsdRate, fetchManaUsdRate } from './manaRate'
+
+const MANA_PRICING: TradePricing = { denomination: PriceDenomination.MANA, marketplaceAddress: null }
 
 /**
  * How the given trade-backed listing is priced, for components that render a `price`.
@@ -12,19 +14,19 @@ import { ManaUsdRate, fetchManaUsdRate } from './manaRate'
  * re-renders. Listings without a `tradeId` (legacy on-chain orders, collection-store mints) are
  * always MANA and never trigger a request.
  */
-export function useTradePriceDenomination(tradeId?: string): PriceDenomination {
-  const [denomination, setDenomination] = useState(PriceDenomination.MANA)
+export function useTradePricing(tradeId?: string): TradePricing {
+  const [pricing, setPricing] = useState<TradePricing>(MANA_PRICING)
 
   useEffect(() => {
     if (!tradeId) {
-      setDenomination(PriceDenomination.MANA)
+      setPricing(MANA_PRICING)
       return
     }
 
     let cancelled = false
-    void fetchTradePriceDenomination(tradeId).then(resolved => {
+    void fetchTradePricing(tradeId).then(resolved => {
       if (!cancelled) {
-        setDenomination(resolved)
+        setPricing(resolved)
       }
     })
 
@@ -33,7 +35,7 @@ export function useTradePriceDenomination(tradeId?: string): PriceDenomination {
     }
   }, [tradeId])
 
-  return denomination
+  return pricing
 }
 
 /**
@@ -42,11 +44,13 @@ export function useTradePriceDenomination(tradeId?: string): PriceDenomination {
  * A null result is a real state, not a loading detail to paper over: without the rate there is no honest MANA
  * figure to show for a USD-pegged listing, so the caller renders "price unavailable" instead of guessing.
  */
-export function useManaUsdRate(chainId?: ChainId): ManaUsdRate | null {
+export function useManaUsdRate(chainId?: ChainId, marketplaceAddress?: string | null): ManaUsdRate | null {
   const [rate, setRate] = useState<ManaUsdRate | null>(null)
 
   useEffect(() => {
-    if (!chainId) {
+    // No settlement contract means no honest rate to read — the caller renders "price unavailable" rather
+    // than falling back to a version this listing may not have been signed against.
+    if (!chainId || !marketplaceAddress) {
       setRate(null)
       return
     }
@@ -55,7 +59,7 @@ export function useManaUsdRate(chainId?: ChainId): ManaUsdRate | null {
     // Clear first: on a chain switch the previous chain's rate would otherwise linger until the new read
     // resolves, briefly pricing a listing at another network's rate.
     setRate(null)
-    void fetchManaUsdRate(chainId)
+    void fetchManaUsdRate(chainId, marketplaceAddress)
       .then(resolved => {
         if (!cancelled) {
           setRate(resolved)
@@ -70,7 +74,7 @@ export function useManaUsdRate(chainId?: ChainId): ManaUsdRate | null {
     return () => {
       cancelled = true
     }
-  }, [chainId])
+  }, [chainId, marketplaceAddress])
 
   return rate
 }

--- a/webapp/src/modules/trade/manaRate.spec.ts
+++ b/webapp/src/modules/trade/manaRate.spec.ts
@@ -1,17 +1,17 @@
 import { ChainId } from '@dcl/schemas'
 import { clearManaUsdRateCache, fetchManaUsdRate, usdWeiToManaWei, ManaUsdRate } from './manaRate'
 
+/** The contract a trade settles on — what the caller reads off the trade and passes in. */
+const MARKETPLACE = '0xmarketplace'
+/** A second version on the same chain, for the cache-key case. */
+const OTHER_MARKETPLACE = '0xothermarketplace'
+
 const manaUsdAggregator = jest.fn()
 const decimals = jest.fn()
 const latestRoundData = jest.fn()
 
 jest.mock('decentraland-dapps/dist/lib/eth', () => ({
   getNetworkProvider: jest.fn().mockResolvedValue({ request: jest.fn() })
-}))
-
-jest.mock('decentraland-transactions', () => ({
-  ContractName: { OffChainMarketplaceV2: 'OffChainMarketplaceV2' },
-  getContract: () => ({ address: '0xmarketplace', name: 'OffChainMarketplaceV2', version: '1', abi: [] })
 }))
 
 jest.mock('ethers', () => {
@@ -50,8 +50,8 @@ describe('when reading the MANA/USD rate', () => {
    * decentraland-transactions is `0xe18B1361…` — a different contract, which does not even expose the same
    * interface. Reading it off the marketplace makes the displayed rate the settlement rate by construction.
    */
-  it('should read the aggregator address from the marketplace contract', async () => {
-    await fetchManaUsdRate(ChainId.MATIC_MAINNET)
+  it('should read the aggregator address from the marketplace the caller named', async () => {
+    await fetchManaUsdRate(ChainId.MATIC_MAINNET, MARKETPLACE)
 
     expect(manaUsdAggregator).toHaveBeenCalledWith('0xmarketplace')
     expect(decimals).toHaveBeenCalledWith('0xaggregator')
@@ -59,38 +59,52 @@ describe('when reading the MANA/USD rate', () => {
   })
 
   it('should return the answer and its decimals', async () => {
-    const rate = await fetchManaUsdRate(ChainId.MATIC_MAINNET)
+    const rate = await fetchManaUsdRate(ChainId.MATIC_MAINNET, MARKETPLACE)
 
     expect(rate).toEqual({ answer: 6686601n, decimals: 8 })
   })
 
   it('should reuse the read within the TTL', async () => {
-    await fetchManaUsdRate(ChainId.MATIC_MAINNET)
-    await fetchManaUsdRate(ChainId.MATIC_MAINNET)
+    await fetchManaUsdRate(ChainId.MATIC_MAINNET, MARKETPLACE)
+    await fetchManaUsdRate(ChainId.MATIC_MAINNET, MARKETPLACE)
 
     // One read for a whole grid of cards, rather than one per price.
     expect(manaUsdAggregator).toHaveBeenCalledTimes(1)
   })
 
+  /**
+   * Two marketplace versions on one chain hold their own aggregators, so a chain-only cache key would serve
+   * whichever was read first to both — pricing a V2 listing at V3's rate, which is the exact thing passing the
+   * settlement contract is meant to prevent.
+   */
+  it('should not reuse one marketplace read for a different marketplace on the same chain', async () => {
+    await fetchManaUsdRate(ChainId.MATIC_MAINNET, MARKETPLACE)
+    await fetchManaUsdRate(ChainId.MATIC_MAINNET, OTHER_MARKETPLACE)
+
+    expect(manaUsdAggregator).toHaveBeenCalledTimes(2)
+    expect(manaUsdAggregator).toHaveBeenCalledWith(MARKETPLACE)
+    expect(manaUsdAggregator).toHaveBeenCalledWith(OTHER_MARKETPLACE)
+  })
+
   it('should reject a non-positive rate instead of dividing by it', async () => {
     latestRoundData.mockResolvedValue(round({ toString: () => '0' }))
 
-    await expect(fetchManaUsdRate(ChainId.MATIC_MAINNET)).rejects.toThrow(/non-positive/)
+    await expect(fetchManaUsdRate(ChainId.MATIC_MAINNET, MARKETPLACE)).rejects.toThrow(/non-positive/)
   })
 
   it('should reject when the tuple carries no rate at all', async () => {
     // Not a cast: if the decode shape ever changes, this must fail loudly rather than yield a nonsense price.
     latestRoundData.mockResolvedValue([0, undefined, 0, 0, 0] as unknown[])
 
-    await expect(fetchManaUsdRate(ChainId.MATIC_MAINNET)).rejects.toThrow(/no rate/)
+    await expect(fetchManaUsdRate(ChainId.MATIC_MAINNET, MARKETPLACE)).rejects.toThrow(/no rate/)
   })
 
   it('should not cache a failure', async () => {
     manaUsdAggregator.mockRejectedValueOnce(new Error('rpc down'))
 
-    await expect(fetchManaUsdRate(ChainId.MATIC_MAINNET)).rejects.toThrow('rpc down')
+    await expect(fetchManaUsdRate(ChainId.MATIC_MAINNET, MARKETPLACE)).rejects.toThrow('rpc down')
     // A transient failure must not pin a broken price for the whole TTL.
-    await expect(fetchManaUsdRate(ChainId.MATIC_MAINNET)).resolves.toEqual({ answer: 6686601n, decimals: 8 })
+    await expect(fetchManaUsdRate(ChainId.MATIC_MAINNET, MARKETPLACE)).resolves.toEqual({ answer: 6686601n, decimals: 8 })
   })
 })
 

--- a/webapp/src/modules/trade/manaRate.spec.ts
+++ b/webapp/src/modules/trade/manaRate.spec.ts
@@ -14,6 +14,30 @@ jest.mock('decentraland-dapps/dist/lib/eth', () => ({
   getNetworkProvider: jest.fn().mockResolvedValue({ request: jest.fn() })
 }))
 
+// The registry gate the module now runs the address through. Mirrors the real pair: getContractName maps a
+// known address to its version and THROWS for an unknown one, which is what keeps an attacker-supplied
+// address from being dialled.
+jest.mock('decentraland-transactions', () => ({
+  ContractName: { OffChainMarketplaceV2: 'OffChainMarketplaceV2', OffChainMarketplaceV3: 'OffChainMarketplaceV3' },
+  getContractName: (address: string) => {
+    const known: Record<string, string> = {
+      '0xmarketplace': 'OffChainMarketplaceV2',
+      '0xothermarketplace': 'OffChainMarketplaceV3'
+    }
+    const name = known[address.toLowerCase()]
+    if (!name) {
+      throw new Error(`Could not get a valid contract name for address ${address}`)
+    }
+    return name
+  },
+  getContract: (name: string) => ({
+    address: name === 'OffChainMarketplaceV3' ? '0xothermarketplace' : '0xmarketplace',
+    name,
+    version: '1.0.0',
+    abi: []
+  })
+}))
+
 jest.mock('ethers', () => {
   // Annotated rather than asserted — see the note in the component specs.
   const actual: typeof import('ethers') = jest.requireActual('ethers')
@@ -84,6 +108,17 @@ describe('when reading the MANA/USD rate', () => {
     expect(manaUsdAggregator).toHaveBeenCalledTimes(2)
     expect(manaUsdAggregator).toHaveBeenCalledWith(MARKETPLACE)
     expect(manaUsdAggregator).toHaveBeenCalledWith(OTHER_MARKETPLACE)
+  })
+
+  /**
+   * `marketplaceAddress` arrives from a server-supplied `trade.contract`. Every transacting path already
+   * re-resolves it; this is the one read that would otherwise dial the raw string, and ethers v5 would treat
+   * a non-address as an ENS name to go and look up.
+   */
+  it('should refuse an address the contract registry does not know', async () => {
+    await expect(fetchManaUsdRate(ChainId.MATIC_MAINNET, '0xnotamarketplace')).rejects.toThrow(/valid contract name/)
+
+    expect(manaUsdAggregator).not.toHaveBeenCalled()
   })
 
   it('should reject a non-positive rate instead of dividing by it', async () => {

--- a/webapp/src/modules/trade/manaRate.ts
+++ b/webapp/src/modules/trade/manaRate.ts
@@ -1,7 +1,6 @@
 import { ethers } from 'ethers'
 import { ChainId } from '@dcl/schemas'
 import { getNetworkProvider } from 'decentraland-dapps/dist/lib/eth'
-import { ContractName, getContract } from 'decentraland-transactions'
 
 /**
  * The MANA/USD rate a USD-pegged listing will actually settle at.
@@ -10,7 +9,11 @@ import { ContractName, getContract } from 'decentraland-transactions'
  * accept time using its own oracle. This app charges in MANA, so the only honest thing to show a buyer is how
  * much MANA the listing currently costs — not the USD figure, and certainly not a shop-side unit.
  *
- * READ THROUGH THE MARKETPLACE, NEVER A STANDALONE ORACLE. `decentraland-transactions` also ships a
+ * READ THROUGH THE MARKETPLACE THE TRADE SETTLES ON, and never a standalone oracle or a version this module
+ * picks for itself. Each marketplace version holds its own `manaUsdAggregator`, so a listing signed against V2
+ * has to be priced with V2's feed even once V3 exists — reading "the newest" would quote legacy listings at
+ * another contract's rate. The caller passes the address from the same `fetchTrade` that told it the listing
+ * is USD-pegged, which is why there is no fallback here. `decentraland-transactions` also ships a
  * `ChainlinkOracle` entry, and on Polygon it is a DIFFERENT contract from the one the marketplace settles with
  * (`0xe18B1361…` vs the marketplace's `0xA1CbF3Fe…`, measured on chain — and the marketplace's does not even
  * expose `getRate`). Reading the aggregator address off the marketplace itself makes the displayed rate the
@@ -36,16 +39,21 @@ export type ManaUsdRate = {
 const TTL_MS = 60_000
 
 type CacheEntry = { at: number; rate: Promise<ManaUsdRate> }
-const cache = new Map<ChainId, CacheEntry>()
+// Keyed by chain AND marketplace, not chain alone: two versions on one chain can answer different rates, and a
+// chain-only key would serve whichever was read first to both.
+const cache = new Map<string, CacheEntry>()
 
-async function readRate(chainId: ChainId): Promise<ManaUsdRate> {
+function cacheKey(chainId: ChainId, marketplaceAddress: string): string {
+  return `${chainId}-${marketplaceAddress.toLowerCase()}`
+}
+
+async function readRate(chainId: ChainId, marketplaceAddress: string): Promise<ManaUsdRate> {
   const provider = await getNetworkProvider(chainId)
   if (!provider) {
     throw new Error('Could not get a provider to read the MANA/USD oracle')
   }
   const web3 = new ethers.providers.Web3Provider(provider)
-  const { address } = getContract(ContractName.OffChainMarketplaceV2, chainId)
-  const marketplace = new ethers.Contract(address, MARKETPLACE_ABI, web3)
+  const marketplace = new ethers.Contract(marketplaceAddress, MARKETPLACE_ABI, web3)
   const aggregatorAddress: string = await marketplace.manaUsdAggregator()
 
   const aggregator = new ethers.Contract(aggregatorAddress, AGGREGATOR_ABI, web3)
@@ -65,18 +73,23 @@ async function readRate(chainId: ChainId): Promise<ManaUsdRate> {
   return { answer, decimals: Number(decimals) }
 }
 
-/** The rate for a chain, cached for {@link TTL_MS}. A failed read is not cached. */
-export function fetchManaUsdRate(chainId: ChainId): Promise<ManaUsdRate> {
-  const hit = cache.get(chainId)
+/**
+ * The rate the given marketplace will settle at, cached for {@link TTL_MS}. A failed read is not cached.
+ *
+ * `marketplaceAddress` is required on purpose — see the module comment. It is the trade's own `contract`.
+ */
+export function fetchManaUsdRate(chainId: ChainId, marketplaceAddress: string): Promise<ManaUsdRate> {
+  const key = cacheKey(chainId, marketplaceAddress)
+  const hit = cache.get(key)
   if (hit && Date.now() - hit.at < TTL_MS) {
     return hit.rate
   }
-  const rate = readRate(chainId).catch(error => {
+  const rate = readRate(chainId, marketplaceAddress).catch(error => {
     // Never pin a failure: the next render should try again rather than inherit a broken price for a minute.
-    cache.delete(chainId)
+    cache.delete(key)
     throw error
   })
-  cache.set(chainId, { at: Date.now(), rate })
+  cache.set(key, { at: Date.now(), rate })
   return rate
 }
 

--- a/webapp/src/modules/trade/manaRate.ts
+++ b/webapp/src/modules/trade/manaRate.ts
@@ -1,6 +1,7 @@
 import { ethers } from 'ethers'
 import { ChainId } from '@dcl/schemas'
 import { getNetworkProvider } from 'decentraland-dapps/dist/lib/eth'
+import { getContract, getContractName } from 'decentraland-transactions'
 
 /**
  * The MANA/USD rate a USD-pegged listing will actually settle at.
@@ -48,12 +49,18 @@ function cacheKey(chainId: ChainId, marketplaceAddress: string): string {
 }
 
 async function readRate(chainId: ChainId, marketplaceAddress: string): Promise<ManaUsdRate> {
+  // Resolve the address through the contract registry before calling it. `marketplaceAddress` reaches here
+  // from a server-supplied `trade.contract`, and this is the one path that would otherwise dial it directly:
+  // every transacting path re-resolves and fails closed already. Two things this prevents — pricing off a
+  // contract nobody deployed, and ethers v5 treating a non-address string as an ENS name to go and look up.
+  // An unknown address throws, which the caller renders as "price unavailable".
+  const marketplaceContract = getContract(getContractName(marketplaceAddress), chainId)
   const provider = await getNetworkProvider(chainId)
   if (!provider) {
     throw new Error('Could not get a provider to read the MANA/USD oracle')
   }
   const web3 = new ethers.providers.Web3Provider(provider)
-  const marketplace = new ethers.Contract(marketplaceAddress, MARKETPLACE_ABI, web3)
+  const marketplace = new ethers.Contract(marketplaceContract.address, MARKETPLACE_ABI, web3)
   const aggregatorAddress: string = await marketplace.manaUsdAggregator()
 
   const aggregator = new ethers.Contract(aggregatorAddress, AGGREGATOR_ABI, web3)

--- a/webapp/src/modules/transak/sagas.spec.ts
+++ b/webapp/src/modules/transak/sagas.spec.ts
@@ -252,6 +252,45 @@ describe('when handling the open transak action', () => {
     })
 
     describe('when not using credits', () => {
+      /**
+       * Transak executes `accept` on a contract it has registered on its own side, addressed by an opaque id.
+       * A trade's signature only authorises the contract it was signed against, so running a V3-signed listing
+       * through the pre-V3 registration reverts on chain — after the buyer has already been charged. Until V3
+       * is registered with Transak there is no id to use, and refusing to open the widget is the only outcome
+       * that does not take someone's money for a purchase that cannot complete.
+       */
+      describe('and the trade was signed against a marketplace Transak does not know', () => {
+        let unregisteredTrade: Trade
+
+        beforeEach(() => {
+          unregisteredTrade = {
+            ...mockTrade,
+            contract: getContract(ContractName.OffChainMarketplaceV3, ChainId.MATIC_AMOY).address
+          }
+        })
+
+        it('should fail without opening the widget', () => {
+          return (
+            expectSaga(transakSaga, () => undefined)
+              .provide([
+                [select(getWallet), mockWallet],
+                [select(getAddress), mockWallet.address],
+                [select(getIsCreditsEnabled), false],
+                [matchers.call.fn(TradeService.prototype.fetchTrade), unregisteredTrade]
+              ])
+              // The asset is an NFT, so the trade id reaches the saga through the order, not the asset.
+              .dispatch(openTransak(mockAsset, { ...mockOrder, tradeId: 'mock-trade-id' }))
+              .put(
+                openTransakFailure(`${ContractName.OffChainMarketplaceV3} is not registered with Transak on chainId ${ChainId.MATIC_AMOY}`)
+              )
+              .run({ silenceTimeout: true, timeout: 500 })
+              .then(() => {
+                expect(Transak.prototype.openWidget).not.toHaveBeenCalled()
+              })
+          )
+        })
+      })
+
       describe('and the asset has a trade', () => {
         it('should open the Transak widget with the correct configuration for marketplace v3', () => {
           return expectSaga(transakSaga, () => undefined)

--- a/webapp/src/modules/transak/sagas.spec.ts
+++ b/webapp/src/modules/transak/sagas.spec.ts
@@ -160,6 +160,15 @@ const mockTrade: Trade = {
   ]
 }
 
+/**
+ * The action types still queued after redux-saga-test-plan has consumed the ones a `.put(...)` expectation
+ * matched. These specs used to assert nothing else was dispatched; the failure toast is now deliberately
+ * dispatched alongside, because OPEN_TRANSAK_FAILURE has no reducer and on its own reaches no one.
+ */
+function putActionTypes(effects: { put?: unknown[] }): string[] {
+  return ((effects.put ?? []) as { payload: { action: { type: string } } }[]).map(effect => effect.payload.action.type)
+}
+
 describe('when handling the open transak action', () => {
   afterEach(() => {
     jest.clearAllMocks()
@@ -256,7 +265,7 @@ describe('when handling the open transak action', () => {
               .put(openTransakFailure('No credits available'))
               .run()
               .then(({ effects }) => {
-                expect(effects.put).toBeUndefined()
+                expect(putActionTypes(effects)).toEqual(['Show toast'])
                 expect(Transak.prototype.openWidget).not.toHaveBeenCalled()
               })
           })
@@ -276,7 +285,7 @@ describe('when handling the open transak action', () => {
             .put(openTransakFailure('Credits are not enabled'))
             .run()
             .then(({ effects }) => {
-              expect(effects.put).toBeUndefined()
+              expect(putActionTypes(effects)).toEqual(['Show toast'])
               expect(Transak.prototype.openWidget).not.toHaveBeenCalled()
             })
         })
@@ -431,7 +440,7 @@ describe('when handling the open transak action', () => {
         )
         .run()
         .then(({ effects }) => {
-          expect(effects.put).toBeUndefined()
+          expect(putActionTypes(effects)).toEqual(['Show toast'])
           expect(Transak.prototype.openWidget).not.toHaveBeenCalled()
         })
     })

--- a/webapp/src/modules/transak/sagas.spec.ts
+++ b/webapp/src/modules/transak/sagas.spec.ts
@@ -210,6 +210,38 @@ describe('when handling the open transak action', () => {
           })
         })
 
+        /**
+         * The credits route executes through the CreditsManager, which is what Transak has registered there,
+         * and which resolves the marketplace from the trade on chain itself. A version Transak has no direct
+         * registration for must therefore NOT block this route — only the direct `accept` route needs one.
+         */
+        describe('and the trade was signed against a marketplace Transak has no registration for', () => {
+          let unregisteredTrade: Trade
+
+          beforeEach(() => {
+            unregisteredTrade = {
+              ...mockTrade,
+              contract: getContract(ContractName.OffChainMarketplaceV3, ChainId.MATIC_AMOY).address
+            }
+          })
+
+          it('should still open the widget, because credits do not go through that registration', () => {
+            return expectSaga(transakSaga, () => undefined)
+              .provide([
+                [select(getWallet), mockWallet],
+                [select(getAddress), mockWallet.address],
+                [select(getIsCreditsEnabled), true],
+                [select(getCredits, mockWallet.address), mockCredits],
+                [matchers.call.fn(TradeService.prototype.fetchTrade), unregisteredTrade]
+              ])
+              .dispatch(openTransak(mockAsset, mockOrder, true))
+              .run({ silenceTimeout: true, timeout: 500 })
+              .then(() => {
+                expect(Transak.prototype.openWidget).toHaveBeenCalled()
+              })
+          })
+        })
+
         describe('and the user does not have enough credits', () => {
           it('should throw an error', () => {
             return expectSaga(transakSaga, () => undefined)

--- a/webapp/src/modules/transak/sagas.ts
+++ b/webapp/src/modules/transak/sagas.ts
@@ -22,14 +22,41 @@ import { getWallet } from '../wallet/selectors'
 import { OPEN_TRANSAK, OpenTransakAction, openTransakFailure } from './actions'
 import { encodeTokenId } from './utils'
 
-const MarketplaceV3ContractIds: Pick<Record<Network, Partial<Record<ChainId, string>>>, Network.MATIC | Network.ETHEREUM> = {
-  [Network.MATIC]: {
-    [ChainId.MATIC_AMOY]: '670660ed2bbeb54123b28728',
-    [ChainId.MATIC_MAINNET]: '6717e6cd2fb1688e111c1a80'
+/**
+ * Transak's own id for each marketplace contract it will execute against. These are registrations on
+ * Transak's side, not addresses, so a contract Transak has never been told about simply has no id here.
+ *
+ * Keyed by marketplace VERSION as well as chain. A trade carries the contract it was signed against, and
+ * Transak has to execute `accept` on that same contract — the signature is bound to it. A single id per chain
+ * cannot serve two versions at once: pointing it at V3 would break every V2-signed listing, and leaving it on
+ * the older one breaks the V3 ones.
+ *
+ * V3 is deliberately absent until it is registered with Transak. A missing entry fails closed (see below)
+ * rather than executing a V3 trade against a pre-V3 registration, which would revert on-chain anyway.
+ */
+const OffChainMarketplaceContractIds: Partial<
+  Record<ContractName, Pick<Record<Network, Partial<Record<ChainId, string>>>, Network.MATIC | Network.ETHEREUM>>
+> = {
+  [ContractName.OffChainMarketplace]: {
+    [Network.MATIC]: {
+      [ChainId.MATIC_AMOY]: '670660ed2bbeb54123b28728',
+      [ChainId.MATIC_MAINNET]: '6717e6cd2fb1688e111c1a80'
+    },
+    [Network.ETHEREUM]: {
+      [ChainId.ETHEREUM_MAINNET]: '672100492fb1688e111c2bd4',
+      [ChainId.ETHEREUM_SEPOLIA]: '671a23e92bbeb54123b3b692'
+    }
   },
-  [Network.ETHEREUM]: {
-    [ChainId.ETHEREUM_MAINNET]: '672100492fb1688e111c2bd4',
-    [ChainId.ETHEREUM_SEPOLIA]: '671a23e92bbeb54123b3b692'
+  // The same registrations: before V3 both versions were served by one id per chain.
+  [ContractName.OffChainMarketplaceV2]: {
+    [Network.MATIC]: {
+      [ChainId.MATIC_AMOY]: '670660ed2bbeb54123b28728',
+      [ChainId.MATIC_MAINNET]: '6717e6cd2fb1688e111c1a80'
+    },
+    [Network.ETHEREUM]: {
+      [ChainId.ETHEREUM_MAINNET]: '672100492fb1688e111c2bd4',
+      [ChainId.ETHEREUM_SEPOLIA]: '671a23e92bbeb54123b3b692'
+    }
   }
 }
 const CreditsManagerContractIds: Pick<Record<Network, Partial<Record<ChainId, string>>>, Network.MATIC> = {
@@ -101,14 +128,18 @@ export function* transakSaga(getIdentity: () => AuthIdentity | undefined) {
       }
 
       if (tradeId && wallet?.address) {
-        // MarketplaceV3
-        contractId = MarketplaceV3ContractIds[asset.network]?.[asset.chainId]
-        if (!contractId) {
-          throw new Error(`Marketplace contract not found for network ${asset.network} and chainId ${asset.chainId}`)
-        }
+        // Off-chain marketplace. The trade has to be read BEFORE the Transak contract id is chosen: the id and
+        // the ABI both depend on which marketplace version this particular listing was signed against.
         const tradeService = new TradeService(API_SIGNER, MARKETPLACE_SERVER_URL, () => undefined)
         const trade: Trade = yield call([tradeService, 'fetchTrade'], tradeId)
-        const { abi } = getContract(ContractName.OffChainMarketplace, asset.chainId)
+        const marketplaceName = getContractName(trade.contract)
+        contractId = OffChainMarketplaceContractIds[marketplaceName]?.[asset.network]?.[asset.chainId]
+        if (!contractId) {
+          // Fail closed. Executing against another version's registration would send `accept` to a contract the
+          // signature does not authorise, so the purchase reverts after the buyer has already paid Transak.
+          throw new Error(`${marketplaceName} is not registered with Transak on chainId ${asset.chainId}`)
+        }
+        const { abi } = getContract(marketplaceName, asset.chainId)
 
         // if credits are enabled and useCredits is true, we need to use credits
         if (useCredits && credits) {

--- a/webapp/src/modules/transak/sagas.ts
+++ b/webapp/src/modules/transak/sagas.ts
@@ -8,6 +8,7 @@ import { CreditsResponse } from 'decentraland-dapps/dist/modules/credits/types'
 import { Transak } from 'decentraland-dapps/dist/modules/gateway/transak'
 import { TransakConfig } from 'decentraland-dapps/dist/modules/gateway/types'
 import { closeAllModals } from 'decentraland-dapps/dist/modules/modal/actions'
+import { showToast } from 'decentraland-dapps/dist/modules/toast/actions'
 import { TradeService } from 'decentraland-dapps/dist/modules/trades/TradeService'
 import { getAddress } from 'decentraland-dapps/dist/modules/wallet/selectors'
 import { AuthIdentity } from 'decentraland-crypto-fetch'
@@ -17,6 +18,7 @@ import { API_SIGNER } from '../../lib/api'
 import { getOnChainTrade } from '../../utils/trades'
 import { getAssetImage, isNFT } from '../asset/utils'
 import { getIsCreditsEnabled } from '../features/selectors'
+import { getOpenTransakFailureToast } from '../toast/toasts'
 import { MARKETPLACE_SERVER_URL } from '../vendor/decentraland'
 import { getWallet } from '../wallet/selectors'
 import { OPEN_TRANSAK, OpenTransakAction, openTransakFailure } from './actions'
@@ -34,30 +36,27 @@ import { encodeTokenId } from './utils'
  * V3 is deliberately absent until it is registered with Transak. A missing entry fails closed (see below)
  * rather than executing a V3 trade against a pre-V3 registration, which would revert on-chain anyway.
  */
+/**
+ * The one registration that existed before V3: Transak registered a single contract per chain, and both V1
+ * and V2 were served by it. Named once and referenced twice below so "the same registrations" is a fact of
+ * the code rather than a comment above two identical literals.
+ */
+const PRE_V3_MARKETPLACE_CONTRACT_IDS: Pick<Record<Network, Partial<Record<ChainId, string>>>, Network.MATIC | Network.ETHEREUM> = {
+  [Network.MATIC]: {
+    [ChainId.MATIC_AMOY]: '670660ed2bbeb54123b28728',
+    [ChainId.MATIC_MAINNET]: '6717e6cd2fb1688e111c1a80'
+  },
+  [Network.ETHEREUM]: {
+    [ChainId.ETHEREUM_MAINNET]: '672100492fb1688e111c2bd4',
+    [ChainId.ETHEREUM_SEPOLIA]: '671a23e92bbeb54123b3b692'
+  }
+}
+
 const OffChainMarketplaceContractIds: Partial<
   Record<ContractName, Pick<Record<Network, Partial<Record<ChainId, string>>>, Network.MATIC | Network.ETHEREUM>>
 > = {
-  [ContractName.OffChainMarketplace]: {
-    [Network.MATIC]: {
-      [ChainId.MATIC_AMOY]: '670660ed2bbeb54123b28728',
-      [ChainId.MATIC_MAINNET]: '6717e6cd2fb1688e111c1a80'
-    },
-    [Network.ETHEREUM]: {
-      [ChainId.ETHEREUM_MAINNET]: '672100492fb1688e111c2bd4',
-      [ChainId.ETHEREUM_SEPOLIA]: '671a23e92bbeb54123b3b692'
-    }
-  },
-  // The same registrations: before V3 both versions were served by one id per chain.
-  [ContractName.OffChainMarketplaceV2]: {
-    [Network.MATIC]: {
-      [ChainId.MATIC_AMOY]: '670660ed2bbeb54123b28728',
-      [ChainId.MATIC_MAINNET]: '6717e6cd2fb1688e111c1a80'
-    },
-    [Network.ETHEREUM]: {
-      [ChainId.ETHEREUM_MAINNET]: '672100492fb1688e111c2bd4',
-      [ChainId.ETHEREUM_SEPOLIA]: '671a23e92bbeb54123b3b692'
-    }
-  }
+  [ContractName.OffChainMarketplace]: PRE_V3_MARKETPLACE_CONTRACT_IDS,
+  [ContractName.OffChainMarketplaceV2]: PRE_V3_MARKETPLACE_CONTRACT_IDS
 }
 const CreditsManagerContractIds: Pick<Record<Network, Partial<Record<ChainId, string>>>, Network.MATIC> = {
   [Network.MATIC]: {
@@ -280,6 +279,9 @@ export function* transakSaga(getIdentity: () => AuthIdentity | undefined) {
         yield call([transak, 'openWidget'], { ...customizationOptions, walletAddress: address, network: Network.MATIC })
       }
     } catch (error) {
+      // Tell the buyer. OPEN_TRANSAK_FAILURE has no reducer or handler, so on its own it is a dead end —
+      // the widget just never opens.
+      yield put(showToast(getOpenTransakFailureToast()))
       yield put(openTransakFailure(error instanceof Error ? error.message : 'Unknown error'))
     }
   }

--- a/webapp/src/modules/transak/sagas.ts
+++ b/webapp/src/modules/transak/sagas.ts
@@ -128,18 +128,11 @@ export function* transakSaga(getIdentity: () => AuthIdentity | undefined) {
       }
 
       if (tradeId && wallet?.address) {
-        // Off-chain marketplace. The trade has to be read BEFORE the Transak contract id is chosen: the id and
-        // the ABI both depend on which marketplace version this particular listing was signed against.
+        // Off-chain marketplace. The trade is read first because which marketplace version this listing was
+        // signed against decides the Transak registration and the ABI — but only on the direct route; the
+        // credits route goes through the CreditsManager and needs neither.
         const tradeService = new TradeService(API_SIGNER, MARKETPLACE_SERVER_URL, () => undefined)
         const trade: Trade = yield call([tradeService, 'fetchTrade'], tradeId)
-        const marketplaceName = getContractName(trade.contract)
-        contractId = OffChainMarketplaceContractIds[marketplaceName]?.[asset.network]?.[asset.chainId]
-        if (!contractId) {
-          // Fail closed. Executing against another version's registration would send `accept` to a contract the
-          // signature does not authorise, so the purchase reverts after the buyer has already paid Transak.
-          throw new Error(`${marketplaceName} is not registered with Transak on chainId ${asset.chainId}`)
-        }
-        const { abi } = getContract(marketplaceName, asset.chainId)
 
         // if credits are enabled and useCredits is true, we need to use credits
         if (useCredits && credits) {
@@ -164,9 +157,19 @@ export function* transakSaga(getIdentity: () => AuthIdentity | undefined) {
           // encode useCredits function data
           calldata = CreditsManagerInterface.encodeFunctionData('useCredits', [useCreditsArgs])
         } else {
-          // native call to marketplace
-          const MarketplaveV3Interface = new ethers.utils.Interface(abi)
-          calldata = MarketplaveV3Interface.encodeFunctionData('accept', [[getOnChainTrade(trade, transakMulticallContract)]])
+          // Native call to the marketplace: Transak executes `accept` on the contract itself, so it needs a
+          // registration for THIS version. The credits route above does not — the CreditsManager is the
+          // registered contract there, and it resolves the marketplace from the trade on chain.
+          const marketplaceName = getContractName(trade.contract)
+          contractId = OffChainMarketplaceContractIds[marketplaceName]?.[asset.network]?.[asset.chainId]
+          if (!contractId) {
+            // Fail closed. Executing against another version's registration would send `accept` to a contract
+            // the signature does not authorise, so the purchase reverts after the buyer has already paid.
+            throw new Error(`${marketplaceName} is not registered with Transak on chainId ${asset.chainId}`)
+          }
+          const { abi } = getContract(marketplaceName, asset.chainId)
+          const marketplaceInterface = new ethers.utils.Interface(abi)
+          calldata = marketplaceInterface.encodeFunctionData('accept', [[getOnChainTrade(trade, transakMulticallContract)]])
         }
       } else if (order && isNFT(asset)) {
         // Legacy Marketplace

--- a/webapp/src/modules/transak/sagas.ts
+++ b/webapp/src/modules/transak/sagas.ts
@@ -25,18 +25,6 @@ import { OPEN_TRANSAK, OpenTransakAction, openTransakFailure } from './actions'
 import { encodeTokenId } from './utils'
 
 /**
- * Transak's own id for each marketplace contract it will execute against. These are registrations on
- * Transak's side, not addresses, so a contract Transak has never been told about simply has no id here.
- *
- * Keyed by marketplace VERSION as well as chain. A trade carries the contract it was signed against, and
- * Transak has to execute `accept` on that same contract — the signature is bound to it. A single id per chain
- * cannot serve two versions at once: pointing it at V3 would break every V2-signed listing, and leaving it on
- * the older one breaks the V3 ones.
- *
- * V3 is deliberately absent until it is registered with Transak. A missing entry fails closed (see below)
- * rather than executing a V3 trade against a pre-V3 registration, which would revert on-chain anyway.
- */
-/**
  * The one registration that existed before V3: Transak registered a single contract per chain, and both V1
  * and V2 were served by it. Named once and referenced twice below so "the same registrations" is a fact of
  * the code rather than a comment above two identical literals.
@@ -52,6 +40,18 @@ const PRE_V3_MARKETPLACE_CONTRACT_IDS: Pick<Record<Network, Partial<Record<Chain
   }
 }
 
+/**
+ * Transak's own id for each marketplace contract it will execute against. These are registrations on
+ * Transak's side, not addresses, so a contract Transak has never been told about simply has no id here.
+ *
+ * Keyed by marketplace VERSION as well as chain. A trade carries the contract it was signed against, and
+ * Transak has to execute `accept` on that same contract — the signature is bound to it. A single id per chain
+ * cannot serve two versions at once: pointing it at V3 would break every V2-signed listing, and leaving it on
+ * the older one breaks the V3 ones.
+ *
+ * V3 is deliberately absent until it is registered with Transak. A missing entry fails closed (see below)
+ * rather than executing a V3 trade against a pre-V3 registration, which would revert on-chain anyway.
+ */
 const OffChainMarketplaceContractIds: Partial<
   Record<ContractName, Pick<Record<Network, Partial<Record<ChainId, string>>>, Network.MATIC | Network.ETHEREUM>>
 > = {

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -1275,6 +1275,10 @@
       "title": "Temporarily unavailable",
       "body": "NAME registration with credits is temporarily paused due to high network costs. Please try again later."
     },
+    "open_transak_failure": {
+      "title": "Card payment unavailable",
+      "body": "Card payments are not available for this listing yet. You can still buy it with MANA or credits."
+    },
     "cross_chain_tx": {
       "body": "The transaction can take up to <highlight>3 minutes</highlight> to be processed.<br></br>You can also track its progress in the links below:",
       "view_transaction": "View transaction"

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -1277,7 +1277,7 @@
     },
     "open_transak_failure": {
       "title": "Card payment unavailable",
-      "body": "Card payments are not available for this listing yet. You can still buy it with MANA or credits."
+      "body": "Card payment could not be started for this listing."
     },
     "cross_chain_tx": {
       "body": "The transaction can take up to <highlight>3 minutes</highlight> to be processed.<br></br>You can also track its progress in the links below:",

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -1243,6 +1243,10 @@
       "title": "Temporalmente no disponible",
       "body": "El registro de NAME con créditos está temporalmente pausado por los altos costos de la red. Por favor, inténtalo de nuevo más tarde."
     },
+    "open_transak_failure": {
+      "title": "Pago con tarjeta no disponible",
+      "body": "Los pagos con tarjeta aún no están disponibles para esta publicación. Puedes comprarla con MANA o créditos."
+    },
     "cross_chain_tx": {
       "body": "La transacción puede tardar hasta <highlight>3 miuntos</highlight> para ser procesada.<br></br>Puedes seguir su progreso en los siguientes enlaces:",
       "view_transaction": "Ver transacción"

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -1245,7 +1245,7 @@
     },
     "open_transak_failure": {
       "title": "Pago con tarjeta no disponible",
-      "body": "Los pagos con tarjeta aún no están disponibles para esta publicación. Puedes comprarla con MANA o créditos."
+      "body": "No se pudo iniciar el pago con tarjeta para esta publicación."
     },
     "cross_chain_tx": {
       "body": "La transacción puede tardar hasta <highlight>3 miuntos</highlight> para ser procesada.<br></br>Puedes seguir su progreso en los siguientes enlaces:",

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -1246,6 +1246,10 @@
       "title": "暂时不可用",
       "body": "由于网络费用较高，使用积分注册 NAME 暂时暂停。请稍后再试。"
     },
+    "open_transak_failure": {
+      "title": "暂不支持银行卡支付",
+      "body": "此商品暂不支持银行卡支付。你仍然可以使用 MANA 或积分购买。"
+    },
     "cross_chain_tx": {
       "body": "处理该交易最多可能需要 <highlight>3 分钟</highlight>。<br></br>您还可以在以下链接中跟踪其进度：",
       "view_transaction": "查看交易"

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -1248,7 +1248,7 @@
     },
     "open_transak_failure": {
       "title": "暂不支持银行卡支付",
-      "body": "此商品暂不支持银行卡支付。你仍然可以使用 MANA 或积分购买。"
+      "body": "无法为此商品发起银行卡支付。"
     },
     "cross_chain_tx": {
       "body": "处理该交易最多可能需要 <highlight>3 分钟</highlight>。<br></br>您还可以在以下链接中跟踪其进度：",

--- a/webapp/src/modules/vendor/decentraland/contracts.ts
+++ b/webapp/src/modules/vendor/decentraland/contracts.ts
@@ -7,7 +7,6 @@ export const LEGACY_MARKETPLACE_MAINNET_CONTRACT = '0xb3bca6f5052c7e24726b44da74
 export enum ContractName {
   MANA = 'MANA',
   MARKETPLACE = 'Marketplace',
-  OFF_CHAIN_MARKETPLACE = 'OffChainMarketplace',
   LEGACY_MARKETPLACE = 'LegacyMarketplace',
   CREDITS_MANAGER = 'CreditsManager',
   BIDS = 'Bids',
@@ -469,14 +468,6 @@ const localContracts = {
       chainId: ChainId.ETHEREUM_SEPOLIA
     },
     {
-      name: ContractName.OFF_CHAIN_MARKETPLACE,
-      address: getContract(CN.OffChainMarketplace, ChainId.ETHEREUM_SEPOLIA).address,
-      vendor: 'decentraland',
-      category: null,
-      network: Network.ETHEREUM,
-      chainId: ChainId.ETHEREUM_SEPOLIA
-    },
-    {
       name: ContractName.CREDITS_MANAGER,
       address: getContract(CN.CreditsManager, ChainId.MATIC_AMOY).address,
       vendor: 'decentraland',
@@ -512,14 +503,6 @@ const localContracts = {
       name: ContractName.MARKETPLACE,
       address: getContract(CN.MarketplaceV2, ChainId.MATIC_AMOY).address,
       label: 'MarketplaceV2',
-      vendor: 'decentraland',
-      category: null,
-      network: Network.MATIC,
-      chainId: ChainId.MATIC_AMOY
-    },
-    {
-      name: ContractName.OFF_CHAIN_MARKETPLACE,
-      address: getContract(CN.OffChainMarketplace, ChainId.MATIC_AMOY).address,
       vendor: 'decentraland',
       category: null,
       network: Network.MATIC,
@@ -645,14 +628,6 @@ const localContracts = {
       chainId: ChainId.ETHEREUM_MAINNET
     },
     {
-      name: ContractName.OFF_CHAIN_MARKETPLACE,
-      address: getContract(CN.OffChainMarketplace, ChainId.ETHEREUM_MAINNET).address,
-      vendor: 'decentraland',
-      category: null,
-      network: Network.ETHEREUM,
-      chainId: ChainId.ETHEREUM_MAINNET
-    },
-    {
       name: ContractName.CREDITS_MANAGER,
       address: getContract(CN.CreditsManager, ChainId.MATIC_MAINNET).address,
       vendor: 'decentraland',
@@ -687,14 +662,6 @@ const localContracts = {
     {
       name: ContractName.MARKETPLACE,
       address: getContract(CN.MarketplaceV2, ChainId.MATIC_MAINNET).address,
-      vendor: 'decentraland',
-      category: null,
-      network: Network.MATIC,
-      chainId: ChainId.MATIC_MAINNET
-    },
-    {
-      name: ContractName.OFF_CHAIN_MARKETPLACE,
-      address: getContract(CN.OffChainMarketplace, ChainId.MATIC_MAINNET).address,
       vendor: 'decentraland',
       category: null,
       network: Network.MATIC,

--- a/webapp/src/utils/trades.spec.ts
+++ b/webapp/src/utils/trades.spec.ts
@@ -20,7 +20,8 @@ import {
   getOnChainTrade,
   getValueForTradeAsset,
   estimateTradeGas,
-  getLatestOffChainMarketplaceContract
+  getLatestOffChainMarketplaceContract,
+  getDeployedOffChainMarketplaceContracts
 } from './trades'
 
 jest.mock('decentraland-dapps/dist/lib/eth', () => {
@@ -442,6 +443,38 @@ describe('when estimating trade gas', () => {
 
     it('should propagate the error', async () => {
       return expect(estimateTradeGas(tradeId, undefined, chainId, buyerAddress, provider)).rejects.toThrow('Gas estimation failed')
+    })
+  })
+})
+
+/**
+ * Asserted against the versions themselves rather than against the enumerator's own output. contract/sagas
+ * builds its expected authorizations by calling this function, so a regression in it would move both sides
+ * of that comparison and pass — this is the check that would not.
+ */
+describe('when listing every off-chain marketplace deployed on a chain', () => {
+  describe('and the chain has all three versions', () => {
+    it('should return them newest first', () => {
+      expect(getDeployedOffChainMarketplaceContracts(ChainId.ETHEREUM_SEPOLIA).map(({ contractName }) => contractName)).toEqual([
+        ContractName.OffChainMarketplaceV3,
+        ContractName.OffChainMarketplaceV2,
+        ContractName.OffChainMarketplace
+      ])
+    })
+  })
+
+  describe('and the chain has no V3 deployment', () => {
+    it('should return only the versions that are actually there', () => {
+      expect(getDeployedOffChainMarketplaceContracts(ChainId.ETHEREUM_MAINNET).map(({ contractName }) => contractName)).toEqual([
+        ContractName.OffChainMarketplaceV2,
+        ContractName.OffChainMarketplace
+      ])
+    })
+  })
+
+  describe('and the chain has no off-chain marketplace at all', () => {
+    it('should return nothing instead of throwing', () => {
+      expect(getDeployedOffChainMarketplaceContracts(ChainId.ARBITRUM_MAINNET)).toEqual([])
     })
   })
 })

--- a/webapp/src/utils/trades.spec.ts
+++ b/webapp/src/utils/trades.spec.ts
@@ -384,6 +384,37 @@ describe('when estimating trade gas', () => {
     jest.clearAllMocks()
   })
 
+  /**
+   * The caller does not always know the settlement contract, and the fallback used to be V1 — so a V2 or V3
+   * trade was measured against a contract its signature does not authorise. That estimates a call that would
+   * revert, which is precisely what the buyer needs the estimate to surface.
+   */
+  describe('and the caller does not pass a settlement contract', () => {
+    beforeEach(() => {
+      mockEstimateGas.mockResolvedValue(ethers.BigNumber.from('100000'))
+    })
+
+    it('should estimate against the contract the trade settles on', async () => {
+      await estimateTradeGas(tradeId, undefined, chainId, buyerAddress, provider)
+
+      expect(ethers.Contract).toHaveBeenCalledWith(
+        getContract(ContractName.OffChainMarketplaceV2, ChainId.ETHEREUM_SEPOLIA).address,
+        expect.anything(),
+        provider
+      )
+    })
+
+    it('should not fall back to a fixed version', async () => {
+      await estimateTradeGas(tradeId, undefined, chainId, buyerAddress, provider)
+
+      expect(ethers.Contract).not.toHaveBeenCalledWith(
+        getContract(ContractName.OffChainMarketplace, ChainId.ETHEREUM_SEPOLIA).address,
+        expect.anything(),
+        expect.anything()
+      )
+    })
+  })
+
   describe.skip('when the gas estimation succeeds', () => {
     beforeEach(() => {
       mockEstimateGas.mockResolvedValue(ethers.BigNumber.from('100000'))

--- a/webapp/src/utils/trades.spec.ts
+++ b/webapp/src/utils/trades.spec.ts
@@ -14,7 +14,14 @@ import * as ethUtils from 'decentraland-dapps/dist/lib/eth'
 import { TradeService } from 'decentraland-dapps/dist/modules/trades/TradeService'
 import { ContractData, ContractName, getContract } from 'decentraland-transactions'
 import { fromMillisecondsToSeconds } from '../lib/time'
-import { OFFCHAIN_MARKETPLACE_TYPES, getTradeSignature, getOnChainTrade, getValueForTradeAsset, estimateTradeGas } from './trades'
+import {
+  OFFCHAIN_MARKETPLACE_TYPES,
+  getTradeSignature,
+  getOnChainTrade,
+  getValueForTradeAsset,
+  estimateTradeGas,
+  getLatestOffChainMarketplaceContract
+} from './trades'
 
 jest.mock('decentraland-dapps/dist/lib/eth', () => {
   const module = jest.requireActual('decentraland-dapps/dist/lib/eth')
@@ -92,10 +99,8 @@ describe('when getting the trade signature', () => {
       } as Omit<TradeCreation, 'signature'>
     })
 
-    it('should throw an error', async () => {
-      await expect(getTradeSignature(trade)).rejects.toThrowError(
-        'Could not get a valid contract for OffChainMarketplaceV2 using chain 42161'
-      )
+    it('should throw naming the chain that has no off-chain marketplace', async () => {
+      await expect(getTradeSignature(trade)).rejects.toThrowError('No off-chain marketplace contract exists on chain 42161')
     })
   })
 
@@ -147,7 +152,7 @@ describe('when getting the trade signature', () => {
       }
 
       const SALT = ethers.utils.hexZeroPad(ethers.utils.hexlify(trade.chainId), 32)
-      offchainMarketplaceContract = getContract(ContractName.OffChainMarketplaceV2, trade.chainId)
+      offchainMarketplaceContract = getLatestOffChainMarketplaceContract(trade.chainId)
       domain = {
         name: offchainMarketplaceContract.name,
         version: offchainMarketplaceContract.version,
@@ -406,6 +411,40 @@ describe('when estimating trade gas', () => {
 
     it('should propagate the error', async () => {
       return expect(estimateTradeGas(tradeId, undefined, chainId, buyerAddress, provider)).rejects.toThrow('Gas estimation failed')
+    })
+  })
+})
+
+describe('when getting the latest off-chain marketplace contract', () => {
+  let chainId: ChainId
+
+  describe('and the chain has a V3 deployment', () => {
+    beforeEach(() => {
+      chainId = ChainId.ETHEREUM_SEPOLIA
+    })
+
+    it('should return V3, so a listing and its approval both name the newest deployment', () => {
+      expect(getLatestOffChainMarketplaceContract(chainId)).toEqual(getContract(ContractName.OffChainMarketplaceV3, chainId))
+    })
+  })
+
+  describe('and the chain has no V3 deployment', () => {
+    beforeEach(() => {
+      chainId = ChainId.ETHEREUM_MAINNET
+    })
+
+    it('should fall back to V2 rather than throw', () => {
+      expect(getLatestOffChainMarketplaceContract(chainId)).toEqual(getContract(ContractName.OffChainMarketplaceV2, chainId))
+    })
+  })
+
+  describe('and the chain has no off-chain marketplace at all', () => {
+    beforeEach(() => {
+      chainId = ChainId.ARBITRUM_MAINNET
+    })
+
+    it('should throw naming the chain', () => {
+      expect(() => getLatestOffChainMarketplaceContract(chainId)).toThrowError('No off-chain marketplace contract exists on chain 42161')
     })
   })
 })

--- a/webapp/src/utils/trades.ts
+++ b/webapp/src/utils/trades.ts
@@ -54,11 +54,43 @@ export const OFFCHAIN_MARKETPLACE_TYPES: Record<string, TypedDataField[]> = {
 const OFF_CHAIN_MARKETPLACE_CONTRACT_NAMES = [ContractName.OffChainMarketplaceV3, ContractName.OffChainMarketplaceV2]
 
 /**
+ * The same versions plus V1, for enumerating EXISTING grants rather than choosing where to sign. V1 never
+ * receives a new listing, but a wallet that traded before V2 can still hold an allowance on it.
+ */
+const OFF_CHAIN_MARKETPLACE_SETTINGS_CONTRACT_NAMES = [
+  ContractName.OffChainMarketplaceV3,
+  ContractName.OffChainMarketplaceV2,
+  ContractName.OffChainMarketplace
+]
+
+/**
  * The newest off-chain marketplace deployed on a chain.
  *
  * `getContract` THROWS for a version that is not deployed on the given chain rather than returning a
  * falsy value, which is why each candidate is tried in turn.
  */
+/**
+ * Every off-chain marketplace version deployed on a chain, newest first.
+ *
+ * Distinct from {@link getLatestOffChainMarketplaceContract}, which answers "where do NEW listings go".
+ * This answers "where might a user already have granted an allowance" — a grant made against an older
+ * version stays live on chain after a newer one ships, so the Settings page has to be able to show and
+ * revoke it. Guarded per candidate because `getContract` throws for a version a chain does not have.
+ */
+export function getDeployedOffChainMarketplaceContracts(chainId: ChainId): { contractName: ContractName; contract: ContractData }[] {
+  return OFF_CHAIN_MARKETPLACE_SETTINGS_CONTRACT_NAMES.reduce<{ contractName: ContractName; contract: ContractData }[]>(
+    (deployed, contractName) => {
+      try {
+        deployed.push({ contractName, contract: getContract(contractName, chainId) })
+      } catch (_error) {
+        // Not deployed on this chain.
+      }
+      return deployed
+    },
+    []
+  )
+}
+
 export function getLatestOffChainMarketplaceContract(chainId: ChainId): ContractData {
   for (const contractName of OFF_CHAIN_MARKETPLACE_CONTRACT_NAMES) {
     try {

--- a/webapp/src/utils/trades.ts
+++ b/webapp/src/utils/trades.ts
@@ -229,9 +229,15 @@ export async function estimateTradeGas(
   const trade = await new TradeService(API_SIGNER, MARKETPLACE_SERVER_URL, () => undefined).fetchTrade(tradeId)
   // Build the trade data
   const tradeToAccept = getOnChainTrade(trade, buyerAddress)
-  // Estimate the gas
-  const offchainContractName = tradeContractAddress ? getContractName(tradeContractAddress) : ContractName.OffChainMarketplace
-  const contract = getContract(offchainContractName, chainId)
+  // Estimate against the contract this trade actually settles on. The caller's address wins when given,
+  // but the fallback is the trade's own `contract`, never a fixed version: estimating a V2 or V3 trade
+  // against V1 measures a call that would revert, and `accept` reverting is exactly what a buyer needs the
+  // estimate to warn them about. Fail closed if neither is available rather than guess a version.
+  const settlementAddress = tradeContractAddress ?? trade.contract
+  if (!settlementAddress) {
+    throw new Error(`Trade ${tradeId} has no settlement contract to estimate against`)
+  }
+  const contract = getContract(getContractName(settlementAddress), chainId)
   const c = new ethers.Contract(contract.address, contract.abi, provider)
   return c.estimateGas.accept([tradeToAccept], { from: buyerAddress })
 }

--- a/webapp/src/utils/trades.ts
+++ b/webapp/src/utils/trades.ts
@@ -64,12 +64,6 @@ const OFF_CHAIN_MARKETPLACE_SETTINGS_CONTRACT_NAMES = [
 ]
 
 /**
- * The newest off-chain marketplace deployed on a chain.
- *
- * `getContract` THROWS for a version that is not deployed on the given chain rather than returning a
- * falsy value, which is why each candidate is tried in turn.
- */
-/**
  * Every off-chain marketplace version deployed on a chain, newest first.
  *
  * Distinct from {@link getLatestOffChainMarketplaceContract}, which answers "where do NEW listings go".
@@ -91,6 +85,12 @@ export function getDeployedOffChainMarketplaceContracts(chainId: ChainId): { con
   )
 }
 
+/**
+ * The newest off-chain marketplace deployed on a chain.
+ *
+ * `getContract` THROWS for a version that is not deployed on the given chain rather than returning a
+ * falsy value, which is why each candidate is tried in turn.
+ */
 export function getLatestOffChainMarketplaceContract(chainId: ChainId): ContractData {
   for (const contractName of OFF_CHAIN_MARKETPLACE_CONTRACT_NAMES) {
     try {
@@ -110,17 +110,6 @@ export async function getOffChainMarketplaceContract(chainId: ChainId) {
   const { address, abi } = getLatestOffChainMarketplaceContract(chainId)
   const instance = new ethers.Contract(address, abi, new ethers.providers.Web3Provider(provider))
   return instance
-}
-
-export async function getOffChainMarketplaceContractInstance(chainId: ChainId) {
-  const provider = await getNetworkProvider(chainId)
-  if (!provider) {
-    throw new Error('Could not get connected provider')
-  }
-
-  const contractData = getLatestOffChainMarketplaceContract(chainId)
-  const contract = new ethers.Contract(contractData.address, contractData.abi, new ethers.providers.Web3Provider(provider))
-  return { contractData, contract }
 }
 
 export function getValueForTradeAsset(asset: TradeAsset): string {
@@ -203,7 +192,7 @@ export function getOnChainTrade(trade: Trade, sentBeneficiaryAddress: string): O
   }
 }
 
-export async function getTradeSignature(trade: Omit<TradeCreation, 'signature' | 'contract'>) {
+export async function getTradeSignature(trade: Omit<TradeCreation, 'signature'>) {
   const marketplaceContract: ContractData = getLatestOffChainMarketplaceContract(trade.chainId)
 
   const signer = (await getSigner()) as ethers.providers.JsonRpcSigner

--- a/webapp/src/utils/trades.ts
+++ b/webapp/src/utils/trades.ts
@@ -44,12 +44,38 @@ export const OFFCHAIN_MARKETPLACE_TYPES: Record<string, TypedDataField[]> = {
   ]
 }
 
+/**
+ * Off-chain marketplace versions, newest first.
+ *
+ * The EIP-712 domain names its verifying contract, so the version a trade is signed against is part of
+ * what the signer signed, and every approval the UI asks for has to name that same contract. V3 is
+ * testnet-only for now, so mainnet has to keep using V2 rather than fail.
+ */
+const OFF_CHAIN_MARKETPLACE_CONTRACT_NAMES = [ContractName.OffChainMarketplaceV3, ContractName.OffChainMarketplaceV2]
+
+/**
+ * The newest off-chain marketplace deployed on a chain.
+ *
+ * `getContract` THROWS for a version that is not deployed on the given chain rather than returning a
+ * falsy value, which is why each candidate is tried in turn.
+ */
+export function getLatestOffChainMarketplaceContract(chainId: ChainId): ContractData {
+  for (const contractName of OFF_CHAIN_MARKETPLACE_CONTRACT_NAMES) {
+    try {
+      return getContract(contractName, chainId)
+    } catch (_error) {
+      continue
+    }
+  }
+  throw new Error(`No off-chain marketplace contract exists on chain ${chainId}`)
+}
+
 export async function getOffChainMarketplaceContract(chainId: ChainId) {
   const provider = await getNetworkProvider(chainId)
   if (!provider) {
     throw new Error('Could not get connected provider')
   }
-  const { address, abi } = getContract(ContractName.OffChainMarketplaceV2, chainId)
+  const { address, abi } = getLatestOffChainMarketplaceContract(chainId)
   const instance = new ethers.Contract(address, abi, new ethers.providers.Web3Provider(provider))
   return instance
 }
@@ -60,7 +86,7 @@ export async function getOffChainMarketplaceContractInstance(chainId: ChainId) {
     throw new Error('Could not get connected provider')
   }
 
-  const contractData = getContract(ContractName.OffChainMarketplaceV2, chainId)
+  const contractData = getLatestOffChainMarketplaceContract(chainId)
   const contract = new ethers.Contract(contractData.address, contractData.abi, new ethers.providers.Web3Provider(provider))
   return { contractData, contract }
 }
@@ -146,11 +172,7 @@ export function getOnChainTrade(trade: Trade, sentBeneficiaryAddress: string): O
 }
 
 export async function getTradeSignature(trade: Omit<TradeCreation, 'signature' | 'contract'>) {
-  const marketplaceContract: ContractData = getContract(ContractName.OffChainMarketplaceV2, trade.chainId)
-
-  if (!marketplaceContract) {
-    throw new Error(`The ${ContractName.OffChainMarketplace} contract doesn't exist on chain ${trade.chainId}`)
-  }
+  const marketplaceContract: ContractData = getLatestOffChainMarketplaceContract(trade.chainId)
 
   const signer = (await getSigner()) as ethers.providers.JsonRpcSigner
   const SALT = ethers.utils.hexZeroPad(ethers.utils.hexlify(trade.chainId), 32)


### PR DESCRIPTION
Moves the webapp onto `OffChainMarketplaceV3` where it is deployed, matching decentraland-dapps#824 and marketplace-server#395.

## Why both halves had to move together

The webapp pinned V2 in two places that must name the same contract:

- the **EIP-712 domain** a listing or bid is signed against (`utils/trades.ts`)
- the **spender** the UI asks the user to approve (`BidModal`, both `SellModal`s)

Changing only the signing would have had users approve V2 while the trade settles on V3, so the allowance sits on the wrong contract and `accept()` fails. Both move here.

Note the webapp does **not** use dapps' trades lib — it has its own copy of `getTradeSignature`, `OFFCHAIN_MARKETPLACE_TYPES` and friends. So this needs no dapps bump, only `decentraland-transactions` `^3.0.3` → `^3.1.1` for `ContractName.OffChainMarketplaceV3`.

## Resolution is a fallback, not a switch

`getContract` **throws** for a version a chain does not have, and V3 is testnet-only. `getLatestOffChainMarketplaceContract` tries V3 then V2, so testnets move while mainnet keeps V2 until V3 ships there.

The Settings page now names an approval granted to *any* version, guarded the same way — without it a V3 approval falls through to the generic lookup, which does not know these addresses.

## Deliberately left alone

`getAcceptBidAuthorizationOptions` still defaults to V2 when a bid carries no `tradeContractAddress`. That fallback only fires for legacy rows predating the column, which were signed against V1/V2; pointing it at V3 would mis-authorize them. New bids carry the address and resolve through `getContractName`, which knows V3 as of 3.1.1.

## Verification

`tsc` clean, `eslint` clean, full suite **1841 passed / 21 skipped, 160 suites**. The one failure in the full run (`RentalPeriodFilter`, a 5s timeout) passes in isolation in 19ms and touches nothing here.

The existing signature test derives its expectation from the resolved contract rather than a hardcoded string, so it now proves the signature is bound to V3 on Sepolia. Three cases added for the resolver: V3 chain, V2 fallback, no marketplace at all.
