### PR TITLE
fix: bind the mobile-iap checkout to the payment source it presents

### DIFF
--- a/webapp/src/components/AssetPage/SaleActionBox/BuyNFTButtons/BuyNFTButtons.spec.tsx
+++ b/webapp/src/components/AssetPage/SaleActionBox/BuyNFTButtons/BuyNFTButtons.spec.tsx
@@ -1,0 +1,92 @@
+import React from 'react'
+import { screen, waitFor } from '@testing-library/react'
+import { ChainId, NFTCategory, Network } from '@dcl/schemas'
+import { Asset, AssetType } from '../../../../modules/asset/types'
+import { renderWithProviders } from '../../../../utils/test'
+import BuyNFTButtons from './BuyNFTButtons'
+import { Props } from './BuyNFTButtons.types'
+
+const ITEM = {
+  id: 'an-item',
+  itemId: '0',
+  contractAddress: '0xcollection',
+  category: NFTCategory.WEARABLE,
+  network: Network.MATIC,
+  chainId: ChainId.MATIC_MAINNET,
+  price: '100000000000000000000',
+  available: 1,
+  data: {},
+  isOnSale: true
+} as unknown as Asset
+
+// Supplies the loaded asset the real provider would resolve, so the render callback under test runs
+// without the store and network machinery behind it.
+jest.mock('../../../AssetProvider', () => ({
+  AssetProvider: ({ children }: { children: (asset: Asset, order: null) => React.ReactNode }) => children(ITEM, null)
+}))
+
+jest.mock('../UseCreditsToggle', () => ({ __esModule: true, default: () => null }))
+jest.mock('./BuyWithCryptoButton', () => ({ BuyWithCryptoButton: () => <button>buy</button> }))
+jest.mock('./BuyWithCardButton', () => ({ BuyWithCardButton: () => <button>card</button> }))
+
+function renderButtons(url: string, overrides: Partial<Props> = {}) {
+  const onBuyWithCrypto = jest.fn()
+  const props = {
+    asset: ITEM,
+    assetType: AssetType.ITEM,
+    isBuyingWithCryptoModalOpen: false,
+    wallet: { address: '0xbuyer', networks: { [Network.MATIC]: { mana: 1000 }, [Network.ETHEREUM]: { mana: 0 } } },
+    credits: null,
+    isConnecting: false,
+    isCreditsEnabled: false,
+    isCreditsSecondarySalesEnabled: false,
+    onBuyWithCrypto,
+    onExecuteOrderWithCard: jest.fn(),
+    onBuyItemWithCard: jest.fn(),
+    onUseCredits: jest.fn(),
+    ...overrides
+  } as unknown as Props
+
+  const rendered = renderWithProviders(<BuyNFTButtons {...props} />, { initialEntries: [url] })
+  // Re-renders the same component, which is what a dispatch sitting in the render body reacted to.
+  const rerender = () => rendered.rerender(<BuyNFTButtons {...props} />)
+  return { onBuyWithCrypto, rerender }
+}
+
+// A `buyWithCrypto=true` deep link opens the checkout on arrival. The call used to sit in the render
+// body and reach the dispatch prop directly, which re-dispatched on every render and dropped the
+// credits selection — the two things these tests pin.
+describe('when a deep link asks for the checkout to be opened', () => {
+  it('should open it once, not once per render', async () => {
+    const { onBuyWithCrypto, rerender } = renderButtons('/?buyWithCrypto=true')
+
+    await waitFor(() => expect(onBuyWithCrypto).toHaveBeenCalled())
+    rerender()
+    rerender()
+
+    expect(onBuyWithCrypto).toHaveBeenCalledTimes(1)
+  })
+
+  it('should carry the credits selection that mobile-iap mode turns on', async () => {
+    const { onBuyWithCrypto } = renderButtons('/?buyWithCrypto=true&view=mobile-iap')
+
+    await waitFor(() => expect(onBuyWithCrypto).toHaveBeenCalled())
+    expect(onBuyWithCrypto).toHaveBeenCalledWith(ITEM, null, true)
+  })
+
+  it('should carry the credits selection as off outside mobile-iap mode', async () => {
+    const { onBuyWithCrypto } = renderButtons('/?buyWithCrypto=true')
+
+    await waitFor(() => expect(onBuyWithCrypto).toHaveBeenCalled())
+    expect(onBuyWithCrypto).toHaveBeenCalledWith(ITEM, null, false)
+  })
+})
+
+describe('when no deep link asks for it', () => {
+  it('should not open the checkout on its own', async () => {
+    const { onBuyWithCrypto } = renderButtons('/')
+
+    await waitFor(() => expect(screen.getByText('buy')).toBeInTheDocument())
+    expect(onBuyWithCrypto).not.toHaveBeenCalled()
+  })
+})

--- a/webapp/src/components/AssetPage/SaleActionBox/BuyNFTButtons/BuyNFTButtons.tsx
+++ b/webapp/src/components/AssetPage/SaleActionBox/BuyNFTButtons/BuyNFTButtons.tsx
@@ -1,4 +1,5 @@
-import { memo, useCallback, useEffect, useMemo, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { ReactNode } from 'react'
 import { useHistory, useLocation } from 'react-router-dom'
 import classNames from 'classnames'
 import { BigNumber } from 'ethers'
@@ -20,6 +21,32 @@ import { BuyWithCardButton } from './BuyWithCardButton'
 import { BuyWithCryptoButton } from './BuyWithCryptoButton'
 import { Props } from './BuyNFTButtons.types'
 import styles from './BuyNFTButtons.module.css'
+
+// A `buyWithCrypto=true` deep link opens the checkout on arrival. It runs from an effect
+// rather than during render, and exactly once per mount: the previous call sat in the render
+// body, so it re-dispatched on every render, and it called the dispatch prop directly, which
+// dropped the credits selection that `handleBuyWithCrypto` carries.
+const AutoOpenCheckout = ({
+  asset,
+  order,
+  onOpen
+}: {
+  asset: Asset
+  order: Order | null
+  onOpen: (asset: Asset, order: Order | null) => void
+}) => {
+  const hasOpened = useRef(false)
+
+  useEffect(() => {
+    if (hasOpened.current) {
+      return
+    }
+    hasOpened.current = true
+    onOpen(asset, order)
+  }, [asset, order, onOpen])
+
+  return null
+}
 
 const BuyNFTButtons = ({
   credits,
@@ -87,9 +114,14 @@ const BuyNFTButtons = ({
       <AssetProvider type={assetType} contractAddress={asset.contractAddress} tokenId={tokenId}>
         {(asset, order) => {
           if (!asset) return <Loader active size="medium" className={styles.loading_asset} />
-          if (asset && shouldOpenBuyWithCryptoModal) {
-            onBuyWithCrypto(asset, order)
-          }
+          // Every branch below carries the same auto-open, so a deep link behaves the same
+          // whichever call to action the asset resolves to.
+          const withAutoOpen = (children: ReactNode) => (
+            <>
+              {shouldOpenBuyWithCryptoModal ? <AutoOpenCheckout asset={asset} order={order} onOpen={handleBuyWithCrypto} /> : null}
+              {children}
+            </>
+          )
           const isItemFree = !isNFT(asset) && asset.price === '0'
           const isBuyingEntirelyWithCredits =
             useCredits &&
@@ -102,7 +134,7 @@ const BuyNFTButtons = ({
             if (!wallet) {
               const basename = getBasename()
               const redirectTo = `${basename}${location.pathname}${location.search}`
-              return (
+              return withAutoOpen(
                 <Button
                   primary
                   fluid
@@ -116,7 +148,7 @@ const BuyNFTButtons = ({
 
             // NFT without an active order cannot be purchased
             if (isNFT(asset) && !order) {
-              return (
+              return withAutoOpen(
                 <Button primary fluid className={styles.buyWithCryptoButton} disabled>
                   <span>{t('asset_page.actions.checkout')}</span>
                 </Button>
@@ -126,7 +158,7 @@ const BuyNFTButtons = ({
             const assetPrice = !isNFT(asset) ? asset.price : order!.price
             const hasEnoughCredits = !!credits && BigInt(credits.totalCredits) >= BigInt(assetPrice)
 
-            return (
+            return withAutoOpen(
               <Button
                 primary
                 fluid
@@ -139,7 +171,7 @@ const BuyNFTButtons = ({
             )
           }
 
-          return (
+          return withAutoOpen(
             <>
               {/* Credits toggle is only available for items with price > 1 MANA or for NFTs as well if the secondary sales are enabled */}
               {((isCreditsEnabled && !isNFT(asset) && BigNumber.from(asset.price).gte(getMinSaleValueInWei() || '')) ||

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyNftWithCryptoModal/BuyNftWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyNftWithCryptoModal/BuyNftWithCryptoModal.tsx
@@ -4,7 +4,9 @@ import withAuthorizedAction from 'decentraland-dapps/dist/containers/withAuthori
 import { AuthorizedAction } from 'decentraland-dapps/dist/containers/withAuthorizedAction/AuthorizationModal'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics'
 import { AuthorizationType } from 'decentraland-dapps/dist/modules/authorization'
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { ContractName, getContractName, getContract as getDCLContract } from 'decentraland-transactions'
+import { useIsIAP } from '../../../../modules/iap/useIAP'
 import { useFingerprint } from '../../../../modules/nft/hooks'
 import { getBuyItemStatus, getError } from '../../../../modules/order/selectors'
 import { useCheckoutPriceInMana } from '../../../../modules/trade/hooks'
@@ -41,6 +43,7 @@ const BuyNftWithCryptoModalHOC = (props: Props) => {
   // instead of from `order.price`.
   const checkoutPrice = useCheckoutPriceInMana(order.price, nft.network, order.tradeId)
   const priceInMana = checkoutPrice.manaWei
+  const isIAP = useIsIAP()
 
   // Legacy `safeExecuteOrder` on V1 marketplace verifies the fingerprint
   // against the upgraded EstateRegistry (getFingerprintV2). Use the contract
@@ -148,9 +151,25 @@ const BuyNftWithCryptoModalHOC = (props: Props) => {
     return <CheckoutPriceUnavailableModal name={name} isLoading={checkoutPrice.status === 'resolving'} onClose={onClose} />
   }
 
+  // A mobile-IAP checkout is presented as a Credits purchase, so it must not fall through to
+  // spending MANA. The credits selection is what the execution branch, the allowance and the
+  // figure on screen all derive from, so without it nothing is put up for approval.
+  if (isIAP && useCredits !== true) {
+    return (
+      <CheckoutPriceUnavailableModal
+        name={name}
+        isLoading={false}
+        title={t('iap_payment_unavailable.title')}
+        description={t('iap_payment_unavailable.description')}
+        onClose={onClose}
+      />
+    )
+  }
+
   return (
     <BuyWithCryptoModal
       price={price}
+      priceBeforeCredits={priceInMana ?? undefined}
       isPriceApproximate={checkoutPrice.isUSDPegged}
       useCredits={useCredits}
       isBuyingAsset={isExecutingOrder || isExecutingOrderCrossChain}

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyNftWithCryptoModal/BuyNftWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyNftWithCryptoModal/BuyNftWithCryptoModal.tsx
@@ -4,9 +4,7 @@ import withAuthorizedAction from 'decentraland-dapps/dist/containers/withAuthori
 import { AuthorizedAction } from 'decentraland-dapps/dist/containers/withAuthorizedAction/AuthorizationModal'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics'
 import { AuthorizationType } from 'decentraland-dapps/dist/modules/authorization'
-import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { ContractName, getContractName, getContract as getDCLContract } from 'decentraland-transactions'
-import { useIsIAP } from '../../../../modules/iap/useIAP'
 import { useFingerprint } from '../../../../modules/nft/hooks'
 import { getBuyItemStatus, getError } from '../../../../modules/order/selectors'
 import { useCheckoutPriceInMana } from '../../../../modules/trade/hooks'
@@ -43,7 +41,6 @@ const BuyNftWithCryptoModalHOC = (props: Props) => {
   // instead of from `order.price`.
   const checkoutPrice = useCheckoutPriceInMana(order.price, nft.network, order.tradeId)
   const priceInMana = checkoutPrice.manaWei
-  const isIAP = useIsIAP()
 
   // Legacy `safeExecuteOrder` on V1 marketplace verifies the fingerprint
   // against the upgraded EstateRegistry (getFingerprintV2). Use the contract
@@ -149,21 +146,6 @@ const BuyNftWithCryptoModalHOC = (props: Props) => {
   // anyone who came through the asset page); `unavailable` is an unreadable trade or an unreachable oracle.
   if (price === null) {
     return <CheckoutPriceUnavailableModal name={name} isLoading={checkoutPrice.status === 'resolving'} onClose={onClose} />
-  }
-
-  // A mobile-IAP checkout is presented as a Credits purchase, so it must not fall through to
-  // spending MANA. The credits selection is what the execution branch, the allowance and the
-  // figure on screen all derive from, so without it nothing is put up for approval.
-  if (isIAP && useCredits !== true) {
-    return (
-      <CheckoutPriceUnavailableModal
-        name={name}
-        isLoading={false}
-        title={t('iap_payment_unavailable.title')}
-        description={t('iap_payment_unavailable.description')}
-        onClose={onClose}
-      />
-    )
   }
 
   return (

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyNftWithCryptoModal/BuyNftWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyNftWithCryptoModal/BuyNftWithCryptoModal.tsx
@@ -144,14 +144,14 @@ const BuyNftWithCryptoModalHOC = (props: Props) => {
 
   // Without a resolved amount there is nothing to confirm. `resolving` is the trade read (a cache hit for
   // anyone who came through the asset page); `unavailable` is an unreadable trade or an unreachable oracle.
-  if (price === null) {
+  if (price === null || priceInMana === null) {
     return <CheckoutPriceUnavailableModal name={name} isLoading={checkoutPrice.status === 'resolving'} onClose={onClose} />
   }
 
   return (
     <BuyWithCryptoModal
       price={price}
-      priceBeforeCredits={priceInMana ?? undefined}
+      priceBeforeCredits={priceInMana}
       isPriceApproximate={checkoutPrice.isUSDPegged}
       useCredits={useCredits}
       isBuyingAsset={isExecutingOrder || isExecutingOrderCrossChain}

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.spec.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.spec.tsx
@@ -1,7 +1,9 @@
 import { Context as ResponsiveContext } from 'react-responsive'
 import { fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { BigNumber } from 'ethers'
 import { BodyShape, ChainId, Item, NFTCategory, Network, Rarity, WearableCategory } from '@dcl/schemas'
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { CrossChainProvider, Route, AxelarProvider } from 'decentraland-transactions/crossChain'
 import * as configModule from '../../../config'
@@ -499,6 +501,42 @@ describe('BuyWithCryptoModal', () => {
         }
       } as Wallet
     }
+  })
+
+  // The mobile-IAP action button used to pick its execution branch from whichever callback was
+  // supplied. `onBuyWithCredits` is passed on the ENS claim path regardless of what the buyer
+  // selected, so the button settled through credits even when they chose MANA. It now follows the
+  // payment source the screen presents.
+  describe('and the mobile-IAP action is pressed on an asset whose flow supplies a credits callback', () => {
+    let onBuyWithCredits: jest.Mock
+    let onBuyNatively: jest.Mock
+
+    beforeEach(() => {
+      onBuyWithCredits = jest.fn()
+      onBuyNatively = jest.fn()
+    })
+
+    it('should settle natively when the buyer did not select credits', async () => {
+      const { getByText } = await renderBuyWithCryptoModal({ ...modalProps, useCredits: false, onBuyWithCredits, onBuyNatively }, [
+        '/?view=mobile-iap'
+      ])
+
+      await userEvent.click(getByText(t('buy_with_crypto_modal.buy_now')))
+
+      expect(onBuyNatively).toHaveBeenCalled()
+      expect(onBuyWithCredits).not.toHaveBeenCalled()
+    })
+
+    it('should settle through credits when the buyer did select them', async () => {
+      const { getByText } = await renderBuyWithCryptoModal({ ...modalProps, useCredits: true, onBuyWithCredits, onBuyNatively }, [
+        '/?view=mobile-iap'
+      ])
+
+      await userEvent.click(getByText(t('buy_with_crypto_modal.buy_now')))
+
+      expect(onBuyWithCredits).toHaveBeenCalled()
+      expect(onBuyNatively).not.toHaveBeenCalled()
+    })
   })
 
   // Mobile-IAP mode shows the full price before credits. It used to read the asset's own `price`

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.spec.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.spec.tsx
@@ -404,6 +404,7 @@ async function renderBuyWithCryptoModal(props: Partial<Props> = {}, initialEntri
     name: 'A name',
     metadata: { asset: MOCKED_ITEM },
     price: (MOCKED_ITEM as Item).price,
+    priceBeforeCredits: (MOCKED_ITEM as Item).price,
     wallet: null,
     isBuyingAsset: false,
     isLoadingAuthorization: false,

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.spec.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.spec.tsx
@@ -503,6 +503,24 @@ describe('BuyWithCryptoModal', () => {
     }
   })
 
+  // The mobile-IAP marker rides on the URL and says nothing about the payment source. Keying the
+  // Credits branding off it alone meant a flow that settles in MANA — a LAND or Estate order, an ENS
+  // resale, or a checkout opened without the credits selection — showed a Credits-branded figure for
+  // a MANA debit.
+  describe('and a mobile-IAP checkout will settle in MANA rather than credits', () => {
+    it('should not brand the figures as credits', async () => {
+      const { queryAllByAltText } = await renderBuyWithCryptoModal({ ...modalProps, useCredits: false }, ['/?view=mobile-iap'])
+
+      expect(queryAllByAltText('Credits')).toHaveLength(0)
+    })
+
+    it('should brand them as credits once credits are the payment source', async () => {
+      const { queryAllByAltText } = await renderBuyWithCryptoModal({ ...modalProps, useCredits: true }, ['/?view=mobile-iap'])
+
+      expect(queryAllByAltText('Credits').length).toBeGreaterThan(0)
+    })
+  })
+
   // The mobile-IAP action button used to pick its execution branch from whichever callback was
   // supplied. `onBuyWithCredits` is passed on the ENS claim path regardless of what the buyer
   // selected, so the button settled through credits even when they chose MANA. It now follows the

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.spec.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.spec.tsx
@@ -5,6 +5,7 @@ import { BodyShape, ChainId, Item, NFTCategory, Network, Rarity, WearableCategor
 import { Wallet } from 'decentraland-dapps/dist/modules/wallet/types'
 import { CrossChainProvider, Route, AxelarProvider } from 'decentraland-transactions/crossChain'
 import * as configModule from '../../../config'
+import { formatWeiMANA } from '../../../lib/mana'
 import { Asset } from '../../../modules/asset/types'
 import { marketplaceAPI } from '../../../modules/vendor/decentraland/marketplace/api'
 import { renderWithProviders } from '../../../utils/test'
@@ -396,7 +397,7 @@ const MOCKED_ITEM: Asset = {
   }
 }
 
-async function renderBuyWithCryptoModal(props: Partial<Props> = {}) {
+async function renderBuyWithCryptoModal(props: Partial<Props> = {}, initialEntries?: string[]) {
   const defaultProps: Props = {
     name: 'A name',
     metadata: { asset: MOCKED_ITEM },
@@ -431,7 +432,8 @@ async function renderBuyWithCryptoModal(props: Partial<Props> = {}) {
   const rendered = renderWithProviders(
     <ResponsiveContext.Provider value={{ width: 900 }}>
       <BuyWithCryptoModal {...defaultProps} {...props} />
-    </ResponsiveContext.Provider>
+    </ResponsiveContext.Provider>,
+    { initialEntries }
   )
 
   await waitFor(() => expect(rendered.findByTestId(PAY_WITH_DATA_TEST_ID)))
@@ -497,6 +499,34 @@ describe('BuyWithCryptoModal', () => {
         }
       } as Wallet
     }
+  })
+
+  // Mobile-IAP mode shows the full price before credits. It used to read the asset's own `price`
+  // field, which carries no unit: on a USD-pegged listing that is USD wei, so the figure on screen
+  // bore no relation to the MANA the purchase would debit. It now comes from the resolved amount
+  // the caller passes.
+  describe('and the checkout is opened in mobile-IAP mode for a USD-pegged item', () => {
+    // 2,529.1 USD at 0.076148 USD/MANA.
+    const rawUsdAmount = '2529100000000000000000'
+    const resolvedMana = '33212953721699847665073'
+
+    it('should show the resolved MANA amount rather than the listed figure', async () => {
+      const { getByText } = await renderBuyWithCryptoModal(
+        {
+          ...modalProps,
+          metadata: { asset: { ...MOCKED_ITEM, price: rawUsdAmount } as Asset },
+          price: resolvedMana,
+          priceBeforeCredits: resolvedMana
+        },
+        ['/?view=mobile-iap']
+      )
+
+      // Scoped to the total, which is the figure the buyer approves against.
+      const total = getByText('Total').parentElement
+
+      expect(total).toHaveTextContent(formatWeiMANA(resolvedMana))
+      expect(total).not.toHaveTextContent(formatWeiMANA(rawUsdAmount))
+    })
   })
 
   describe('and the user is connected to Ethereum network', () => {

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.tsx
@@ -52,6 +52,7 @@ export const BuyWithCryptoModal = (props: Props) => {
   const {
     price,
     isPriceApproximate,
+    priceBeforeCredits,
     wallet,
     credits,
     useCredits,
@@ -85,20 +86,10 @@ export const BuyWithCryptoModal = (props: Props) => {
   const abortControllerRef = useRef(new AbortController())
 
   const isIAP = useIsIAP()
-  // In IAP mode, show the original asset price (not adjusted by credits).
-  // For items, asset.price has the original. For NFTs, price is already adjusted
-  // (original - credits), so we reconstruct it by adding credits back.
-  const displayPrice = useMemo(() => {
-    if (!isIAP) return price
-    if ('price' in asset) return asset.price
-    if (credits?.totalCredits && price === '0') {
-      return credits.totalCredits.toString()
-    }
-    if (credits?.totalCredits) {
-      return (BigInt(price) + BigInt(credits.totalCredits)).toString()
-    }
-    return price
-  }, [isIAP, asset, price, credits])
+  // IAP mode shows the full price rather than what is left after credits. It comes from the caller, which
+  // resolved it in MANA: reading the asset's own `price` here rendered an unconverted figure on a USD-pegged
+  // listing, and reconstructing it by adding credits back guessed at an amount the caller already knows.
+  const displayPrice = useMemo(() => (isIAP ? priceBeforeCredits ?? price : price), [isIAP, priceBeforeCredits, price])
 
   // useStates
   const [providerChains, setProviderChains] = useState<ChainData[]>(getDefaultChains())

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.tsx
@@ -90,6 +90,11 @@ export const BuyWithCryptoModal = (props: Props) => {
   // resolved it in MANA: reading the asset's own `price` here rendered an unconverted figure on a USD-pegged
   // listing, and reconstructing it by adding credits back guessed at an amount the caller already knows.
   const displayPrice = useMemo(() => (isIAP ? priceBeforeCredits ?? price : price), [isIAP, priceBeforeCredits, price])
+  // Whether to present this as a Credits purchase. The mobile-IAP marker alone is not enough: it rides on the
+  // URL and says nothing about the payment source, so keying the branding off it let flows that settle in MANA
+  // — a LAND or Estate order, an ENS resale, a checkout opened without the credits selection — render a
+  // Credits-branded confirmation for a MANA debit. The icon now follows what is actually going to be spent.
+  const presentsCredits = isIAP && useCredits === true
 
   // useStates
   const [providerChains, setProviderChains] = useState<ChainData[]>(getDefaultChains())
@@ -787,7 +792,7 @@ export const BuyWithCryptoModal = (props: Props) => {
                   <span className={styles.assetDescription}>{assetDescription}</span>
                 </div>
                 <div className={styles.priceContainer}>
-                  {isIAP ? (
+                  {presentsCredits ? (
                     <span className={styles.creditsPrice}>
                       <img src={CreditsIcon} alt="Credits" className={styles.creditsIcon} />
                       {formatWeiMANA(displayPrice)}
@@ -834,8 +839,16 @@ export const BuyWithCryptoModal = (props: Props) => {
                   <div className={styles.iapTotalContainer}>
                     <span>{t('buy_with_crypto_modal.total')}</span>
                     <span className={styles.creditsPrice}>
-                      <img src={CreditsIcon} alt="Credits" className={styles.creditsIcon} />
-                      {formatWeiMANA(displayPrice)}
+                      {presentsCredits ? <img src={CreditsIcon} alt="Credits" className={styles.creditsIcon} /> : null}
+                      {presentsCredits ? (
+                        formatWeiMANA(displayPrice)
+                      ) : (
+                        <Mana network={asset.network} inline withTooltip>
+                          {isPriceApproximate
+                            ? t('pegged_mana_price.approximate', { amount: formatWeiMANA(displayPrice) })
+                            : formatWeiMANA(displayPrice)}
+                        </Mana>
+                      )}
                     </span>
                   </div>
                   {/* Anchor the Checkout button directly below the Total so the flow reads

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.tsx
@@ -411,9 +411,12 @@ export const BuyWithCryptoModal = (props: Props) => {
           primary
           disabled={!wallet || isBuying}
           loading={isBuying}
-          // onBuyWithCredits is only defined for ENS claims; for wearable/emote purchases
-          // onBuyNatively handles credits via the useCredits flag passed through metadata
-          onClick={onBuyWithCredits ? onPayWithCredits : onBuyNatively}
+          // Follows the payment source this screen presents, not whichever callback happens to be
+          // supplied: `onBuyWithCredits` exists on the ENS claim path regardless of what the buyer
+          // selected, so keying off its presence alone settled through credits even when they chose
+          // MANA. Where it is absent — wearables, emotes — `onBuyNatively` applies credits itself
+          // from the same flag.
+          onClick={useCredits && onBuyWithCredits ? onPayWithCredits : onBuyNatively}
         >
           {isBuying ? t('buy_with_crypto_modal.buying_asset') : t('buy_with_crypto_modal.buy_now')}
         </Button>

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.types.ts
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.types.ts
@@ -30,6 +30,12 @@ export type Props = Pick<WithAuthorizedActionProps, 'isLoadingAuthorization' | '
      * figures rendered from it are marked approximate: the contract recomputes the rate at accept time.
      */
     isPriceApproximate?: boolean
+    /**
+     * The same resolved MANA amount as `price`, before any credits are deducted. Mobile-IAP mode shows the
+     * full price rather than the remainder, and it has to come from here: an asset's own `price` field carries
+     * no unit, so on a USD-pegged listing it is USD wei and bears no relation to what the purchase debits.
+     */
+    priceBeforeCredits?: string
     credits: CreditsResponse | null
     useCredits?: boolean
     wallet: Wallet | null
@@ -56,6 +62,7 @@ export type ContainerProps = Pick<
   | 'metadata'
   | 'price'
   | 'isPriceApproximate'
+  | 'priceBeforeCredits'
   | 'useCredits'
   | 'isBuyingAsset'
   | 'onBuyNatively'

--- a/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.types.ts
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/BuyWithCryptoModal.types.ts
@@ -34,8 +34,9 @@ export type Props = Pick<WithAuthorizedActionProps, 'isLoadingAuthorization' | '
      * The same resolved MANA amount as `price`, before any credits are deducted. Mobile-IAP mode shows the
      * full price rather than the remainder, and it has to come from here: an asset's own `price` field carries
      * no unit, so on a USD-pegged listing it is USD wei and bears no relation to what the purchase debits.
+     * Required rather than optional so that a caller cannot leave it out and fall back to the remainder.
      */
-    priceBeforeCredits?: string
+    priceBeforeCredits: string
     credits: CreditsResponse | null
     useCredits?: boolean
     wallet: Wallet | null

--- a/webapp/src/components/Modals/BuyWithCryptoModal/CheckoutPriceUnavailableModal/CheckoutPriceUnavailableModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/CheckoutPriceUnavailableModal/CheckoutPriceUnavailableModal.tsx
@@ -10,17 +10,18 @@ import styles from './CheckoutPriceUnavailableModal.module.css'
  * A listing's `price` field carries no unit: a USD-pegged trade prices in USD and the marketplace converts to
  * MANA with its own oracle at accept time, so the MANA to charge is only known once the trade and the rate
  * have been read. When either read is unavailable, this stands in for the confirmation screen rather than
- * showing a figure in the wrong unit.
+ * showing a figure in the wrong unit. `title` and `description` let a caller reuse it for another detail of
+ * the purchase it could not establish.
  */
-const CheckoutPriceUnavailableModal = ({ name, isLoading, onClose }: Props) => (
+const CheckoutPriceUnavailableModal = ({ name, isLoading, title, description, onClose }: Props) => (
   <Modal open name={name} size="tiny" className={styles.modal} onClose={onClose}>
-    <ModalNavigation title={t('checkout_price_unavailable_modal.title')} onClose={onClose} />
+    <ModalNavigation title={title ?? t('checkout_price_unavailable_modal.title')} onClose={onClose} />
     <Modal.Content className={styles.content}>
       {isLoading ? (
         <Loader active inline size="medium" data-testid="checkout-price-loader" />
       ) : (
         <>
-          <p className={styles.description}>{t('checkout_price_unavailable_modal.description')}</p>
+          <p className={styles.description}>{description ?? t('checkout_price_unavailable_modal.description')}</p>
           <Button primary fluid onClick={onClose}>
             {t('global.close')}
           </Button>

--- a/webapp/src/components/Modals/BuyWithCryptoModal/CheckoutPriceUnavailableModal/CheckoutPriceUnavailableModal.types.ts
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/CheckoutPriceUnavailableModal/CheckoutPriceUnavailableModal.types.ts
@@ -1,6 +1,9 @@
 import { ModalProps } from 'decentraland-dapps/dist/providers/ModalProvider/ModalProvider.types'
 
 export type Props = Pick<ModalProps, 'name' | 'onClose'> & {
-  /** True while the listing's price is still being resolved, false once it is known to be unresolvable. */
+  /** True while what the modal stands in for is still being resolved, false once it is known to be unresolvable. */
   isLoading: boolean
+  /** Overrides the wording for a checkout that something other than the price is holding up. */
+  title?: string
+  description?: string
 }

--- a/webapp/src/components/Modals/BuyWithCryptoModal/MintNameWithCryptoModal/MintNameWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/MintNameWithCryptoModal/MintNameWithCryptoModal.tsx
@@ -177,6 +177,7 @@ const MintNameWithCryptoModalHOC = (props: Props) => {
       isBuyingAsset={isMintingName || isMintingNameCrossChain}
       onBuyNatively={onBuyNatively}
       onBuyCrossChain={onClaimNameCrossChain}
+      priceBeforeCredits={PRICE_IN_WEI}
       onBuyWithCredits={onBuyWithCredits}
       onGetGasCost={onGetGasCost}
       isLoadingAuthorization={isLoadingAuthorization}

--- a/webapp/src/components/Modals/BuyWithCryptoModal/MintNftWithCryptoModal/MintNftWithCryptoModal.spec.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/MintNftWithCryptoModal/MintNftWithCryptoModal.spec.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ChainId, Item, Network } from '@dcl/schemas'
@@ -38,7 +39,7 @@ jest.mock('../BuyWithCryptoModal.container', () => ({
 
 const mockedUseCheckoutPriceInMana = useCheckoutPriceInMana as jest.MockedFunction<typeof useCheckoutPriceInMana>
 
-function renderModal(overrides: Partial<Props> = {}) {
+function renderModal(overrides: Partial<Props> = {}, url = '/') {
   const item = {
     price: '2529100000000000000000',
     network: Network.MATIC,
@@ -63,7 +64,12 @@ function renderModal(overrides: Partial<Props> = {}) {
     ...overrides
   } as unknown as Props
 
-  return render(<MintNftWithCryptoModal {...props} />)
+  // The modal reads the mobile-IAP marker off the URL, so it renders inside a router.
+  return render(
+    <MemoryRouter initialEntries={[url]}>
+      <MintNftWithCryptoModal {...props} />
+    </MemoryRouter>
+  )
 }
 
 describe('when minting an item whose listing is priced in USD', () => {
@@ -131,5 +137,54 @@ describe('when minting an item whose listing is priced in USD', () => {
 
       expect(screen.getByText(t('checkout_price_unavailable_modal.title'))).toBeInTheDocument()
     })
+  })
+})
+
+// A mobile-IAP checkout is branded as a Credits purchase. Reaching it without the credits
+// selection used to leave the flag falsey, which authorised and settled in MANA behind that
+// branding, and on a USD-pegged listing for a different figure than the one on screen.
+describe('when a mobile-IAP checkout is opened without the credits selection', () => {
+  beforeEach(() => {
+    mockedUseCheckoutPriceInMana.mockReturnValue({
+      status: 'ready',
+      manaWei: '33212953721699847665073',
+      isUSDPegged: true
+    } as CheckoutPrice)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it.each([{ useCredits: undefined }, { useCredits: false }])(
+    'should withhold the confirmation when useCredits is %p',
+    metadataOverride => {
+      const item = {
+        price: '2529100000000000000000',
+        network: Network.MATIC,
+        chainId: ChainId.MATIC_MAINNET,
+        tradeId: 'a-trade',
+        tradeContractAddress: '0xmarketplace'
+      } as Item
+
+      renderModal({ metadata: { item, ...metadataOverride } } as Partial<Props>, '/?view=mobile-iap')
+
+      expect(screen.queryByTestId('confirmation')).not.toBeInTheDocument()
+      expect(screen.getByText(t('iap_payment_unavailable.title'))).toBeInTheDocument()
+    }
+  )
+
+  it('should present the confirmation once the credits selection is present', () => {
+    const item = {
+      price: '2529100000000000000000',
+      network: Network.MATIC,
+      chainId: ChainId.MATIC_MAINNET,
+      tradeId: 'a-trade',
+      tradeContractAddress: '0xmarketplace'
+    } as Item
+
+    renderModal({ metadata: { item, useCredits: true } } as Partial<Props>, '/?view=mobile-iap')
+
+    expect(screen.getByTestId('confirmation')).toBeInTheDocument()
   })
 })

--- a/webapp/src/components/Modals/BuyWithCryptoModal/MintNftWithCryptoModal/MintNftWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/MintNftWithCryptoModal/MintNftWithCryptoModal.tsx
@@ -4,7 +4,9 @@ import { withAuthorizedAction } from 'decentraland-dapps/dist/containers'
 import { AuthorizedAction } from 'decentraland-dapps/dist/containers/withAuthorizedAction/AuthorizationModal'
 import { getAnalytics } from 'decentraland-dapps/dist/modules/analytics'
 import { AuthorizationType } from 'decentraland-dapps/dist/modules/authorization'
+import { t } from 'decentraland-dapps/dist/modules/translation/utils'
 import { ContractName, getContractName, getContract as getDCLContract } from 'decentraland-transactions'
+import { useIsIAP } from '../../../../modules/iap/useIAP'
 import { getMintItemStatus, getError } from '../../../../modules/item/selectors'
 import { useCheckoutPriceInMana } from '../../../../modules/trade/hooks'
 import { getContractNames } from '../../../../modules/vendor'
@@ -40,6 +42,7 @@ const MintNftWithCryptoModalHOC = (props: Props) => {
   // instead of from `item.price`.
   const checkoutPrice = useCheckoutPriceInMana(item.price, item.network, item.tradeId)
   const priceInMana = checkoutPrice.manaWei
+  const isIAP = useIsIAP()
 
   const onBuyNatively = useCallback(() => {
     // Not reachable from the UI (nothing renders until the price resolves), but this builds an allowance
@@ -139,9 +142,25 @@ const MintNftWithCryptoModalHOC = (props: Props) => {
     return <CheckoutPriceUnavailableModal name={name} isLoading={checkoutPrice.status === 'resolving'} onClose={onClose} />
   }
 
+  // A mobile-IAP checkout is presented as a Credits purchase, so it must not fall through to
+  // spending MANA. The credits selection is what the execution branch, the allowance and the
+  // figure on screen all derive from, so without it nothing is put up for approval.
+  if (isIAP && useCredits !== true) {
+    return (
+      <CheckoutPriceUnavailableModal
+        name={name}
+        isLoading={false}
+        title={t('iap_payment_unavailable.title')}
+        description={t('iap_payment_unavailable.description')}
+        onClose={onClose}
+      />
+    )
+  }
+
   return (
     <BuyWithCryptoModal
       price={price}
+      priceBeforeCredits={priceInMana ?? undefined}
       isPriceApproximate={checkoutPrice.isUSDPegged}
       useCredits={useCredits}
       isBuyingAsset={isBuyingItemNatively || isBuyingItemCrossChain}

--- a/webapp/src/components/Modals/BuyWithCryptoModal/MintNftWithCryptoModal/MintNftWithCryptoModal.tsx
+++ b/webapp/src/components/Modals/BuyWithCryptoModal/MintNftWithCryptoModal/MintNftWithCryptoModal.tsx
@@ -138,7 +138,7 @@ const MintNftWithCryptoModalHOC = (props: Props) => {
 
   // Without a resolved amount there is nothing to confirm. `resolving` is the trade read (a cache hit for
   // anyone who came through the item page); `unavailable` is an unreadable trade or an unreachable oracle.
-  if (price === null) {
+  if (price === null || priceInMana === null) {
     return <CheckoutPriceUnavailableModal name={name} isLoading={checkoutPrice.status === 'resolving'} onClose={onClose} />
   }
 
@@ -160,7 +160,7 @@ const MintNftWithCryptoModalHOC = (props: Props) => {
   return (
     <BuyWithCryptoModal
       price={price}
-      priceBeforeCredits={priceInMana ?? undefined}
+      priceBeforeCredits={priceInMana}
       isPriceApproximate={checkoutPrice.isUSDPegged}
       useCredits={useCredits}
       isBuyingAsset={isBuyingItemNatively || isBuyingItemCrossChain}

--- a/webapp/src/modules/iap/shopRedirect.spec.ts
+++ b/webapp/src/modules/iap/shopRedirect.spec.ts
@@ -28,6 +28,27 @@ describe('when mapping a marketplace destination to the shop', () => {
     expect(getShopPath('/marketplace/names/claim', params(''))).toBe('/items?category=names')
   })
 
+  // `history` recognises the basename case-insensitively before React Router resolves the
+  // path, so a case variant reaches the very same route. Recognising it differently here
+  // would leave that route served by this app instead of redirecting it.
+  it.each([
+    '/MARKETPLACE/contracts/0xAbC0000000000000000000000000000000000001/items/3',
+    '/MarketPlace/contracts/0xAbC0000000000000000000000000000000000001/items/3',
+    '/marketplace/contracts/0xAbC0000000000000000000000000000000000001/items/3'
+  ])('should map %s the same way the router resolves it', pathname => {
+    expect(getShopPath(pathname, params(''))).toBe('/item/0xabc0000000000000000000000000000000000001/3')
+  })
+
+  it.each(['/MARKETPLACE/browse', '/MarketPlace/names/claim'])('should map the case variant %s', pathname => {
+    expect(getShopPath(pathname, params(''))).not.toBeNull()
+  })
+
+  // The basename has to end at a path boundary, which is also what `history` requires: a
+  // path that merely starts with those characters is a different route and keeps its prefix.
+  it('should not treat a longer first segment as the basename', () => {
+    expect(getShopPath('/marketplacefoo/contracts/0xAbC0000000000000000000000000000000000001/items/3', params(''))).toBeNull()
+  })
+
   it('should leave the purchase flow and everything else on this app', () => {
     expect(getShopPath('/marketplace/buy', params(''))).toBeNull()
     expect(getShopPath('/marketplace/success', params(''))).toBeNull()

--- a/webapp/src/modules/iap/shopRedirect.spec.ts
+++ b/webapp/src/modules/iap/shopRedirect.spec.ts
@@ -49,6 +49,14 @@ describe('when mapping a marketplace destination to the shop', () => {
     expect(getShopPath('/marketplacefoo/contracts/0xAbC0000000000000000000000000000000000001/items/3', params(''))).toBeNull()
   })
 
+  // The router resolves a trailing slash to the same route, so the hand-off has to match.
+  it.each(['/marketplace/names/claim/', '/MARKETPLACE/names/claim/', '/marketplace/browse/'])(
+    'should map %s the same way as its slashless form',
+    pathname => {
+      expect(getShopPath(pathname, params(''))).not.toBeNull()
+    }
+  )
+
   it('should leave the purchase flow and everything else on this app', () => {
     expect(getShopPath('/marketplace/buy', params(''))).toBeNull()
     expect(getShopPath('/marketplace/success', params(''))).toBeNull()

--- a/webapp/src/modules/iap/shopRedirect.ts
+++ b/webapp/src/modules/iap/shopRedirect.ts
@@ -16,9 +16,19 @@ const BROWSE_SECTION_TO_SHOP_CATEGORY: Record<string, string> = {
 /** `locations.item()` — `/contracts/:contractAddress/items/:itemId`. */
 const ITEM_PATH = /^\/contracts\/(0x[0-9a-fA-F]{40})\/items\/(\d+)\/?$/
 
+// Recognises the basename the way `history` does before React Router sees the path:
+// case-insensitively, and only when the basename ends at a path boundary. Anything
+// stricter here lets a URL the router still resolves skip the redirect below, and
+// anything looser strips a prefix the router keeps.
 export const stripBasename = (pathname: string): string => {
   const basename = getBasename()
-  return basename && pathname.startsWith(basename) ? pathname.slice(basename.length) || '/' : pathname
+  if (!basename) {
+    return pathname
+  }
+  const isBasename =
+    pathname.slice(0, basename.length).toLowerCase() === basename.toLowerCase() &&
+    ['/', '', '?', '#'].includes(pathname.charAt(basename.length))
+  return isBasename ? pathname.slice(basename.length) || '/' : pathname
 }
 
 /** The shop path serving the same destination, or `null` to keep handling it here. */

--- a/webapp/src/modules/iap/shopRedirect.ts
+++ b/webapp/src/modules/iap/shopRedirect.ts
@@ -33,7 +33,9 @@ export const stripBasename = (pathname: string): string => {
 
 /** The shop path serving the same destination, or `null` to keep handling it here. */
 export const getShopPath = (pathname: string, params: URLSearchParams): string | null => {
-  const path = stripBasename(pathname)
+  // A trailing slash resolves to the same route, so it has to hand off to the shop the same way.
+  // `ITEM_PATH` already tolerates one; the fixed paths below compare against the trimmed form.
+  const path = stripBasename(pathname).replace(/(.)\/$/, '$1')
 
   const item = ITEM_PATH.exec(path)
   if (item) {

--- a/webapp/src/modules/store.ts
+++ b/webapp/src/modules/store.ts
@@ -99,8 +99,10 @@ export const createHistory = () => {
       originalReplace(injectParams(location as string | Location) as Path & Location, state)
     }
 
-    // In IAP mode, redirect root to /browse on initial load
-    if (isIAP && window.location.pathname === (getBasename() || '/')) {
+    // In IAP mode, redirect root to /browse on initial load. Compared case-insensitively for the
+    // same reason `stripBasename` is: the router resolves a case variant of the basename to the
+    // same route, so recognising it differently here leaves that route unredirected.
+    if (isIAP && window.location.pathname.toLowerCase() === (getBasename() || '/').toLowerCase()) {
       history.replace(`/browse?${initialParams.toString()}`)
     }
   }

--- a/webapp/src/modules/translation/locales/en.json
+++ b/webapp/src/modules/translation/locales/en.json
@@ -1752,6 +1752,10 @@
     "approximate": "~{amount}",
     "unavailable": "Price unavailable"
   },
+  "iap_payment_unavailable": {
+    "title": "Checkout unavailable",
+    "description": "This checkout is presented as a Credits purchase, but the Credits payment did not come through, so we are not asking you to approve anything. Please open the item again from the store and retry."
+  },
   "checkout_price_unavailable_modal": {
     "title": "Price unavailable",
     "description": "We couldn't confirm how much MANA this listing costs right now, so we're not showing you an amount to approve. Please try again in a moment."

--- a/webapp/src/modules/translation/locales/es.json
+++ b/webapp/src/modules/translation/locales/es.json
@@ -1714,6 +1714,10 @@
     "approximate": "~{amount}",
     "unavailable": "Precio no disponible"
   },
+  "iap_payment_unavailable": {
+    "title": "Checkout no disponible",
+    "description": "Este checkout se presenta como una compra con Credits, pero el pago con Credits no llegó, así que no le pedimos aprobar nada. Abra el ítem otra vez desde la tienda e inténtelo de nuevo."
+  },
   "checkout_price_unavailable_modal": {
     "title": "Precio no disponible",
     "description": "No pudimos confirmar cuánto MANA cuesta esta publicación en este momento, así que no te mostramos un monto para aprobar. Volvé a intentar en un rato."

--- a/webapp/src/modules/translation/locales/zh.json
+++ b/webapp/src/modules/translation/locales/zh.json
@@ -1718,6 +1718,10 @@
     "approximate": "~{amount}",
     "unavailable": "价格不可用"
   },
+  "iap_payment_unavailable": {
+    "title": "无法结账",
+    "description": "此结账页面呈现为使用 Credits 付款，但 Credits 付款未能完成，因此我们不会请您授权任何交易。请从商店重新打开该商品后重试。"
+  },
   "checkout_price_unavailable_modal": {
     "title": "价格不可用",
     "description": "我们目前无法确认此挂单需要多少 MANA，因此不会向你显示待批准的金额。请稍后重试。"

--- a/webapp/src/utils/test.tsx
+++ b/webapp/src/utils/test.tsx
@@ -17,7 +17,13 @@ const allTranslations = mergeTranslations(flatten(en), flatten(locales.en) as an
 
 export function renderWithProviders(
   component: JSX.Element,
-  { preloadedState, store }: { preloadedState?: Partial<RootState>; store?: Store } = {}
+  {
+    preloadedState,
+    store,
+    // Route the component renders at. Components that read the URL — the mobile-IAP marker,
+    // for one — need it set; everything else keeps the router's default entry.
+    initialEntries
+  }: { preloadedState?: Partial<RootState>; store?: Store; initialEntries?: string[] } = {}
 ) {
   const initializedStore =
     store ||
@@ -35,7 +41,7 @@ export function renderWithProviders(
   function AppProviders({ children }: { children: React.ReactNode }) {
     return (
       <Provider store={initializedStore}>
-        <MemoryRouter>
+        <MemoryRouter initialEntries={initialEntries}>
           <DclThemeProvider theme={darkTheme}>
             <TranslationProvider locales={['en']}>{children}</TranslationProvider>
           </DclThemeProvider>


### PR DESCRIPTION
## Changes

- Recognise the `/marketplace` basename the way `history` does before the router sees the path — case-insensitively, and only at a path boundary. The redirect in `shopRedirect` and the router disagreed, so a case variant of the basename resolved to the route while skipping the hand-off to the shop. Fixed paths now also tolerate a trailing slash, which `ITEM_PATH` already did.
- Open the checkout a `buyWithCrypto=true` deep link asks for from an effect, once per mount, through the same handler the button uses. It ran from the render body and called the dispatch prop directly, so it re-dispatched on every render and dropped the credits selection the handler carries.
- Pass the resolved pre-credits MANA amount down as `priceBeforeCredits`. Mobile-IAP mode read the asset's own `price` field instead, which carries no unit — on a USD-denominated listing it is USD wei — and reconstructed the pre-credits figure by adding credits back to an amount the caller already knew.
- Present a purchase as credits only when credits are the payment source. The mobile-IAP marker rides on the URL and says nothing about what will be spent, so keying the branding off it alone labelled a MANA purchase as credits on any flow that does not set the flag.
- Pick the mobile-IAP action from the payment source rather than from whichever callback was supplied. `onBuyWithCredits` is passed on the ENS claim path regardless of what the buyer selected, so the old check settled through credits even when they chose MANA. This matches what `renderBuyNowButton` already did.
- Withhold the mobile-IAP confirmation for an item when the credits selection did not arrive, rather than falling through to MANA.

## Test plan

- [x] `shopRedirect` covered for every case variant of the basename, for a longer first segment that is not the basename, and for trailing slashes
- [x] The deep-link opening covered for firing once per mount rather than per render, and for carrying the credits selection in and out of mobile-IAP mode
- [x] The shared checkout covered for the branding following the payment source, for the action following it, and for showing the resolved MANA amount rather than the listed figure on a USD-denominated item
- [x] The item checkout covered for withholding the confirmation without the credits selection, and for presenting it once the selection is there
- [x] `npm run build`, `npm run check:code` and `npx jest` (164 suites, 1899 tests)