### PR TITLE
feat: show the selling approvals a wallet holds so they can be revoked

### DIFF
--- a/webapp/src/components/SettingsPage/SettingsPage.container.ts
+++ b/webapp/src/components/SettingsPage/SettingsPage.container.ts
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux'
-import { FETCH_AUTHORIZATIONS_REQUEST } from 'decentraland-dapps/dist/modules/authorization/actions'
+import { FETCH_AUTHORIZATIONS_REQUEST, fetchAuthorizationsRequest } from 'decentraland-dapps/dist/modules/authorization/actions'
 import { getData as getAuthorizations, getLoading, getError } from 'decentraland-dapps/dist/modules/authorization/selectors'
 import { isLoadingType } from 'decentraland-dapps/dist/modules/loading/selectors'
 import { isConnecting } from 'decentraland-dapps/dist/modules/wallet/selectors'
@@ -33,7 +33,8 @@ const mapState = (state: RootState): MapStateProps => {
 }
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
-  onFetchContracts: () => dispatch(fetchContractsRequest())
+  onFetchContracts: () => dispatch(fetchContractsRequest()),
+  onFetchAuthorizations: authorizations => dispatch(fetchAuthorizationsRequest(authorizations))
 })
 
 export default connect(mapState, mapDispatch)(SettingsPage)

--- a/webapp/src/components/SettingsPage/SettingsPage.spec.tsx
+++ b/webapp/src/components/SettingsPage/SettingsPage.spec.tsx
@@ -1,0 +1,83 @@
+import { waitFor } from '@testing-library/react'
+import { ChainId, NFTCategory, Network } from '@dcl/schemas'
+import { AuthorizationType } from 'decentraland-dapps/dist/modules/authorization/types'
+import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
+import { nftMarketplaceAPI } from '../../modules/vendor/decentraland/nft/api'
+import { renderWithProviders } from '../../utils/test'
+import SettingsPage from './SettingsPage'
+import { Props } from './SettingsPage.types'
+
+jest.mock('../../modules/vendor/decentraland/nft/api', () => ({
+  nftMarketplaceAPI: { fetch: jest.fn() }
+}))
+
+const aWallet = { address: '0xowner' } as Wallet
+
+function heldNft(contractAddress: string) {
+  return {
+    nft: {
+      contractAddress,
+      chainId: ChainId.MATIC_MAINNET,
+      network: Network.MATIC,
+      category: NFTCategory.WEARABLE
+    }
+  }
+}
+
+function renderSettingsPage(props: Partial<Props> = {}) {
+  return renderWithProviders(
+    <SettingsPage
+      wallet={aWallet}
+      authorizations={[]}
+      isLoading={false}
+      hasError={false}
+      isConnecting={false}
+      hasFetchedContracts
+      getContract={jest.fn()}
+      onFetchContracts={jest.fn()}
+      onFetchAuthorizations={jest.fn()}
+      {...props}
+    />
+  )
+}
+
+describe('when rendering the settings page', () => {
+  let onFetchAuthorizations: jest.Mock
+
+  beforeEach(() => {
+    onFetchAuthorizations = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('and the wallet holds collectibles', () => {
+    beforeEach(() => {
+      // Two tokens of the SAME collection: the page asks about collections, not about tokens.
+      ;(nftMarketplaceAPI.fetch as jest.Mock).mockResolvedValue({
+        data: [heldNft('0xcollection'), heldNft('0xcollection')],
+        total: 2
+      })
+    })
+
+    it('should ask about the selling approval of each distinct collection', async () => {
+      renderSettingsPage({ onFetchAuthorizations })
+
+      await waitFor(() => expect(onFetchAuthorizations).toHaveBeenCalled())
+
+      const asked = onFetchAuthorizations.mock.calls[0][0] as { contractAddress: string; type: AuthorizationType }[]
+      expect(asked.every(authorization => authorization.type === AuthorizationType.APPROVAL)).toBe(true)
+      expect(new Set(asked.map(authorization => authorization.contractAddress))).toEqual(new Set(['0xcollection']))
+    })
+  })
+
+  describe('and there is no wallet', () => {
+    it('should not ask about anything, since approvals belong to an address', async () => {
+      renderSettingsPage({ wallet: null, onFetchAuthorizations })
+
+      await waitFor(() => expect(nftMarketplaceAPI.fetch).not.toHaveBeenCalled())
+      expect(onFetchAuthorizations).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/webapp/src/components/SettingsPage/SettingsPage.tsx
+++ b/webapp/src/components/SettingsPage/SettingsPage.tsx
@@ -1,13 +1,14 @@
 import React, { useEffect } from 'react'
 import { Network, NFTCategory } from '@dcl/schemas'
 import { isMobile } from 'decentraland-dapps/dist/lib/utils'
-import { AuthorizationType } from 'decentraland-dapps/dist/modules/authorization/types'
+import { AuthorizationType, type Authorization as AuthorizationData } from 'decentraland-dapps/dist/modules/authorization/types'
 import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { ContractName } from 'decentraland-transactions'
 import { Page, Grid, Blockie, Loader, Form } from 'decentraland-ui'
 import copyText from '../../lib/copyText'
 import { useTimer } from '../../lib/timer'
 import { getContractNames } from '../../modules/vendor'
+import { nftMarketplaceAPI as nftAPI } from '../../modules/vendor/decentraland/nft/api'
 import { shortenAddress } from '../../modules/wallet/utils'
 import { getDeployedOffChainMarketplaceContracts } from '../../utils/trades'
 import { PageLayout } from '../PageLayout'
@@ -15,8 +16,18 @@ import { Authorization } from './Authorization'
 import { Props } from './SettingsPage.types'
 import './SettingsPage.css'
 
+/**
+ * How many of the wallet's collectibles are read to work out which collections to check.
+ *
+ * Selling approvals are per-collection `setApprovalForAll` grants and nothing indexes them, so the only
+ * way to know which collections to ask about is to look at what the wallet holds. One page is enough to
+ * cover the collections a seller actually deals in; a wallet holding more than this may not see every
+ * approval it granted.
+ */
+const HELD_COLLECTIBLES_TO_SCAN = 1000
+
 const SettingsPage = (props: Props) => {
-  const { wallet, authorizations, isLoading, hasError, hasFetchedContracts, getContract, onFetchContracts } = props
+  const { wallet, authorizations, isLoading, hasError, hasFetchedContracts, getContract, onFetchContracts, onFetchAuthorizations } = props
 
   const [hasCopiedText, setHasCopiedAddress] = useTimer(1200)
 
@@ -27,6 +38,73 @@ const SettingsPage = (props: Props) => {
       onFetchContracts()
     }
   }, [onFetchContracts, hasFetchedContracts, isLoading, wallet])
+
+  /**
+   * Ask about the selling approvals the wallet may hold, so the section below has something to show.
+   *
+   * The page renders whatever selling approvals are in the store, but nothing here ever put any there:
+   * only the sell and rent flows fetch them, for the one collection they are about, and the store is not
+   * persisted. So the section was empty on every visit, and a `setApprovalForAll` granted while listing
+   * an item had nowhere to be revoked.
+   *
+   * These are per-collection grants and nothing indexes them, so which collections to ask about has to be
+   * inferred from what the wallet holds. Cheap to over-ask: the saga checks them in a single multicall
+   * batch, and only the ones actually granted reach the store, so a collection that was never approved
+   * costs a slot in that batch and renders nothing.
+   */
+  useEffect(() => {
+    if (!wallet) {
+      return
+    }
+
+    let cancelled = false
+
+    const askAboutHeldCollections = async () => {
+      const { data } = await nftAPI.fetch({ first: HELD_COLLECTIBLES_TO_SCAN, skip: 0, address: wallet.address })
+      if (cancelled) {
+        return
+      }
+
+      const seen = new Set<string>()
+      const held = data.reduce<AuthorizationData[]>((acc, { nft }) => {
+        const key = `${nft.contractAddress}-${nft.chainId}`
+        if (seen.has(key)) {
+          return acc
+        }
+        seen.add(key)
+
+        // A Polygon wearable or emote is an ERC721CollectionV2; everything else answers as a plain ERC721.
+        // Same pairing the sell flow uses, so the row here describes the grant that flow actually made.
+        const contractName =
+          (nft.category === NFTCategory.WEARABLE || nft.category === NFTCategory.EMOTE) && nft.network === Network.MATIC
+            ? ContractName.ERC721CollectionV2
+            : ContractName.ERC721
+
+        for (const { contract } of getDeployedOffChainMarketplaceContracts(nft.chainId)) {
+          acc.push({
+            address: wallet.address,
+            authorizedAddress: contract.address,
+            contractAddress: nft.contractAddress,
+            contractName,
+            chainId: nft.chainId,
+            type: AuthorizationType.APPROVAL
+          })
+        }
+
+        return acc
+      }, [])
+
+      if (held.length > 0) {
+        onFetchAuthorizations(held)
+      }
+    }
+
+    void askAboutHeldCollections()
+
+    return () => {
+      cancelled = true
+    }
+  }, [wallet, onFetchAuthorizations])
 
   const contractNames = getContractNames()
 

--- a/webapp/src/components/SettingsPage/SettingsPage.types.ts
+++ b/webapp/src/components/SettingsPage/SettingsPage.types.ts
@@ -1,4 +1,5 @@
 import { Dispatch } from 'redux'
+import { fetchAuthorizationsRequest, FetchAuthorizationsRequestAction } from 'decentraland-dapps/dist/modules/authorization/actions'
 import { Authorization } from 'decentraland-dapps/dist/modules/authorization/types'
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { fetchContractsRequest, FetchContractsRequestAction } from '../../modules/contract/actions'
@@ -14,11 +15,12 @@ export type Props = {
   hasFetchedContracts: boolean
   getContract: (query: Partial<Contract>) => ReturnType<typeof getContract>
   onFetchContracts: typeof fetchContractsRequest
+  onFetchAuthorizations: typeof fetchAuthorizationsRequest
 }
 
 export type MapStateProps = Pick<
   Props,
   'wallet' | 'authorizations' | 'isLoading' | 'isConnecting' | 'hasError' | 'getContract' | 'hasFetchedContracts'
 >
-export type MapDispatchProps = Pick<Props, 'onFetchContracts'>
-export type MapDispatch = Dispatch<FetchContractsRequestAction>
+export type MapDispatchProps = Pick<Props, 'onFetchContracts' | 'onFetchAuthorizations'>
+export type MapDispatch = Dispatch<FetchContractsRequestAction | FetchAuthorizationsRequestAction>


### PR DESCRIPTION
Listing an item grants a `setApprovalForAll` over the whole collection: blanket, per-collection transfer rights, with no amount and no expiry. Settings is where you would go to take one back, and its **For selling** section is empty on every visit.

## Why it is empty

The section is not missing. It already filters the authorizations store for per-collection grants and renders a working toggle for each — and `decentraland-dapps` already revokes an `APPROVAL` with `setApprovalForAll(spender, false)`.

What was missing is that **nothing ever put any there**. Only the sell and rent flows fetch authorizations, for the single collection they are about, and `authorization` is not among the persisted state paths (`ui.archivedBidIds`, `ui.preview.isTryingOn`). So a fresh load of Settings has an empty store, an empty filter, and no section.

The result: a grant made while listing an item had nowhere to be revoked.

## The change

Settings now asks about the collections the wallet holds, and the section that was already written does the rest. No new UI.

Which collections to ask about has to be inferred from holdings, because **nothing indexes these grants** — there is no approvals or operator table in the squid, so the set of collections an address has approved cannot be looked up.

Over-asking is deliberate and cheap:

- the fetch saga checks every authorization in **one multicall batch** (batchSize 500), so a handful or a hundred is the same round trip
- the reducer keeps only the ones that came back granted, so a collection that was never approved costs a slot in that batch and renders nothing

Each held collection is paired with every off-chain marketplace deployed on its chain, via the existing `getDeployedOffChainMarketplaceContracts` — whose contract list is already named `OFF_CHAIN_MARKETPLACE_SETTINGS_CONTRACT_NAMES`. `ERC721CollectionV2` for a Polygon wearable or emote, plain `ERC721` otherwise: the same pairing the sell flow uses, so a row here describes the grant that flow actually made.

## Known bound

Collections are read from one page of the wallet's collectibles. A wallet that approved a collection and later sold out of it keeps the grant and will not see it listed. Closing that needs the seller's past listings, which `order` can answer (`owner` + `nft_address`); it is a follow-up, not a blocker, and this returns the capability for the case that actually happens.

## Test plan

- [x] Two tokens of one collection produce one collection's worth of asks, not two
- [x] Every asked authorization is an `APPROVAL`
- [x] No wallet asks nothing, since a grant belongs to an address
- [x] Verified in the negative: with the dispatch removed, the first fails
- [x] `SettingsPage` suite, typecheck, lint