### PR TITLE
fix: browse nav entry points (LANDs, NAMEs) + remove dead locale block

### DIFF
--- a/webapp/src/components/Navigation/Navigation.tsx
+++ b/webapp/src/components/Navigation/Navigation.tsx
@@ -74,7 +74,7 @@ const Navigation = (props: Props) => {
               <Link to={locations.lands({ section: Section.LAND, assetType: AssetType.NFT, isMap: false })}>
                 <Tabs.Tab active={activeTab === NavigationTab.LANDS}>{t('navigation.land')}</Tabs.Tab>
               </Link>
-              <Link to={locations.claimName()}>
+              <Link to={locations.names({ section: Section.ENS, vendor: VendorName.DECENTRALAND, page: 1, sortBy: SortBy.NEWEST })}>
                 <Tabs.Tab active={activeTab === NavigationTab.NAMES}>{t('navigation.names')}</Tabs.Tab>
               </Link>
               <Link to={locations.defaultCurrentAccount()}>

--- a/webapp/src/components/Navigation/Navigation.tsx
+++ b/webapp/src/components/Navigation/Navigation.tsx
@@ -71,7 +71,7 @@ const Navigation = (props: Props) => {
           </Link>
           {!isIAP && (
             <>
-              <Link to={locations.lands({ section: Section.LAND, assetType: AssetType.NFT })}>
+              <Link to={locations.lands({ section: Section.LAND, assetType: AssetType.NFT, isMap: false })}>
                 <Tabs.Tab active={activeTab === NavigationTab.LANDS}>{t('navigation.land')}</Tabs.Tab>
               </Link>
               <Link to={locations.claimName()}>

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -1063,10 +1063,6 @@
     "disallowed": "You unauthorized the {contract_link} contract to operate {symbol} on your behalf",
     "disapproved": "You unauthorized the {contract_link} contract to operate {symbol} on your behalf"
   },
-  "authorization_modal": {
-    "title": "Authorize {token}",
-    "description": "In order to continue you will need to authorize the {contract} contract to operate {token} tokens on your behalf.{br}This only has to be done once, and you can always manage your authorizations from the {settings_link} page."
-  },
   "transfer_page": {
     "title": "Transfer {category}",
     "subtitle": "You are about to transfer {name}.",

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -1045,10 +1045,6 @@
     "disallowed": "Haz desautorizado al contrato de {contract_link} a operar {symbol} por tí",
     "disapproved": "Haz desautorizado al contrato de {contract_link} a operar {symbol} por tí"
   },
-  "authorization_modal": {
-    "title": "Autorizar {token}",
-    "description": "Para poder continuar deberás autorizar al contrato de {contract} a operar tus tokens de {token}.{br}Esto solo debe realizarse una única vez, y siempre puedes gestionar tus autorizaciones desde la pagina de {settings_link}."
-  },
   "transfer_page": {
     "title": "Transferir {category}",
     "subtitle": "Estás por transferir {name}.",

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -1048,10 +1048,6 @@
     "disallowed": "您未授权{contract_link}合同代表您操作{symbol}",
     "disapproved": "您未授权{contract_link}合同代表您操作{symbol}"
   },
-  "authorization_modal": {
-    "title": "授权{token}",
-    "description": "欲继续操作, 您需要授权{contract}合同代表您操作{token}令牌。{br}只需执行一次, 并且您随时可以在{settings_link}页上管理您的授权。"
-  },
   "transfer_page": {
     "title": "转让{category}",
     "subtitle": "您即将转移{name}。",


### PR DESCRIPTION
Three small independent fixes:

- **LANDs tab: always open in list view.** The nav tab inherited the persisted `is-map` localStorage flag, so users who last browsed land in fullscreen map mode reopened the tab with the filter sidebar hidden (the symptom family of dapps-issues#121). `AssetBrowse` already special-cases a persisted `false` but not `true`; passing an explicit `isMap: false` from the tab completes that intent. Map view stays one toggle away.
- **NAMEs tab: point at the browse view.** The tab landed on `/names/claim` (marketing/claim layout, no filters); the browse view with the filter sidebar was only reachable from secondary links inside the claim page (dapps-issues#120 reported exactly this gap). The tab now opens the names browse with the same param shape the Collectibles tab uses; `SortBy.NEWEST` + `Section.ENS` matches the existing `locations.names` call in `ClaimNamePage`. A follow-up issue proposes a "Claim a NAME" CTA on the browse view so minting keeps a visible entry point.
- **Remove the dead `authorization_modal` locale block** (en/es/zh). Zero call sites — the live modal copy comes from decentraland-dapps' `@dapps.authorization_modal` namespace; this block was an unreachable, divergent duplicate.

Verified against the routing serialization (`isMap !== undefined` -> URL param; `isMap ?? persisted` short-circuit) and existing param precedents; relying on CI for build/tests.
