### PR TITLE
fix: point the DAO proposal link on the claim name page to decentraland.org

### DIFF
--- a/webapp/src/components/NamesPage/ClaimNamePage/ClaimNamePage.tsx
+++ b/webapp/src/components/NamesPage/ClaimNamePage/ClaimNamePage.tsx
@@ -348,7 +348,7 @@ const ClaimNamePage = (props: Props) => {
                         content={t('names_page.dao_tooltip', {
                           link: (
                             <a
-                              href="https://decentraland.zone/governance/proposal/?id=a3bdc100-9b34-11ed-ae61-5f6dd0bf8358"
+                              href="https://decentraland.org/governance/proposal/?id=a3bdc100-9b34-11ed-ae61-5f6dd0bf8358"
                               target="_blank"
                               rel="noopener noreferrer"
                             >


### PR DESCRIPTION
The "Learn more" link in the NAME cost tooltip on the claim name page pointed to \`decentraland.zone\`, so in prod it opened the dev governance site. It now points to \`decentraland.org\`, matching every other hardcoded link in the webapp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)