### PR TITLE
feat: deliver segment events through the first party proxy behind a kill switch

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -27,7 +27,7 @@
         "dcl-catalyst-commons": "^9.0.1",
         "decentraland-connect": "^12.0.0",
         "decentraland-crypto-fetch": "^2.0.1",
-        "decentraland-dapps": "^29.7.0",
+        "decentraland-dapps": "^29.8.0",
         "decentraland-transactions": "^3.0.3",
         "decentraland-ui": "^7.1.0",
         "decentraland-ui2": "^3.22.0",
@@ -15123,9 +15123,9 @@
       }
     },
     "node_modules/decentraland-dapps": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-29.7.0.tgz",
-      "integrity": "sha512-pXcr2Wx5aali68tzE1WKCtFIAN1eeh1oaFJUriixZXm3OmXBCcNqkXH+GOE5lwwESSuRho6ddyHrhDulqgf0dg==",
+      "version": "29.8.0",
+      "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-29.8.0.tgz",
+      "integrity": "sha512-bQWS2d4K76skULJpQE/Wc1LDmeJUEqB9pKmx9yTr+HkfcJrTpDSO81R732yM4hali/2+dajUSqeG7oN7FlL5Pg==",
       "dependencies": {
         "@0xsequence/multicall": "0.25.1",
         "@0xsequence/relayer": "0.25.1",
@@ -15135,7 +15135,7 @@
         "date-fns": "1.30.1",
         "dcl-catalyst-client": "^22.0.0",
         "decentraland-crypto-fetch": "^3.0.0",
-        "decentraland-transactions": "^3.0.2",
+        "decentraland-transactions": "^3.1.1",
         "events": "3.3.0",
         "eventsource": "3.0.7",
         "flat": "5.0.2",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,7 +22,7 @@
     "dcl-catalyst-commons": "^9.0.1",
     "decentraland-connect": "^12.0.0",
     "decentraland-crypto-fetch": "^2.0.1",
-    "decentraland-dapps": "^29.7.0",
+    "decentraland-dapps": "^29.8.0",
     "decentraland-transactions": "^3.0.3",
     "decentraland-ui": "^7.1.0",
     "decentraland-ui2": "^3.22.0",

--- a/webapp/src/config/env/dev.json
+++ b/webapp/src/config/env/dev.json
@@ -32,6 +32,7 @@
   "INTERCOM_APP_ID": "z0h94kay",
   "SEGMENT_API_KEY": "gMnkewUBzA6J879kAtMvp2WhohEk36uy",
   "SEGMENT_ANALYTICS_URL": "https://evs.e.decentraland.org/z8jpJNrQbg/rqp8VgURTs.min.js",
+  "SEGMENT_API_HOST": "api.e.decentraland.org/v1",
   "DISCORD_URL": "https://dcl.gg/discord",
   "ENVIRONMENT": "development",
   "MIN_SALE_VALUE_IN_WEI": "1000000000000000000",

--- a/webapp/src/config/env/prod.json
+++ b/webapp/src/config/env/prod.json
@@ -32,6 +32,7 @@
   "INTERCOM_APP_ID": "z0h94kay",
   "SEGMENT_API_KEY": "WijgHCmOGJjV04XBGghZGEadMD4454R3",
   "SEGMENT_ANALYTICS_URL": "https://evs.e.decentraland.org/z8jpJNrQbg/YUxRAEHA4U.min.js",
+  "SEGMENT_API_HOST": "api.e.decentraland.org/v1",
   "DISCORD_URL": "https://dcl.gg/discord",
   "ENVIRONMENT": "production",
   "MIN_SALE_VALUE_IN_WEI": "1000000000000000000",

--- a/webapp/src/config/env/stg.json
+++ b/webapp/src/config/env/stg.json
@@ -32,6 +32,7 @@
   "INTERCOM_APP_ID": "z0h94kay",
   "SEGMENT_API_KEY": "WijgHCmOGJjV04XBGghZGEadMD4454R3",
   "SEGMENT_ANALYTICS_URL": "https://evs.e.decentraland.org/z8jpJNrQbg/YUxRAEHA4U.min.js",
+  "SEGMENT_API_HOST": "api.e.decentraland.org/v1",
   "DISCORD_URL": "https://dcl.gg/discord",
   "ENVIRONMENT": "staging",
   "MIN_SALE_VALUE_IN_WEI": "1000000000000000000",

--- a/webapp/src/modules/analytics/proxy.spec.ts
+++ b/webapp/src/modules/analytics/proxy.spec.ts
@@ -1,0 +1,88 @@
+import { getAnalyticsProxyOptions, persistSegmentKillSwitch, SEGMENT_KILL_SWITCH_KEY } from './proxy'
+
+const ANALYTICS_URL = 'https://evs.example.org/abc/def.min.js'
+const API_HOST = 'api.e.example.org/v1'
+
+describe('when reading the analytics proxy options', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  describe('and the kill switch was never persisted', () => {
+    it('should return the configured proxy, an unknown flag must not turn tracking off', () => {
+      expect(getAnalyticsProxyOptions(ANALYTICS_URL, API_HOST)).toEqual({ analyticsUrl: ANALYTICS_URL, apiHost: API_HOST })
+    })
+  })
+
+  describe('and the kill switch was persisted as off', () => {
+    beforeEach(() => {
+      persistSegmentKillSwitch(false)
+    })
+
+    it('should return the configured proxy', () => {
+      expect(getAnalyticsProxyOptions(ANALYTICS_URL, API_HOST)).toEqual({ analyticsUrl: ANALYTICS_URL, apiHost: API_HOST })
+    })
+  })
+
+  describe('and the kill switch was persisted as on', () => {
+    beforeEach(() => {
+      persistSegmentKillSwitch(true)
+    })
+
+    it('should return nothing, so analytics goes straight to Segment', () => {
+      expect(getAnalyticsProxyOptions(ANALYTICS_URL, API_HOST)).toBeUndefined()
+    })
+
+    describe('and it is persisted as off again', () => {
+      beforeEach(() => {
+        persistSegmentKillSwitch(false)
+      })
+
+      it('should return the configured proxy on the next read', () => {
+        expect(getAnalyticsProxyOptions(ANALYTICS_URL, API_HOST)).toEqual({ analyticsUrl: ANALYTICS_URL, apiHost: API_HOST })
+      })
+    })
+  })
+
+  describe('and nothing is configured', () => {
+    it('should return nothing rather than empty options', () => {
+      expect(getAnalyticsProxyOptions('', '')).toBeUndefined()
+    })
+  })
+
+  describe('and only one of the two is configured', () => {
+    it('should return just that one, the halves are independent', () => {
+      expect(getAnalyticsProxyOptions(ANALYTICS_URL, '')).toEqual({ analyticsUrl: ANALYTICS_URL })
+    })
+  })
+})
+
+describe('when persisting the kill switch', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('should store a value the next boot can read synchronously', () => {
+    persistSegmentKillSwitch(true)
+
+    expect(localStorage.getItem(SEGMENT_KILL_SWITCH_KEY)).toBe('1')
+  })
+
+  describe('and storage throws, as it does in private mode', () => {
+    let setItem: jest.SpyInstance
+
+    beforeEach(() => {
+      setItem = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('QuotaExceededError')
+      })
+    })
+
+    afterEach(() => {
+      setItem.mockRestore()
+    })
+
+    it('should not throw, tracking configuration is not worth breaking the app over', () => {
+      expect(() => persistSegmentKillSwitch(true)).not.toThrow()
+    })
+  })
+})

--- a/webapp/src/modules/analytics/proxy.ts
+++ b/webapp/src/modules/analytics/proxy.ts
@@ -1,0 +1,47 @@
+import { AnalyticsSnippetOptions } from 'decentraland-dapps/dist/modules/analytics/snippet'
+
+/**
+ * Last known value of the `dapps-seg-alt` flag, kept here because the analytics middleware is created
+ * while the store is built and the flag only arrives later, through the features saga. So the boot
+ * decides with what the previous session learned, and flipping the flag takes effect on the next load.
+ */
+export const SEGMENT_KILL_SWITCH_KEY = 'dcl-analytics-seg-alt'
+
+/**
+ * Options that send analytics.js and its events through our first party proxy, unless the kill switch
+ * says otherwise. Ad blockers drop Segment's own hosts, which is why the proxy exists.
+ *
+ * Undefined means "no options", which is what leaves the SDK on Segment's CDN and ingestion. A value
+ * that was never persisted counts as off: a flag service that is down or unreachable must not be able
+ * to change where analytics goes.
+ */
+export function getAnalyticsProxyOptions(analyticsUrl: string, apiHost: string): AnalyticsSnippetOptions | undefined {
+  if (isSegmentKillSwitchOn()) {
+    return undefined
+  }
+
+  const options = {
+    ...(analyticsUrl ? { analyticsUrl } : undefined),
+    ...(apiHost ? { apiHost } : undefined)
+  }
+
+  return Object.keys(options).length > 0 ? options : undefined
+}
+
+/** Records the flag so the next boot can read it synchronously, before anything can fetch it. */
+export function persistSegmentKillSwitch(isEnabled: boolean): void {
+  try {
+    localStorage.setItem(SEGMENT_KILL_SWITCH_KEY, isEnabled ? '1' : '0')
+  } catch (error) {
+    // Storage can be unavailable (private mode, quota). The proxy stays as configured, which is the
+    // safe end: events keep flowing, they just keep taking the route this build was deployed with.
+  }
+}
+
+function isSegmentKillSwitchOn(): boolean {
+  try {
+    return localStorage.getItem(SEGMENT_KILL_SWITCH_KEY) === '1'
+  } catch (error) {
+    return false
+  }
+}

--- a/webapp/src/modules/analytics/sagas.spec.ts
+++ b/webapp/src/modules/analytics/sagas.spec.ts
@@ -1,8 +1,13 @@
+import { select } from 'redux-saga/effects'
 import { expectSaga } from 'redux-saga-test-plan'
 import * as matchers from 'redux-saga-test-plan/matchers'
+import { fetchApplicationFeaturesSuccess } from 'decentraland-dapps/dist/modules/features/actions'
+import { ApplicationFeatures, ApplicationName } from 'decentraland-dapps/dist/modules/features/types'
+import { getIsSegmentKillSwitchEnabled } from '../features/selectors'
 import { waitForFeatureFlagsToBeLoaded } from '../features/utils'
 import { AnalyticsService } from '../vendor/decentraland'
 import { fetchAnalyticsVolumeDataRequest, fetchAnalyticsVolumeDataSuccess, fetchAnalyticsVolumeDataFailure } from './actions'
+import { SEGMENT_KILL_SWITCH_KEY } from './proxy'
 import { analyticsSagas } from './sagas'
 import { AnalyticsTimeframe, AnalyticsVolumeData } from './types'
 
@@ -54,6 +59,36 @@ describe('when handling a fetch volume data request', () => {
         .put(fetchAnalyticsVolumeDataFailure('some error'))
         .dispatch(fetchAnalyticsVolumeDataRequest(timeframe))
         .silentRun()
+    })
+  })
+})
+
+describe('when the application features are fetched', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  describe('and the analytics kill switch is on', () => {
+    it('should record it so the next boot sends analytics straight to Segment', () => {
+      return expectSaga(analyticsSagas)
+        .provide([[select(getIsSegmentKillSwitchEnabled), true]])
+        .dispatch(fetchApplicationFeaturesSuccess([ApplicationName.DAPPS], {} as Record<ApplicationName, ApplicationFeatures>))
+        .silentRun()
+        .then(() => {
+          expect(localStorage.getItem(SEGMENT_KILL_SWITCH_KEY)).toBe('1')
+        })
+    })
+  })
+
+  describe('and the analytics kill switch is off', () => {
+    it('should record it so the next boot keeps using the proxy', () => {
+      return expectSaga(analyticsSagas)
+        .provide([[select(getIsSegmentKillSwitchEnabled), false]])
+        .dispatch(fetchApplicationFeaturesSuccess([ApplicationName.DAPPS], {} as Record<ApplicationName, ApplicationFeatures>))
+        .silentRun()
+        .then(() => {
+          expect(localStorage.getItem(SEGMENT_KILL_SWITCH_KEY)).toBe('0')
+        })
     })
   })
 })

--- a/webapp/src/modules/analytics/sagas.ts
+++ b/webapp/src/modules/analytics/sagas.ts
@@ -1,7 +1,9 @@
-import { call, takeEvery, put } from '@redux-saga/core/effects'
+import { call, takeEvery, put, select } from '@redux-saga/core/effects'
+import { FETCH_APPLICATION_FEATURES_SUCCESS } from 'decentraland-dapps/dist/modules/features/actions'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { config } from '../../config'
 import { isErrorWithMessage } from '../../lib/error'
+import { getIsSegmentKillSwitchEnabled } from '../features/selectors'
 import { waitForFeatureFlagsToBeLoaded } from '../features/utils'
 import { AnalyticsService } from '../vendor/decentraland'
 import { RankingsAPI } from '../vendor/decentraland/rankings/api'
@@ -15,6 +17,7 @@ import {
   fetchRankingsSuccess,
   fetchRankingsFailure
 } from './actions'
+import { persistSegmentKillSwitch } from './proxy'
 import { AnalyticsVolumeData, RankingEntity } from './types'
 
 const MARKETPLACE_SERVER_URL = config.get('MARKETPLACE_SERVER_URL')
@@ -22,6 +25,18 @@ const MARKETPLACE_SERVER_URL = config.get('MARKETPLACE_SERVER_URL')
 export function* analyticsSagas() {
   yield takeEvery(FETCH_ANALYTICS_VOLUME_DATA_REQUEST, handleFetchVolumeDataRequest)
   yield takeEvery(FETCH_RANKINGS_REQUEST, handleFetchRankingsRequest)
+  yield takeEvery(FETCH_APPLICATION_FEATURES_SUCCESS, handleFetchApplicationFeaturesSuccess)
+}
+
+/**
+ * The analytics middleware is created before any flag is fetched, so the value is recorded here for the
+ * next boot to read. Runs on every successful fetch, including the polling ones, so flipping the flag
+ * reaches a long lived tab's next reload rather than waiting for a new session.
+ */
+export function* handleFetchApplicationFeaturesSuccess() {
+  const isKillSwitchEnabled: boolean = yield select(getIsSegmentKillSwitchEnabled)
+
+  persistSegmentKillSwitch(isKillSwitchEnabled)
 }
 
 export function* handleFetchVolumeDataRequest(action: FetchAnalyticsDayDataRequestAction) {

--- a/webapp/src/modules/features/selectors.ts
+++ b/webapp/src/modules/features/selectors.ts
@@ -16,6 +16,19 @@ export const isLoadingFeatureFlags = (state: RootState) => {
   return getLoading(state)
 }
 
+/**
+ * Kill switch for the analytics first party proxy, shared with the other dapps through the `dapps`
+ * application. ON means analytics goes straight to Segment's own hosts.
+ */
+export const getIsSegmentKillSwitchEnabled = (state: RootState): boolean => {
+  try {
+    return getIsFeatureEnabled(state, ApplicationName.DAPPS, FeatureName.SEGMENT_ALTERNATIVE)
+  } catch (e) {
+    // Flags not fetched yet: the boot decision already used the persisted value, nothing to correct
+    return false
+  }
+}
+
 export const getIsMaintenanceEnabled = (state: RootState) => {
   // As this is called by the routes component which is rendered when the user enters the application,
   // Features might have not yet been requested and will throw in that case.

--- a/webapp/src/modules/features/types.ts
+++ b/webapp/src/modules/features/types.ts
@@ -17,5 +17,7 @@ export enum FeatureName {
   USER_WALLETS = 'alfa-marketplace-credits',
   UNITY_WEARABLE_PREVIEW = 'unity-wearable-preview',
   SOCIAL_EMOTES = 'social-emotes',
-  NAMES_WITH_CREDITS = 'names-with-credits'
+  NAMES_WITH_CREDITS = 'names-with-credits',
+  /** Kill switch for the analytics first party proxy. ON sends analytics straight to Segment. */
+  SEGMENT_ALTERNATIVE = 'seg-alt'
 }

--- a/webapp/src/modules/store.ts
+++ b/webapp/src/modules/store.ts
@@ -13,6 +13,7 @@ import { fetchTranslationsRequest } from 'decentraland-dapps/dist/modules/transl
 import { getPreferredLocale } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Locale } from 'decentraland-ui'
 import { config } from '../config'
+import { getAnalyticsProxyOptions } from './analytics/proxy'
 import { ARCHIVE_BID, UNARCHIVE_BID } from './bid/actions'
 import { getCurrentIdentity } from './identity/selectors'
 import { createRootReducer, RootState } from './reducer'
@@ -132,10 +133,12 @@ export function initStore(history: History) {
     actions: [CLEAR_TRANSACTIONS, ARCHIVE_BID, UNARCHIVE_BID, SET_IS_TRYING_ON], // array of actions types that will trigger a SAVE (optional)
     migrations: {} // migration object that will migrate your localstorage (optional)
   }) as { storageMiddleware: Middleware; loadStorageMiddleware: Middleware }
-  // analytics.js is served from a first party proxy where configured, ad blockers drop the requests to Segment's CDN
-  const analyticsMiddleware = createAnalyticsMiddleware(config.get('SEGMENT_API_KEY'), {
-    analyticsUrl: config.get('SEGMENT_ANALYTICS_URL', '') || undefined
-  })
+  // analytics.js and the events it sends go through a first party proxy where configured, ad blockers drop
+  // Segment's own hosts. The `dapps-seg-alt` flag is the kill switch back to them, see modules/analytics/proxy
+  const analyticsMiddleware = createAnalyticsMiddleware(
+    config.get('SEGMENT_API_KEY'),
+    getAnalyticsProxyOptions(config.get('SEGMENT_ANALYTICS_URL', ''), config.get('SEGMENT_API_HOST', ''))
+  )
 
   const middleware = applyMiddleware(sagasMiddleware, loggerMiddleware, transactionMiddleware, storageMiddleware, analyticsMiddleware)
   const enhancer = composeEnhancers(middleware)


### PR DESCRIPTION
Marketplace loads analytics.js from our first party proxy already, but its events still POST to `api.segment.io`, which the same ad-blocker filter lists that block `cdn.segment.com` also block. For a blocked user nothing was actually recovered: the script loads and every event still dies on the way out. This closes that half, and puts the whole thing behind a kill switch.

`SEGMENT_API_HOST` (`api.e.decentraland.org/v1`) is now passed to the analytics middleware alongside the bundle url, using the `apiHost` option added in `decentraland-dapps` 29.8.0. Sites has been sending events through that host in production since Aug 19, and the client IP still reaches Segment, so `context_ip` and anything derived from it are unaffected.

The `dapps-seg-alt` flag is the kill switch: turning it ON sends analytics straight to Segment's own CDN and ingestion. OFF, which is its current state, means the configured proxy, so merging and deploying this changes nothing until someone flips it.

The flag cannot be read at boot: the analytics middleware is created while the store is built and flags arrive later through the features saga. So the last known value is persisted to `localStorage` on every successful features fetch, including the 60s polling ones, and the boot decides with that. Consequences worth knowing: flipping the flag takes effect on the next page load rather than mid-session, and a value that was never persisted counts as off, so a flag service that is down or blocked cannot turn tracking off by accident.

How to test: with no `dcl-analytics-seg-alt` key in `localStorage`, the network tab shows `analytics.js` coming from `evs.e.decentraland.org` and events posting to `api.e.decentraland.org/v1/t`, with nothing going to `cdn.segment.com` or `api.segment.io`. Set that key to `'1'` and reload: both go back to Segment's own hosts. Set it to `'0'` and reload: proxy again.

Same contract is going into builder, shop and sites, so one flag covers every dapp. The helper is isolated in `modules/analytics/proxy.ts` so it can move to `decentraland-dapps` if a fifth app needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDE5NS3oeKPcJWXbTTqSBx
