### PR TITLE
fix: separate the homepage campaign banner from the content below it

### DIFF
--- a/webapp/src/components/HomePage/HomePage.css
+++ b/webapp/src/components/HomePage/HomePage.css
@@ -1,3 +1,7 @@
+.HomePageBanner {
+  margin-bottom: 24px;
+}
+
 .HomePageHero.dcl.hero {
   height: var(--page-header-height);
 }

--- a/webapp/src/components/HomePage/HomePage.tsx
+++ b/webapp/src/components/HomePage/HomePage.tsx
@@ -227,7 +227,11 @@ const HomePage = (props: Props) => {
           out of the way of the landing page's first paint. */}
       <HoverPreviewProvider>
         <ListsLaunchModal />
-        {isCampaignHomepageBannerEnabled ? <Banner id={MARKETPLACE_HOMEPAGE_BANNER_ID} /> : null}
+        {isCampaignHomepageBannerEnabled ? (
+          <div className="HomePageBanner">
+            <Banner id={MARKETPLACE_HOMEPAGE_BANNER_ID} />
+          </div>
+        ) : null}
         <Page className="HomePage">
           {firstViewsSection.map(renderSlideshow)}
           <RankingsTable />


### PR DESCRIPTION
The campaign banner on the Overview page sat flush against the first section below it (Trending Items), because it was rendered without any spacing wrapper. Collectibles and the campaign browse page already wrap the same banner in a container with a 24px bottom margin, this brings Overview in line with them.

The wrapper is only mounted when `isCampaignHomepageBannerEnabled` is on, so pages without the banner are unaffected.

How to test:
1. Enable the `marketplaceHomepageBanner` campaign banner and open the Overview tab.
2. There should be 24px between the bottom of the banner and the "Trending Items" heading, matching the spacing used in Collectibles.
3. Disable the banner and confirm the spacing above "Trending Items" is unchanged.