### PR TITLE
fix: send mobile-IAP entry points to the shop

### DIFF
--- a/webapp/src/modules/iap/shopRedirect.spec.ts
+++ b/webapp/src/modules/iap/shopRedirect.spec.ts
@@ -1,0 +1,48 @@
+import { config } from '../../config'
+import { getShopPath, getShopUrl } from './shopRedirect'
+
+jest.mock('../routing/basename', () => ({
+  getBasename: () => '/marketplace'
+}))
+
+const params = (search: string) => new URLSearchParams(search)
+
+describe('when mapping a marketplace destination to the shop', () => {
+  it('should map an item detail page, lowercasing the contract', () => {
+    expect(getShopPath('/marketplace/contracts/0xAbC0000000000000000000000000000000000001/items/3', params(''))).toBe(
+      '/item/0xabc0000000000000000000000000000000000001/3'
+    )
+  })
+
+  it('should map the browse sections a mobile client links to', () => {
+    expect(getShopPath('/marketplace/browse', params('section=wearables'))).toBe('/items?category=wearable')
+    expect(getShopPath('/marketplace/browse', params('section=emotes'))).toBe('/items?category=emote')
+  })
+
+  it('should fall back to the unfiltered grid for a section the shop has no category for', () => {
+    expect(getShopPath('/marketplace/browse', params('section=land'))).toBe('/items')
+    expect(getShopPath('/marketplace', params(''))).toBe('/items')
+  })
+
+  it('should map the NAME claim page to the shop names category', () => {
+    expect(getShopPath('/marketplace/names/claim', params(''))).toBe('/items?category=names')
+  })
+
+  it('should leave the purchase flow and everything else on this app', () => {
+    expect(getShopPath('/marketplace/buy', params(''))).toBeNull()
+    expect(getShopPath('/marketplace/success', params(''))).toBeNull()
+    expect(getShopPath('/marketplace/account/0xabc', params(''))).toBeNull()
+  })
+})
+
+describe('when building the absolute shop url', () => {
+  it('should carry the mobile-iap marker the shop reads', () => {
+    expect(getShopUrl('/marketplace/browse', params('section=wearables&view=mobile-iap'))).toBe(
+      `${config.get('SHOP_URL')}/items?category=wearable&view=mobile-iap`
+    )
+  })
+
+  it('should return null when the shop does not serve the destination', () => {
+    expect(getShopUrl('/marketplace/success', params(''))).toBeNull()
+  })
+})

--- a/webapp/src/modules/iap/shopRedirect.ts
+++ b/webapp/src/modules/iap/shopRedirect.ts
@@ -1,0 +1,52 @@
+import { config } from '../../config'
+import { getBasename } from '../routing/basename'
+import { IAP_VIEW_PARAM, IAP_VIEW_VALUE } from './useIAP'
+
+// Mobile clients already published to the app stores still build classic marketplace
+// URLs. In mobile-IAP mode we hand the destinations they link to over to the shop, so a
+// shipped build reaches the right storefront without waiting for an app update. Every
+// other route stays here — `/success` above all, which fires the deep link back into
+// the app.
+
+const BROWSE_SECTION_TO_SHOP_CATEGORY: Record<string, string> = {
+  wearables: 'wearable',
+  emotes: 'emote'
+}
+
+/** `locations.item()` — `/contracts/:contractAddress/items/:itemId`. */
+const ITEM_PATH = /^\/contracts\/(0x[0-9a-fA-F]{40})\/items\/(\d+)\/?$/
+
+export const stripBasename = (pathname: string): string => {
+  const basename = getBasename()
+  return basename && pathname.startsWith(basename) ? pathname.slice(basename.length) || '/' : pathname
+}
+
+/** The shop path serving the same destination, or `null` to keep handling it here. */
+export const getShopPath = (pathname: string, params: URLSearchParams): string | null => {
+  const path = stripBasename(pathname)
+
+  const item = ITEM_PATH.exec(path)
+  if (item) {
+    return `/item/${item[1].toLowerCase()}/${item[2]}`
+  }
+  // Not a listing: the shop swaps the grid for the NAME registration page.
+  if (path === '/names/claim') {
+    return '/items?category=names'
+  }
+  if (path === '/' || path === '/browse') {
+    const category = BROWSE_SECTION_TO_SHOP_CATEGORY[params.get('section') ?? '']
+    return category ? `/items?category=${category}` : '/items'
+  }
+  return null
+}
+
+/** Absolute shop URL, keeping the marker the shop reads under the same spelling. */
+export const getShopUrl = (pathname: string, params: URLSearchParams): string | null => {
+  const path = getShopPath(pathname, params)
+  if (!path) {
+    return null
+  }
+  const url = new URL(`${config.get('SHOP_URL')}${path}`)
+  url.searchParams.set(IAP_VIEW_PARAM, IAP_VIEW_VALUE)
+  return url.toString()
+}

--- a/webapp/src/modules/iap/useIAP.ts
+++ b/webapp/src/modules/iap/useIAP.ts
@@ -1,8 +1,8 @@
 import { useMemo } from 'react'
 import { useLocation } from 'react-router-dom'
 
-const IAP_VIEW_PARAM = 'view'
-const IAP_VIEW_VALUE = 'mobile-iap'
+export const IAP_VIEW_PARAM = 'view'
+export const IAP_VIEW_VALUE = 'mobile-iap'
 
 export const useIsIAP = (): boolean => {
   const { search } = useLocation()

--- a/webapp/src/modules/store.ts
+++ b/webapp/src/modules/store.ts
@@ -14,6 +14,7 @@ import { getPreferredLocale } from 'decentraland-dapps/dist/modules/translation/
 import { Locale } from 'decentraland-ui'
 import { config } from '../config'
 import { ARCHIVE_BID, UNARCHIVE_BID } from './bid/actions'
+import { getShopUrl } from './iap/shopRedirect'
 import { getCurrentIdentity } from './identity/selectors'
 import { createRootReducer, RootState } from './reducer'
 import { getBasename } from './routing/basename'
@@ -52,6 +53,14 @@ export const createHistory = () => {
   const isIAP = viewParam === 'mobile-iap'
 
   if (isIAP) {
+    // Hand the request to the shop when it serves this destination. Runs before the
+    // router exists, so there is no flash of this app's shell.
+    const shopUrl = getShopUrl(window.location.pathname, initialParams)
+    if (shopUrl) {
+      window.location.replace(shopUrl)
+      return history
+    }
+
     const injectParams = (path: string | Location): string | Location => {
       if (typeof path === 'string') {
         const [pathname, search = ''] = path.split('?')


### PR DESCRIPTION
## What

While this app is in mobile-IAP mode (`?view=mobile-iap`), the destinations a mobile client links to now redirect to the equivalent shop route: `/browse?section=wearables|emotes` → `/shop/items?category=wearable|emote`, `/contracts/{c}/items/{i}` → `/shop/item/{c}/{i}`, `/names/claim` → `/shop/items?category=names`. Every other route, `/buy` and `/success` included, keeps being served here.

## Why

The shop replaced this app as the storefront on `.org`, but the mobile clients already published to the app stores still build classic marketplace URLs — so a player tapping a recommended item in the backpack lands here instead of in the shop. The client-side fix ([godot-explorer#2872](https://github.com/decentraland/godot-explorer/pull/2872)) only reaches players who update; this redirect covers the builds already installed.

Nothing changes outside mobile-IAP mode: without `view=mobile-iap` in the URL, the app behaves exactly as before.

## Details

<details>
<summary>Expand</summary>

The mapping lives in `webapp/src/modules/iap/shopRedirect.ts` and is called from `createHistory()` in `webapp/src/modules/store.ts`, at the top of the block that already handles IAP mode. That runs at module scope, before the router exists, so there is no flash of this app's shell. The shop base comes from the existing `SHOP_URL` config key, and `view=mobile-iap` is carried over — the shop reads the same spelling.

`/success` deliberately stays here: it is what fires `decentraland://open?iap_enabled=true&urn=` back into the app, and the shop has no equivalent yet. A reload mid-purchase must not lose it.

No feature flag. Flags load asynchronously through a saga, so gating this would force it out of `createHistory()` and into React, which brings back the shell flash. Happy to add one if you'd rather have the kill switch.

</details>

## Test plan

1. Open `https://decentraland.org/marketplace/browse?section=wearables&view=mobile-iap`.
   - [ ] Lands on `https://decentraland.org/shop/items?category=wearable&view=mobile-iap` with items in the grid
2. Open `/marketplace/browse?section=emotes&view=mobile-iap`.
   - [ ] Lands on `/shop/items?category=emote&view=mobile-iap`
3. Open `/marketplace/contracts/<contract>/items/<itemId>?view=mobile-iap` for any on-sale item.
   - [ ] Lands on `/shop/item/<contract>/<itemId>` showing that item
4. Open `/marketplace/names/claim?view=mobile-iap`.
   - [ ] Lands on `/shop/items?category=names` showing the NAME registration page
5. Open `/marketplace/success?view=mobile-iap` and `/marketplace/browse?section=wearables` (no `view` param).
   - [ ] Neither redirects — both stay on `/marketplace`
6. From the mobile app (a build that still links here), open the backpack and tap a recommended item.
   - [ ] The in-app browser ends up on `/shop/item/…`, and the item page renders
