### PR TITLE
fix: run the campaign banner edge to edge without upscaling the art

### DIFF
--- a/webapp/src/components/BrowsePage/BrowsePage.module.css
+++ b/webapp/src/components/BrowsePage/BrowsePage.module.css
@@ -1,3 +1,0 @@
-.banner {
-  margin-bottom: 24px;
-}

--- a/webapp/src/components/BrowsePage/BrowsePage.tsx
+++ b/webapp/src/components/BrowsePage/BrowsePage.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
-import { Banner } from 'decentraland-dapps/dist/containers/Banner'
 import { View } from '../../modules/ui/types'
 import { Section } from '../../modules/vendor/decentraland'
 import { VendorName } from '../../modules/vendor/types'
 import { isVendor } from '../../modules/vendor/utils'
 import { AssetBrowse } from '../AssetBrowse'
+import CampaignBanner from '../CampaignBanner'
 import { NavigationTab } from '../Navigation/Navigation.types'
 import { PageLayout } from '../PageLayout'
 import { Props } from './BrowsePage.types'
-import styles from './BrowsePage.module.css'
 
 const MARKETPLACE_COLLECTIBLES_BANNER_ID = 'marketplaceCollectiblesBanner'
 
@@ -20,11 +19,7 @@ const BrowsePage = (props: Props) => {
 
   return (
     <PageLayout activeTab={activeTab}>
-      {isCampaignCollectiblesBannerEnabled ? (
-        <div className={styles.banner}>
-          <Banner id={MARKETPLACE_COLLECTIBLES_BANNER_ID} />
-        </div>
-      ) : null}
+      {isCampaignCollectiblesBannerEnabled ? <CampaignBanner id={MARKETPLACE_COLLECTIBLES_BANNER_ID} /> : null}
       <AssetBrowse
         vendor={vendor}
         isFullscreen={Boolean(isFullscreen)}

--- a/webapp/src/components/CampaignBanner/CampaignBanner.module.css
+++ b/webapp/src/components/CampaignBanner/CampaignBanner.module.css
@@ -1,0 +1,90 @@
+/* The banner itself is Contentful artwork rendered by decentraland-ui2's <Banner>, so its box can only be
+   sized from the outside. Its emotion class names are hashed, so its parts are reached structurally:
+     .banner > div                    ui2's BannerContainer: a grid that paints the artwork as its background
+     .banner > div > div:not(:last-child)  its BackgroundSizer: an empty box carrying the artwork's own
+                                      aspect ratio, which is what gives the banner its height
+     .banner > div > :last-child      its Layout: the title, text and CTA, already padded by 2rem
+
+   The banner runs edge to edge, but the desktop artwork is only 1280px wide (the Shop campaign ships
+   `Web_1280x300.png`), and ui2 stretches it across the whole container: on a 2560px window that came out
+   2512x589, twice its native size, soft avatars and a banner taller than half the viewport. So the artwork
+   is NOT stretched to the full width any more. It is drawn near its native size, pinned to the right where
+   its subject is, and the space left of it is filled with a blurred copy of the same image - the sides read
+   as a continuation of the art instead of as a gap, and no colour has to be hardcoded here, because both
+   layers pick the URL up from the container with `background-image: inherit`. */
+
+.banner {
+  /* The rows underneath are 70px apart (Slideshow.css), so the old 24px left the artwork almost touching
+     the first section title. */
+  margin-bottom: 40px;
+}
+
+@media (min-width: 768px) {
+  .banner {
+    /* Out to the window edges: PageLayout's content gutter is the only thing between us and them. */
+    margin-inline: -24px;
+  }
+}
+
+.banner > div {
+  /* Containing block for the blurred layer below. The container already clips (`overflow: hidden`), which
+     is what keeps both the blur's soft edges and the mask inside the banner. */
+  position: relative;
+}
+
+/* The filler: the same artwork blurred out to fill the strip, so what shows beside the sharp copy is the
+   artwork's own colour and light rather than a flat panel. Two deliberate choices here:
+
+   - `600% 100%` rather than `cover`, which maps the WHOLE frame across the strip: on a very wide window
+     that put the blurred avatars just left of the sharp ones, reading as a ghost of the artwork. Six times
+     the width samples only the empty left sixth of the frame and stretches it across, so the filler
+     carries the art's light with none of its subject. The horizontal distortion that costs is free - the
+     layer is blurred past recognition anyway. The vertical scale stays 100%, so nothing is cropped.
+   - Not darkened: a brightness tweak makes the boundary with the sharp layer visible as a step. */
+.banner > div::before {
+  content: '';
+  position: absolute;
+  /* Overscanned, otherwise the blur fades into transparency at the edges of the strip. */
+  inset: -6%;
+  z-index: 0;
+  background-image: inherit;
+  background-size: 600% 100%;
+  background-position: left center;
+  filter: blur(32px);
+  pointer-events: none;
+}
+
+/* The sharp layer. The sizer's box is already exactly the artwork's aspect ratio, so `cover` fits the
+   image into it without cropping, and capping its width caps the banner's height with it: 1360px keeps
+   the upscale at 1.06x (and is the same cap `.ui.container` uses in index.css). Pinned right because the
+   avatars and the coins live on that side of the frame; its left edge is faded out so it melts into the
+   blurred layer instead of ending on a seam. */
+.banner > div > div:not(:last-child) {
+  position: relative;
+  z-index: 1;
+  max-width: 1360px;
+  margin-left: auto;
+  margin-right: 0;
+  background-image: inherit;
+  background-size: cover;
+  background-position: center;
+  -webkit-mask-image: linear-gradient(to right, transparent, #000 140px);
+  mask-image: linear-gradient(to right, transparent, #000 140px);
+}
+
+@media (min-width: 768px) {
+  .banner > div > :last-child {
+    /* Above both artwork layers. */
+    position: relative;
+    z-index: 2;
+    /* Back onto the page's content column: 48px is where the section titles start (PageLayout's 24px plus
+       `.dcl.page`'s own 24px), and past 1456px it follows the centred column the homepage rows sit in. */
+    padding-inline: max(48px, calc((100% - 1360px) / 2));
+  }
+
+  /* ui2 gives side aligned copy half of the banner, and now that the banner is as wide as the window that
+     runs the paragraph across the artwork's subject. 620px is what the two lines need at this font size. */
+  .banner > div > :last-child > :first-child {
+    max-width: min(45%, 620px);
+  }
+}

--- a/webapp/src/components/CampaignBanner/CampaignBanner.tsx
+++ b/webapp/src/components/CampaignBanner/CampaignBanner.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Banner } from 'decentraland-dapps/dist/containers/Banner'
+import { Props } from './CampaignBanner.types'
+import styles from './CampaignBanner.module.css'
+
+// Layout wrapper for the Contentful driven campaign banner. Every page that shows one goes through here
+// so the artwork gets the same size, gutter and spacing on all of them.
+const CampaignBanner = ({ id }: Props) => (
+  <div className={styles.banner}>
+    <Banner id={id} />
+  </div>
+)
+
+export default React.memo(CampaignBanner)

--- a/webapp/src/components/CampaignBanner/CampaignBanner.types.ts
+++ b/webapp/src/components/CampaignBanner/CampaignBanner.types.ts
@@ -1,0 +1,4 @@
+export type Props = {
+  /** The admin entry field that holds the banner for this page, e.g. `marketplaceHomepageBanner`. */
+  id: string
+}

--- a/webapp/src/components/CampaignBanner/index.ts
+++ b/webapp/src/components/CampaignBanner/index.ts
@@ -1,0 +1,2 @@
+import CampaignBanner from './CampaignBanner'
+export default CampaignBanner

--- a/webapp/src/components/HomePage/HomePage.css
+++ b/webapp/src/components/HomePage/HomePage.css
@@ -1,7 +1,3 @@
-.HomePageBanner {
-  margin-bottom: 24px;
-}
-
 .HomePageHero.dcl.hero {
   height: var(--page-header-height);
 }

--- a/webapp/src/components/HomePage/HomePage.tsx
+++ b/webapp/src/components/HomePage/HomePage.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo, useRef } from 'react'
 import { useHistory } from 'react-router-dom'
-import { Banner } from 'decentraland-dapps/dist/containers/Banner'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics/utils'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { BackToTopButton, Page } from 'decentraland-ui'
@@ -12,6 +11,7 @@ import { View } from '../../modules/ui/types'
 import { Section } from '../../modules/vendor/decentraland/routing/types'
 import { VendorName } from '../../modules/vendor/types'
 import { AssetStatusFilter } from '../../utils/filters'
+import CampaignBanner from '../CampaignBanner'
 import { HoverPreviewProvider } from '../HoverPreview'
 import { ListsLaunchModal } from '../Modals/ListsLaunchModal'
 import { NavigationTab } from '../Navigation/Navigation.types'
@@ -227,11 +227,7 @@ const HomePage = (props: Props) => {
           out of the way of the landing page's first paint. */}
       <HoverPreviewProvider>
         <ListsLaunchModal />
-        {isCampaignHomepageBannerEnabled ? (
-          <div className="HomePageBanner">
-            <Banner id={MARKETPLACE_HOMEPAGE_BANNER_ID} />
-          </div>
-        ) : null}
+        {isCampaignHomepageBannerEnabled ? <CampaignBanner id={MARKETPLACE_HOMEPAGE_BANNER_ID} /> : null}
         <Page className="HomePage">
           {firstViewsSection.map(renderSlideshow)}
           <RankingsTable />


### PR DESCRIPTION
The campaign banner (ui2's Contentful driven `<Banner>`, on the homepage and on collectibles) had three
problems, all of them the same box problem: PageLayout indents it by 24px while the pages indent their own
content by 48px, so the banner hung 24px outside everything below it; and ui2 stretches the artwork across
the full width of that box with a `cover` background sized by the asset's aspect ratio, so the banner grew
with the window and upscaled past the image's native size. The desktop art the Shop campaign ships is
1280x300, which on a 2560px window came out **2512x589** - twice its size, soft avatars, and a banner
taller than half the viewport. On a 4945px window it was 3.8x.

The banner now runs edge to edge, but the artwork is no longer stretched to get there.

## Changes

- New `CampaignBanner` component wrapping dapps' `<Banner>`, used by both the homepage and the collectibles
  page, so the layout lives in one place instead of two copies of `margin-bottom: 24px`.
- The strip breaks out of the content gutter with `margin-inline: -24px` (not `100vw`, which would add a
  scrollbar notch on machines that show a classic scrollbar).
- The artwork is drawn on ui2's `BackgroundSizer` - the box that already carries the asset's own aspect
  ratio - capped at 1360px (`.ui.container`'s cap in `index.css`) and pinned right, where the subject of
  the frame is. That keeps the upscale at 1.06x and caps the banner's height at 319px without writing any
  of the asset's dimensions into the CSS.
- The space beside it is filled with a blurred copy of the same image. Both layers pick the URL up with
  `background-image: inherit`, so nothing about the current campaign is hardcoded here. The filler samples
  only the empty left sixth of the frame (`600% 100%`) rather than `cover`: mapping the whole frame across
  the strip put the blurred avatars just left of the sharp ones, which read as a ghost of the artwork.
- The sharp layer's left edge is faded with a `mask-image` gradient so it melts into the blurred layer
  instead of ending on a seam.
- The copy sits above both layers and goes back onto the page's content column
  (`padding-inline: max(48px, calc((100% - 1360px) / 2))`), and is capped at `min(45%, 620px)` so the
  paragraph stops running over the avatars.
- Bottom margin 24px -> 40px: the rows below are 70px apart, and 24px left the artwork almost touching the
  first section title.

Mobile is untouched: the page drops its gutter there and the mobile asset is a square meant to fill the
screen width, so the banner stays edge to edge with the artwork filling it.

Worth knowing for whoever picks this up next: the sharpness ceiling is the asset. Even at 1360px, a retina
screen still renders it at roughly twice its pixels - a 2560x600 export would let us grow the artwork and
shrink the filler. And the CSS reaches into ui2's `<Banner>` markup structurally (the emotion class names
are hashed); if that markup changes, the banner degrades to its current look rather than breaking.

## Test plan

- [x] Homepage and collectibles at 390 / 1440 / 2330 / 4945 px: banner spans the window, no horizontal
      overflow, copy aligned with the section titles below it
- [x] Artwork rendered at 1360px (1.06x) instead of 2512px (1.96x) at 2560, height 319px instead of 589px
- [x] No visible seam between the sharp artwork and the blurred filler, and no recognisable ghost of the
      artwork beside it at very wide viewports
- [x] `npm run build`, `npx eslint`, `npx jest` (160/160 suites, 1839 tests)